### PR TITLE
fix(ci): use macos-14 for x86_64-apple-darwin release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             runner: ubuntu-latest
             use_cross: true
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-14
             use_cross: false
           - target: aarch64-apple-darwin
             runner: macos-14


### PR DESCRIPTION
## Summary
- Fixes the release workflow: `macos-13` runners are being retired, causing the x86_64 macOS build to be cancelled instantly
- Switches to `macos-14` (Apple Silicon) which cross-compiles to x86_64 via Rust's `--target` flag

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, push `v0.1.0` tag and all 4 matrix builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)