### PR TITLE
feat(safety): STPA analysis, safety requirements, and 30 new tests

### DIFF
--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -1082,4 +1082,211 @@ mod tests {
         let result = fuser.fuse();
         assert!(matches!(result, Err(Error::NoComponents)));
     }
+
+    /// SR-19: Deterministic output — same input must always produce identical bytes.
+    ///
+    /// This catches non-determinism from HashMap iteration order (LS-CP-2) or any
+    /// other source of randomness in the fusion pipeline. We run the full pipeline
+    /// multiple times with identical input and assert byte-for-byte equality.
+    #[test]
+    fn test_deterministic_output() {
+        use wasm_encoder::{
+            CodeSection, Component, ExportKind, ExportSection, Function, FunctionSection,
+            Instruction, MemorySection, MemoryType, Module as EncoderModule, ModuleSection,
+            TypeSection,
+        };
+
+        /// Build a minimal valid WebAssembly component containing one core module
+        /// with a function, a memory, and exports for both.
+        fn build_minimal_component() -> Vec<u8> {
+            let mut types = TypeSection::new();
+            types.ty().function([], [wasm_encoder::ValType::I32]);
+
+            let mut functions = FunctionSection::new();
+            functions.function(0);
+
+            let mut memory = MemorySection::new();
+            memory.memory(MemoryType {
+                minimum: 1,
+                maximum: None,
+                memory64: false,
+                shared: false,
+                page_size_log2: None,
+            });
+
+            let mut exports = ExportSection::new();
+            exports.export("run", ExportKind::Func, 0);
+            exports.export("memory", ExportKind::Memory, 0);
+
+            let mut code = CodeSection::new();
+            let mut func = Function::new([]);
+            func.instruction(&Instruction::I32Const(42));
+            func.instruction(&Instruction::End);
+            code.function(&func);
+
+            let mut module = EncoderModule::new();
+            module
+                .section(&types)
+                .section(&functions)
+                .section(&memory)
+                .section(&exports)
+                .section(&code);
+
+            let mut component = Component::new();
+            component.section(&ModuleSection(&module));
+            component.finish()
+        }
+
+        let component_bytes = build_minimal_component();
+
+        // Disable attestation: it embeds timestamps and UUIDs which are
+        // intentionally non-deterministic and would mask the HashMap-order
+        // non-determinism we are trying to detect.
+        let config = FuserConfig {
+            attestation: false,
+            ..FuserConfig::default()
+        };
+
+        // Fuse once to get the reference output.
+        let mut reference_fuser = Fuser::new(config.clone());
+        reference_fuser
+            .add_component(&component_bytes)
+            .expect("failed to add component to reference fuser");
+        let reference_output = reference_fuser
+            .fuse()
+            .expect("reference fuse failed");
+
+        // Repeat with fresh Fuser instances. HashMap seeds are randomised per
+        // process but also per HashMap instance, so creating new Fusers (and
+        // therefore new internal HashMaps) on each iteration maximises the
+        // chance of catching iteration-order divergence.
+        for iteration in 0..5 {
+            let mut fuser = Fuser::new(config.clone());
+            fuser
+                .add_component(&component_bytes)
+                .expect("failed to add component");
+            let output = fuser.fuse().expect("fuse failed");
+
+            assert_eq!(
+                reference_output, output,
+                "Fusion output diverged on iteration {} — non-determinism detected (SR-19 / LS-CP-2)",
+                iteration
+            );
+        }
+    }
+
+    /// SR-20 / SC-8: Fail-fast when a core module (not a component) is passed
+    /// to `add_component()`.
+    ///
+    /// The parser must reject core modules immediately with `Error::NotAComponent`
+    /// rather than silently misinterpreting the binary.
+    #[test]
+    fn test_fuser_rejects_core_module_input() {
+        let core_module_bytes = wasm_encoder::Module::new().finish();
+
+        let mut fuser = Fuser::with_defaults();
+        let result = fuser.add_component(&core_module_bytes);
+
+        assert!(
+            matches!(result, Err(Error::NotAComponent)),
+            "expected Error::NotAComponent for a core module, got: {:?}",
+            result
+        );
+    }
+
+    /// SR-20 / SC-9: Fail-fast when address rebasing is requested with
+    /// multi-memory strategy.
+    ///
+    /// Address rebasing only makes sense with shared memory. The fuser must
+    /// reject the incompatible configuration immediately via
+    /// `Error::MemoryStrategyUnsupported`.
+    #[test]
+    fn test_fuser_address_rebasing_requires_shared_memory() {
+        use wasm_encoder::{
+            CodeSection, Component, ExportKind, ExportSection, Function, FunctionSection,
+            Instruction, MemorySection, MemoryType, Module as EncoderModule, ModuleSection,
+            TypeSection,
+        };
+
+        // Build a minimal component so we get past the NoComponents check.
+        let mut types = TypeSection::new();
+        types.ty().function([], [wasm_encoder::ValType::I32]);
+
+        let mut functions = FunctionSection::new();
+        functions.function(0);
+
+        let mut memory = MemorySection::new();
+        memory.memory(MemoryType {
+            minimum: 1,
+            maximum: None,
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        });
+
+        let mut exports = ExportSection::new();
+        exports.export("run", ExportKind::Func, 0);
+        exports.export("memory", ExportKind::Memory, 0);
+
+        let mut code = CodeSection::new();
+        let mut func = Function::new([]);
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::End);
+        code.function(&func);
+
+        let mut module = EncoderModule::new();
+        module
+            .section(&types)
+            .section(&functions)
+            .section(&memory)
+            .section(&exports)
+            .section(&code);
+
+        let mut component = Component::new();
+        component.section(&ModuleSection(&module));
+        let component_bytes = component.finish();
+
+        let config = FuserConfig {
+            memory_strategy: MemoryStrategy::MultiMemory,
+            address_rebasing: true,
+            attestation: false,
+            ..FuserConfig::default()
+        };
+
+        let mut fuser = Fuser::new(config);
+        fuser
+            .add_component(&component_bytes)
+            .expect("add_component should succeed for a valid component");
+
+        let result = fuser.fuse();
+        assert!(
+            matches!(result, Err(Error::MemoryStrategyUnsupported(_))),
+            "expected Error::MemoryStrategyUnsupported when address_rebasing=true with MultiMemory, got: {:?}",
+            result
+        );
+    }
+
+    /// SR-20 / SC-8: Fail-fast on garbage input bytes.
+    ///
+    /// Completely invalid bytes must be rejected immediately rather than
+    /// causing panics or undefined behavior deeper in the pipeline.
+    #[test]
+    fn test_fuser_rejects_invalid_wasm() {
+        let garbage = b"not wasm";
+
+        let mut fuser = Fuser::with_defaults();
+        let result = fuser.add_component(garbage);
+
+        assert!(
+            result.is_err(),
+            "expected an error for garbage input, got Ok(())"
+        );
+
+        // The parser should detect the bad magic number and return InvalidWasm.
+        assert!(
+            matches!(result, Err(Error::InvalidWasm(_))),
+            "expected Error::InvalidWasm for garbage bytes, got: {:?}",
+            result
+        );
+    }
 }

--- a/meld-core/src/parser.rs
+++ b/meld-core/src/parser.rs
@@ -1960,4 +1960,163 @@ mod tests {
         assert_eq!(convert_val_type(WasmValType::F32), ValType::F32);
         assert_eq!(convert_val_type(WasmValType::F64), ValType::F64);
     }
+
+    // ---------------------------------------------------------------
+    // Canonical ABI sizing tests (SR-3: Correct Canonical ABI element
+    // size computation)
+    // ---------------------------------------------------------------
+
+    /// Build a minimal `ParsedComponent` with no types/modules/imports.
+    /// Sufficient for exercising the sizing functions on inline types.
+    fn empty_parsed_component() -> ParsedComponent {
+        ParsedComponent {
+            name: None,
+            core_modules: vec![],
+            imports: vec![],
+            exports: vec![],
+            types: vec![],
+            instances: vec![],
+            canonical_functions: vec![],
+            sub_components: vec![],
+            component_aliases: vec![],
+            component_instances: vec![],
+            core_entity_order: vec![],
+            component_func_defs: vec![],
+            component_instance_defs: vec![],
+            component_type_defs: vec![],
+            original_size: 0,
+            original_hash: String::new(),
+            depth_0_sections: vec![],
+        }
+    }
+
+    /// SR-3: Verify element_size for every primitive type matches the
+    /// Canonical ABI specification (Core Spec 3.0 / Component Model).
+    #[test]
+    fn test_canonical_abi_element_size_primitive_types() {
+        let pc = empty_parsed_component();
+
+        let cases: &[(PrimitiveValType, u32)] = &[
+            (PrimitiveValType::U8, 1),
+            (PrimitiveValType::U16, 2),
+            (PrimitiveValType::U32, 4),
+            (PrimitiveValType::U64, 8),
+            (PrimitiveValType::S8, 1),
+            (PrimitiveValType::S16, 2),
+            (PrimitiveValType::S32, 4),
+            (PrimitiveValType::S64, 8),
+            (PrimitiveValType::F32, 4),
+            (PrimitiveValType::F64, 8),
+            (PrimitiveValType::Bool, 1),
+        ];
+
+        for (prim, expected) in cases {
+            let ty = ComponentValType::Primitive(*prim);
+            assert_eq!(
+                pc.canonical_abi_element_size(&ty),
+                *expected,
+                "element_size mismatch for {:?}",
+                prim,
+            );
+        }
+    }
+
+    /// SR-3: String is a (ptr: i32, len: i32) pair = 8 bytes, align 4.
+    #[test]
+    fn test_canonical_abi_element_size_string() {
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::String;
+        assert_eq!(pc.canonical_abi_element_size(&ty), 8);
+    }
+
+    /// SR-3 / LS-P-2: A record {u8, string} must include alignment
+    /// padding.  Naive sum would give 1 + 8 = 9, but the string field
+    /// requires align-4, so the layout is:
+    ///   offset 0: u8      (1 byte)
+    ///   offset 1: padding  (3 bytes to reach align 4)
+    ///   offset 4: string   (8 bytes: ptr + len)
+    /// Unpadded size = 12.  Record align = max(1, 4) = 4.
+    /// element_size = align_up(12, 4) = 12.
+    #[test]
+    fn test_canonical_abi_element_size_record_with_padding() {
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::Record(vec![
+            ("a".into(), ComponentValType::Primitive(PrimitiveValType::U8)),
+            ("b".into(), ComponentValType::String),
+        ]);
+        assert_eq!(
+            pc.canonical_abi_element_size(&ty),
+            12,
+            "record {{u8, string}} should be 12 (with alignment padding), not 9",
+        );
+    }
+
+    /// SR-3: A homogeneous record {u32, u32} needs no inter-field
+    /// padding — both fields are align-4 and the first already ends on
+    /// an aligned boundary.  element_size = 8.
+    #[test]
+    fn test_canonical_abi_element_size_record_homogeneous() {
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::Record(vec![
+            ("x".into(), ComponentValType::Primitive(PrimitiveValType::U32)),
+            ("y".into(), ComponentValType::Primitive(PrimitiveValType::U32)),
+        ]);
+        assert_eq!(pc.canonical_abi_element_size(&ty), 8);
+    }
+
+    /// SR-3: Verify canonical_abi_align returns the correct power-of-two
+    /// alignment for each primitive and for compound types.
+    #[test]
+    fn test_canonical_abi_align_values() {
+        let pc = empty_parsed_component();
+
+        // Primitives
+        let prim_cases: &[(PrimitiveValType, u32)] = &[
+            (PrimitiveValType::Bool, 1),
+            (PrimitiveValType::U8, 1),
+            (PrimitiveValType::S8, 1),
+            (PrimitiveValType::U16, 2),
+            (PrimitiveValType::S16, 2),
+            (PrimitiveValType::U32, 4),
+            (PrimitiveValType::S32, 4),
+            (PrimitiveValType::F32, 4),
+            (PrimitiveValType::Char, 4),
+            (PrimitiveValType::U64, 8),
+            (PrimitiveValType::S64, 8),
+            (PrimitiveValType::F64, 8),
+        ];
+        for (prim, expected) in prim_cases {
+            let ty = ComponentValType::Primitive(*prim);
+            assert_eq!(
+                pc.canonical_abi_align(&ty),
+                *expected,
+                "align mismatch for {:?}",
+                prim,
+            );
+        }
+
+        // String — pointer alignment = 4
+        assert_eq!(pc.canonical_abi_align(&ComponentValType::String), 4);
+
+        // List — pointer alignment = 4
+        let list_ty = ComponentValType::List(Box::new(ComponentValType::Primitive(
+            PrimitiveValType::U8,
+        )));
+        assert_eq!(pc.canonical_abi_align(&list_ty), 4);
+
+        // Record inherits max alignment of its fields
+        let record_ty = ComponentValType::Record(vec![
+            ("a".into(), ComponentValType::Primitive(PrimitiveValType::U8)),
+            ("b".into(), ComponentValType::Primitive(PrimitiveValType::U64)),
+        ]);
+        assert_eq!(
+            pc.canonical_abi_align(&record_ty),
+            8,
+            "record {{u8, u64}} align should be max(1, 8) = 8",
+        );
+
+        // Empty record defaults to align 1
+        let empty_record = ComponentValType::Record(vec![]);
+        assert_eq!(pc.canonical_abi_align(&empty_record), 1);
+    }
 }

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -1172,6 +1172,13 @@ impl Resolver {
             in_degree[to] += 1;
         }
 
+        // Sort each adjacency list so that neighbours are visited in
+        // ascending index order.  This guarantees deterministic output
+        // regardless of the order edges were supplied (SR-19 / LS-CP-2).
+        for list in &mut adj {
+            list.sort_unstable();
+        }
+
         // Kahn's algorithm
         let mut queue: Vec<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
         let mut result = Vec::with_capacity(n);
@@ -2191,6 +2198,185 @@ mod tests {
         }
     }
 
+    /// Helper: create a `ParsedComponent` with the given component-level
+    /// imports and exports.
+    ///
+    /// Import names go into `component.imports` (matched by the resolver
+    /// against other components' exports).  Export names go into
+    /// `component.exports`.  All other fields use `ParsedComponent::empty()`
+    /// defaults.
+    fn make_component(import_names: &[&str], export_names: &[&str]) -> ParsedComponent {
+        use crate::parser::ComponentImport;
+        use wasmparser::{ComponentExternalKind, ComponentTypeRef};
+
+        let mut comp = ParsedComponent::empty();
+        for name in import_names {
+            comp.imports.push(ComponentImport {
+                name: name.to_string(),
+                ty: ComponentTypeRef::Instance(0),
+            });
+        }
+        for name in export_names {
+            comp.exports.push(ComponentExport {
+                name: name.to_string(),
+                kind: ComponentExternalKind::Instance,
+                index: 0,
+            });
+        }
+        comp
+    }
+
+    /// SR-7: Valid topological instantiation order.
+    /// LS-R-3: Diamond dependency graph.
+    ///
+    /// Four components forming a diamond:
+    ///
+    /// ```text
+    ///       A (0)
+    ///      / \
+    ///   B (1) C (2)
+    ///      \ /
+    ///       D (3)
+    /// ```
+    ///
+    /// A imports from B and C; B and C each import from D.
+    /// Valid instantiation order requires D before {B, C} and {B, C} before A.
+    #[test]
+    fn test_topological_sort_diamond() {
+        let components = vec![
+            make_component(&["iface-b", "iface-c"], &[]),       // A = index 0
+            make_component(&["iface-d"], &["iface-b"]),          // B = index 1
+            make_component(&["iface-d"], &["iface-c"]),          // C = index 2
+            make_component(&[], &["iface-d"]),                   // D = index 3
+        ];
+
+        let resolver = Resolver::new();
+        let graph = resolver.resolve(&components).expect("diamond resolution should succeed");
+
+        let order = &graph.instantiation_order;
+        assert_eq!(order.len(), 4, "all four components must appear in the order");
+
+        // Build position map for order assertions
+        let pos: HashMap<usize, usize> =
+            order.iter().enumerate().map(|(i, &v)| (v, i)).collect();
+
+        // D (3) must come before B (1) and C (2)
+        assert!(
+            pos[&3] < pos[&1],
+            "D (index 3) must be instantiated before B (index 1), got order {:?}",
+            order
+        );
+        assert!(
+            pos[&3] < pos[&2],
+            "D (index 3) must be instantiated before C (index 2), got order {:?}",
+            order
+        );
+
+        // B (1) and C (2) must come before A (0)
+        assert!(
+            pos[&1] < pos[&0],
+            "B (index 1) must be instantiated before A (index 0), got order {:?}",
+            order
+        );
+        assert!(
+            pos[&2] < pos[&0],
+            "C (index 2) must be instantiated before A (index 0), got order {:?}",
+            order
+        );
+
+        // Verify the dependency edges were recorded in resolved_imports
+        assert!(
+            graph.resolved_imports.contains_key(&(0, "iface-b".to_string())),
+            "A's import of iface-b should be resolved"
+        );
+        assert!(
+            graph.resolved_imports.contains_key(&(0, "iface-c".to_string())),
+            "A's import of iface-c should be resolved"
+        );
+        assert!(
+            graph.resolved_imports.contains_key(&(1, "iface-d".to_string())),
+            "B's import of iface-d should be resolved"
+        );
+        assert!(
+            graph.resolved_imports.contains_key(&(2, "iface-d".to_string())),
+            "C's import of iface-d should be resolved"
+        );
+    }
+
+    /// SC-9: Unresolved imports must be reported, not silently dropped.
+    /// LS-R-4: Self-importing component (no provider for the import).
+    ///
+    /// A component imports an interface that no other component exports.
+    /// Under strict mode the resolver must return an `UnresolvedImport` error.
+    #[test]
+    fn test_resolver_unresolved_import_error() {
+        let components = vec![
+            make_component(&["nonexistent-iface"], &[]),
+            make_component(&[], &["some-other-iface"]),
+        ];
+
+        let resolver = Resolver::strict();
+        let result = resolver.resolve(&components);
+
+        assert!(
+            result.is_err(),
+            "strict resolver must reject an import that no component exports"
+        );
+
+        let err = result.unwrap_err();
+        match &err {
+            Error::UnresolvedImport { module, name } => {
+                assert_eq!(module, "component");
+                assert_eq!(
+                    name, "nonexistent-iface",
+                    "error should name the unresolved import"
+                );
+            }
+            other => panic!(
+                "expected Error::UnresolvedImport, got: {:?}",
+                other
+            ),
+        }
+    }
+
+    /// SR-19 / LS-CP-2: Resolver order stability (determinism).
+    ///
+    /// Running the same resolution five times must produce an identical
+    /// instantiation order every time.  Non-determinism here would cause
+    /// downstream merging to produce semantically different modules from
+    /// the same input, violating reproducible builds.
+    #[test]
+    fn test_resolver_preserves_order_stability() {
+        // Use the diamond topology — it has multiple valid topological
+        // orders (B and C are interchangeable), so a non-deterministic
+        // implementation could vary between runs.
+        let components = vec![
+            make_component(&["iface-b", "iface-c"], &[]),       // A = 0
+            make_component(&["iface-d"], &["iface-b"]),          // B = 1
+            make_component(&["iface-d"], &["iface-c"]),          // C = 2
+            make_component(&[], &["iface-d"]),                   // D = 3
+        ];
+
+        let resolver = Resolver::new();
+        let baseline = resolver
+            .resolve(&components)
+            .expect("baseline resolution should succeed")
+            .instantiation_order;
+
+        for iteration in 1..=5 {
+            let order = resolver
+                .resolve(&components)
+                .expect("repeated resolution should succeed")
+                .instantiation_order;
+
+            assert_eq!(
+                order, baseline,
+                "instantiation order diverged on iteration {}: got {:?}, expected {:?}",
+                iteration, order, baseline
+            );
+        }
+    }
+
     #[test]
     fn test_extract_wasi_resource_name() {
         // Standard WASI paths
@@ -2213,5 +2399,198 @@ mod tests {
 
         // Version but no slash
         assert_eq!(extract_wasi_resource_name("something@1.0.0"), "something");
+    }
+
+    // ---------------------------------------------------------------
+    // CopyLayout classification tests (SR-6 / LS-R-2)
+    // ---------------------------------------------------------------
+
+    use crate::parser::{ComponentValType, PrimitiveValType};
+
+    /// Build a minimal `ParsedComponent` with no modules, types, or instances.
+    /// Sufficient for testing `copy_layout` on inline types (no `Type(idx)` references).
+    fn empty_parsed_component() -> ParsedComponent {
+        ParsedComponent {
+            name: None,
+            core_modules: Vec::new(),
+            imports: Vec::new(),
+            exports: Vec::new(),
+            types: Vec::new(),
+            instances: Vec::new(),
+            canonical_functions: Vec::new(),
+            sub_components: Vec::new(),
+            component_aliases: Vec::new(),
+            component_instances: Vec::new(),
+            core_entity_order: Vec::new(),
+            component_func_defs: Vec::new(),
+            component_instance_defs: Vec::new(),
+            component_type_defs: Vec::new(),
+            original_size: 0,
+            original_hash: String::new(),
+            depth_0_sections: Vec::new(),
+        }
+    }
+
+    /// SR-6: list<u32> contains no pointers, so should produce Bulk with
+    /// byte_multiplier = 4 (sizeof(u32)).
+    #[test]
+    fn test_copy_layout_flat_list() {
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::List(Box::new(ComponentValType::Primitive(
+            PrimitiveValType::U32,
+        )));
+        let layout = pc.copy_layout(&ty);
+        match layout {
+            CopyLayout::Bulk { byte_multiplier } => {
+                assert_eq!(byte_multiplier, 4, "u32 element should be 4 bytes");
+            }
+            CopyLayout::Elements { .. } => {
+                panic!("list<u32> should produce Bulk, not Elements");
+            }
+        }
+    }
+
+    /// SR-6: list<string> contains pointer pairs (each string is a (ptr, len) pair),
+    /// so should produce Elements with element_size = 8 and one inner pointer at offset 0.
+    #[test]
+    fn test_copy_layout_string_list() {
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::List(Box::new(ComponentValType::String));
+        let layout = pc.copy_layout(&ty);
+        match layout {
+            CopyLayout::Elements {
+                element_size,
+                inner_pointers,
+            } => {
+                assert_eq!(element_size, 8, "string element is (i32 ptr, i32 len) = 8 bytes");
+                assert_eq!(
+                    inner_pointers.len(),
+                    1,
+                    "one pointer pair per string element"
+                );
+                let (offset, ref inner_layout) = inner_pointers[0];
+                assert_eq!(offset, 0, "string pointer pair starts at byte offset 0");
+                // Inner layout for a string is Bulk { byte_multiplier: 1 }
+                match inner_layout {
+                    CopyLayout::Bulk { byte_multiplier } => {
+                        assert_eq!(*byte_multiplier, 1, "string data is byte-granular");
+                    }
+                    _ => panic!("inner layout for string should be Bulk"),
+                }
+            }
+            CopyLayout::Bulk { .. } => {
+                panic!("list<string> should produce Elements, not Bulk");
+            }
+        }
+    }
+
+    /// SR-6 / LS-R-2: list<record{name: string, value: u32}> MUST produce Elements,
+    /// not Bulk. The record contains a string field which is a (ptr, len) pair.
+    /// Misclassifying this as Bulk would silently corrupt pointer data during
+    /// cross-memory copy.
+    #[test]
+    fn test_copy_layout_record_with_string() {
+        let pc = empty_parsed_component();
+        // record { name: string, value: u32 }
+        let record_ty = ComponentValType::Record(vec![
+            ("name".to_string(), ComponentValType::String),
+            ("value".to_string(), ComponentValType::Primitive(PrimitiveValType::U32)),
+        ]);
+        let ty = ComponentValType::List(Box::new(record_ty));
+        let layout = pc.copy_layout(&ty);
+        match layout {
+            CopyLayout::Elements {
+                element_size,
+                inner_pointers,
+            } => {
+                // Record layout: string at offset 0 (8 bytes: ptr + len, align 4),
+                // then u32 at offset 8 (4 bytes, align 4). Unpadded size = 12.
+                // Alignment = max(4, 4) = 4. Element size = align_up(12, 4) = 12.
+                assert_eq!(element_size, 12, "record{{string, u32}} element should be 12 bytes");
+                assert_eq!(
+                    inner_pointers.len(),
+                    1,
+                    "one pointer pair from the string field"
+                );
+                let (offset, ref inner_layout) = inner_pointers[0];
+                assert_eq!(offset, 0, "string field starts at byte offset 0 in the record");
+                match inner_layout {
+                    CopyLayout::Bulk { byte_multiplier } => {
+                        assert_eq!(*byte_multiplier, 1, "string data is byte-granular");
+                    }
+                    _ => panic!("inner layout for string should be Bulk"),
+                }
+            }
+            CopyLayout::Bulk { .. } => {
+                panic!(
+                    "list<record{{name: string, value: u32}}> MUST produce Elements, not Bulk \
+                     (LS-R-2: pointer-containing record misclassified as Bulk)"
+                );
+            }
+        }
+    }
+
+    /// SR-6: list<list<u8>> contains inner pointer pairs (each inner list is a
+    /// (ptr, len) pair), so should produce Elements.
+    #[test]
+    fn test_copy_layout_nested_list() {
+        let pc = empty_parsed_component();
+        let inner_list = ComponentValType::List(Box::new(ComponentValType::Primitive(
+            PrimitiveValType::U8,
+        )));
+        let ty = ComponentValType::List(Box::new(inner_list));
+        let layout = pc.copy_layout(&ty);
+        match layout {
+            CopyLayout::Elements {
+                element_size,
+                inner_pointers,
+            } => {
+                assert_eq!(element_size, 8, "list element is (i32 ptr, i32 len) = 8 bytes");
+                assert_eq!(
+                    inner_pointers.len(),
+                    1,
+                    "one pointer pair per inner list element"
+                );
+                let (offset, ref inner_layout) = inner_pointers[0];
+                assert_eq!(offset, 0, "inner list pointer pair starts at byte offset 0");
+                // Inner layout for list<u8> is Bulk { byte_multiplier: 1 }
+                match inner_layout {
+                    CopyLayout::Bulk { byte_multiplier } => {
+                        assert_eq!(*byte_multiplier, 1, "list<u8> element is 1 byte");
+                    }
+                    _ => panic!("inner layout for list<u8> should be Bulk"),
+                }
+            }
+            CopyLayout::Bulk { .. } => {
+                panic!("list<list<u8>> should produce Elements, not Bulk");
+            }
+        }
+    }
+
+    /// SR-6: list<record{a: u32, b: u32}> has no pointer-bearing fields,
+    /// so should produce Bulk with byte_multiplier = 8 (two u32 fields).
+    #[test]
+    fn test_copy_layout_flat_record() {
+        let pc = empty_parsed_component();
+        let record_ty = ComponentValType::Record(vec![
+            ("a".to_string(), ComponentValType::Primitive(PrimitiveValType::U32)),
+            ("b".to_string(), ComponentValType::Primitive(PrimitiveValType::U32)),
+        ]);
+        let ty = ComponentValType::List(Box::new(record_ty));
+        let layout = pc.copy_layout(&ty);
+        match layout {
+            CopyLayout::Bulk { byte_multiplier } => {
+                assert_eq!(
+                    byte_multiplier, 8,
+                    "record{{a: u32, b: u32}} should be 8 bytes (4 + 4)"
+                );
+            }
+            CopyLayout::Elements { .. } => {
+                panic!(
+                    "list<record{{a: u32, b: u32}}> should produce Bulk (no pointer fields), \
+                     not Elements"
+                );
+            }
+        }
     }
 }

--- a/meld-core/src/rewriter.rs
+++ b/meld-core/src/rewriter.rs
@@ -904,6 +904,283 @@ mod tests {
         ));
     }
 
+    /// Helper to create an IndexMaps with known remappings for completeness tests:
+    /// function 0→5, memory 0→2, table 0→3, global 0→7, type 0→4
+    fn make_test_maps() -> IndexMaps {
+        let mut maps = IndexMaps::new();
+        maps.functions.insert(0, 5);
+        maps.memories.insert(0, 2);
+        maps.tables.insert(0, 3);
+        maps.globals.insert(0, 7);
+        maps.types.insert(0, 4);
+        maps
+    }
+
+    // --- SR-9 completeness tests ---
+
+    #[test]
+    fn test_rewrite_call_remaps_function_index() {
+        let maps = make_test_maps();
+        let instrs = rewrite_operator(Operator::Call { function_index: 0 }, &maps).unwrap();
+        assert_eq!(instrs.len(), 1);
+        assert!(
+            matches!(instrs[0], Instruction::Call(5)),
+            "Call should remap function index 0→5, got {:?}",
+            instrs[0]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_call_indirect_remaps_type_and_table() {
+        // Addresses UCA-M-4: both type_index and table_index must be remapped
+        let maps = make_test_maps();
+        let instrs = rewrite_operator(
+            Operator::CallIndirect {
+                type_index: 0,
+                table_index: 0,
+            },
+            &maps,
+        )
+        .unwrap();
+        assert_eq!(instrs.len(), 1);
+        match &instrs[0] {
+            Instruction::CallIndirect {
+                type_index,
+                table_index,
+            } => {
+                assert_eq!(
+                    *type_index, 4,
+                    "CallIndirect type_index should remap 0→4"
+                );
+                assert_eq!(
+                    *table_index, 3,
+                    "CallIndirect table_index should remap 0→3"
+                );
+            }
+            other => panic!(
+                "Expected CallIndirect, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_global_get_set_remaps() {
+        let maps = make_test_maps();
+
+        let get_instrs =
+            rewrite_operator(Operator::GlobalGet { global_index: 0 }, &maps).unwrap();
+        assert_eq!(get_instrs.len(), 1);
+        assert!(
+            matches!(get_instrs[0], Instruction::GlobalGet(7)),
+            "GlobalGet should remap global index 0→7, got {:?}",
+            get_instrs[0]
+        );
+
+        let set_instrs =
+            rewrite_operator(Operator::GlobalSet { global_index: 0 }, &maps).unwrap();
+        assert_eq!(set_instrs.len(), 1);
+        assert!(
+            matches!(set_instrs[0], Instruction::GlobalSet(7)),
+            "GlobalSet should remap global index 0→7, got {:?}",
+            set_instrs[0]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_table_ops_remap() {
+        let maps = make_test_maps();
+
+        // TableGet
+        let instrs = rewrite_operator(Operator::TableGet { table: 0 }, &maps).unwrap();
+        assert_eq!(instrs.len(), 1);
+        assert!(
+            matches!(instrs[0], Instruction::TableGet(3)),
+            "TableGet should remap table index 0→3, got {:?}",
+            instrs[0]
+        );
+
+        // TableSet
+        let instrs = rewrite_operator(Operator::TableSet { table: 0 }, &maps).unwrap();
+        assert_eq!(instrs.len(), 1);
+        assert!(
+            matches!(instrs[0], Instruction::TableSet(3)),
+            "TableSet should remap table index 0→3, got {:?}",
+            instrs[0]
+        );
+
+        // TableGrow
+        let instrs = rewrite_operator(Operator::TableGrow { table: 0 }, &maps).unwrap();
+        assert_eq!(instrs.len(), 1);
+        assert!(
+            matches!(instrs[0], Instruction::TableGrow(3)),
+            "TableGrow should remap table index 0→3, got {:?}",
+            instrs[0]
+        );
+
+        // TableSize
+        let instrs = rewrite_operator(Operator::TableSize { table: 0 }, &maps).unwrap();
+        assert_eq!(instrs.len(), 1);
+        assert!(
+            matches!(instrs[0], Instruction::TableSize(3)),
+            "TableSize should remap table index 0→3, got {:?}",
+            instrs[0]
+        );
+
+        // TableFill
+        let instrs = rewrite_operator(Operator::TableFill { table: 0 }, &maps).unwrap();
+        assert_eq!(instrs.len(), 1);
+        assert!(
+            matches!(instrs[0], Instruction::TableFill(3)),
+            "TableFill should remap table index 0→3, got {:?}",
+            instrs[0]
+        );
+    }
+
+    #[test]
+    fn test_rewrite_table_copy_remaps_both() {
+        let mut maps = make_test_maps();
+        // Add a second table mapping to verify both src and dst are independent
+        maps.tables.insert(1, 9);
+
+        let instrs = rewrite_operator(
+            Operator::TableCopy {
+                dst_table: 0,
+                src_table: 1,
+            },
+            &maps,
+        )
+        .unwrap();
+        assert_eq!(instrs.len(), 1);
+        match &instrs[0] {
+            Instruction::TableCopy {
+                src_table,
+                dst_table,
+            } => {
+                assert_eq!(
+                    *src_table, 9,
+                    "TableCopy src_table should remap 1→9"
+                );
+                assert_eq!(
+                    *dst_table, 3,
+                    "TableCopy dst_table should remap 0→3"
+                );
+            }
+            other => panic!(
+                "Expected TableCopy, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_memory_copy_remaps_both_memories() {
+        // Directly tests loss scenario LS-M-2: rewriter must remap BOTH
+        // src_mem and dst_mem in memory.copy.
+        let mut maps = make_test_maps();
+        // Add a second memory mapping so we can distinguish src vs dst
+        maps.memories.insert(1, 8);
+
+        let instrs = rewrite_operator(
+            Operator::MemoryCopy {
+                dst_mem: 0,
+                src_mem: 1,
+            },
+            &maps,
+        )
+        .unwrap();
+
+        // Without address rebasing, should produce a single MemoryCopy instruction
+        assert_eq!(instrs.len(), 1);
+        match &instrs[0] {
+            Instruction::MemoryCopy { src_mem, dst_mem } => {
+                assert_eq!(
+                    *src_mem, 8,
+                    "MemoryCopy src_mem should remap 1→8"
+                );
+                assert_eq!(
+                    *dst_mem, 2,
+                    "MemoryCopy dst_mem should remap 0→2"
+                );
+            }
+            other => panic!(
+                "Expected MemoryCopy, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_memory_load_store_remaps_memory() {
+        let maps = make_test_maps();
+
+        // I32Load with memory index 0 should remap to memory index 2
+        let instrs = rewrite_operator(
+            Operator::I32Load {
+                memarg: WpMemArg {
+                    align: 2,
+                    max_align: 2,
+                    offset: 0,
+                    memory: 0,
+                },
+            },
+            &maps,
+        )
+        .unwrap();
+        assert_eq!(instrs.len(), 1);
+        match &instrs[0] {
+            Instruction::I32Load(ma) => {
+                assert_eq!(
+                    ma.memory_index, 2,
+                    "I32Load memarg.memory_index should remap 0→2"
+                );
+            }
+            other => panic!("Expected I32Load, got {:?}", other),
+        }
+
+        // I32Store with memory index 0 should remap to memory index 2
+        let instrs = rewrite_operator(
+            Operator::I32Store {
+                memarg: WpMemArg {
+                    align: 2,
+                    max_align: 2,
+                    offset: 4,
+                    memory: 0,
+                },
+            },
+            &maps,
+        )
+        .unwrap();
+        assert_eq!(instrs.len(), 1);
+        match &instrs[0] {
+            Instruction::I32Store(ma) => {
+                assert_eq!(
+                    ma.memory_index, 2,
+                    "I32Store memarg.memory_index should remap 0→2"
+                );
+                assert_eq!(
+                    ma.offset, 4,
+                    "I32Store memarg.offset should be preserved"
+                );
+            }
+            other => panic!("Expected I32Store, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_rewrite_ref_func_remaps() {
+        let maps = make_test_maps();
+
+        let instrs =
+            rewrite_operator(Operator::RefFunc { function_index: 0 }, &maps).unwrap();
+        assert_eq!(instrs.len(), 1);
+        assert!(
+            matches!(instrs[0], Instruction::RefFunc(5)),
+            "RefFunc should remap function index 0→5, got {:?}",
+            instrs[0]
+        );
+    }
+
     #[test]
     fn test_convert_abstract_heap_type_all_variants() {
         // Verify all 14 AbstractHeapType variants are handled correctly

--- a/meld-core/src/segments.rs
+++ b/meld-core/src/segments.rs
@@ -621,4 +621,139 @@ mod tests {
             _ => panic!("expected I32Const"),
         }
     }
+
+    /// SR-10: Active element segment table index is remapped correctly.
+    #[test]
+    fn test_reindex_element_segment_active_remaps_table() {
+        let segment = ParsedElementSegment {
+            mode: ParsedElementSegmentMode::Active {
+                table_index: 0,
+                offset: ParsedConstExpr::I32Const(0),
+            },
+            element_type: RefType::FUNCREF,
+            items: ElementItems_::Functions(vec![0]),
+        };
+
+        let mut maps = IndexMaps::new();
+        maps.tables.insert(0, 3);
+
+        let reindexed = reindex_element_segment(&segment, &maps);
+        match &reindexed.mode {
+            ElementSegmentMode::Active { table_index, .. } => {
+                assert_eq!(*table_index, 3, "table index should be remapped from 0 to 3");
+            }
+            _ => panic!("expected active element segment mode"),
+        }
+    }
+
+    /// SR-10: Function references inside element segments are remapped.
+    #[test]
+    fn test_reindex_element_segment_remaps_function_refs() {
+        let segment = ParsedElementSegment {
+            mode: ParsedElementSegmentMode::Passive,
+            element_type: RefType::FUNCREF,
+            items: ElementItems_::Functions(vec![0, 1, 2]),
+        };
+
+        let mut maps = IndexMaps::new();
+        maps.functions.insert(0, 10);
+        maps.functions.insert(1, 11);
+        maps.functions.insert(2, 12);
+
+        let reindexed = reindex_element_segment(&segment, &maps);
+        match &reindexed.items {
+            ReindexedElementItems::Functions(funcs) => {
+                assert_eq!(funcs, &[10, 11, 12], "function indices should be remapped");
+            }
+            _ => panic!("expected Functions variant in reindexed items"),
+        }
+    }
+
+    /// SR-10: Active data segment memory index is remapped correctly.
+    #[test]
+    fn test_reindex_data_segment_remaps_memory_index() {
+        let segment = ParsedDataSegment {
+            mode: DataSegmentMode_::Active {
+                memory_index: 0,
+                offset: ParsedConstExpr::I32Const(0),
+                offset_value: Some(ConstExprValue::I32(0)),
+            },
+            data: vec![0xAA, 0xBB],
+        };
+
+        let mut maps = IndexMaps::new();
+        maps.memories.insert(0, 2);
+
+        let reindexed = reindex_data_segment(&segment, &maps).unwrap();
+        match &reindexed.mode {
+            ReindexedDataMode::Active { memory_index, .. } => {
+                assert_eq!(*memory_index, 2, "memory index should be remapped from 0 to 2");
+            }
+            _ => panic!("expected active data segment mode"),
+        }
+    }
+
+    /// SR-10 / UCA-M-6: Global index in data segment offset expression is
+    /// remapped. Without this, a `global.get 0` offset could reference the
+    /// wrong global after merging, corrupting the data segment placement.
+    #[test]
+    fn test_reindex_data_segment_global_get_remaps_global() {
+        let segment = ParsedDataSegment {
+            mode: DataSegmentMode_::Active {
+                memory_index: 0,
+                offset: ParsedConstExpr::GlobalGet(0),
+                offset_value: None,
+            },
+            data: vec![0xFF],
+        };
+
+        let mut maps = IndexMaps::new();
+        maps.globals.insert(0, 5);
+
+        let reindexed = reindex_data_segment(&segment, &maps).unwrap();
+        let ReindexedDataMode::Active { offset, .. } = &reindexed.mode else {
+            panic!("expected active data segment mode");
+        };
+
+        // Encode both the actual and expected ConstExpr to compare bytes,
+        // since ConstExpr does not implement PartialEq.
+        let mut actual = Vec::new();
+        offset.encode(&mut actual);
+
+        let mut expected = Vec::new();
+        ConstExpr::global_get(5).encode(&mut expected);
+
+        assert_eq!(actual, expected, "global index in offset should be remapped from 0 to 5");
+    }
+
+    /// SR-10: Concrete type index inside RefNull expressions in element
+    /// segments is remapped through the type index map.
+    #[test]
+    fn test_reindex_element_segment_expression_remaps_ref_null_type() {
+        let segment = ParsedElementSegment {
+            mode: ParsedElementSegmentMode::Passive,
+            element_type: RefType::FUNCREF,
+            items: ElementItems_::Expressions(vec![
+                ParsedConstExpr::RefNull(wasm_encoder::HeapType::Concrete(0)),
+            ]),
+        };
+
+        let mut maps = IndexMaps::new();
+        maps.types.insert(0, 4);
+
+        let reindexed = reindex_element_segment(&segment, &maps);
+        let ReindexedElementItems::Expressions(exprs) = &reindexed.items else {
+            panic!("expected Expressions variant in reindexed items");
+        };
+        assert_eq!(exprs.len(), 1, "should have exactly one expression");
+
+        // Encode both the actual and expected ConstExpr to compare bytes.
+        let mut actual = Vec::new();
+        exprs[0].encode(&mut actual);
+
+        let mut expected = Vec::new();
+        ConstExpr::ref_null(wasm_encoder::HeapType::Concrete(4)).encode(&mut expected);
+
+        assert_eq!(actual, expected, "concrete type index should be remapped from 0 to 4");
+    }
 }

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -17,12 +17,13 @@ use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView};
 
 const FIXTURES_DIR: &str = "../tests/wit_bindgen/fixtures";
 
-/// Skip tests when fixture files are not present.
-fn fixtures_available() -> bool {
-    if std::path::Path::new(FIXTURES_DIR).is_dir() {
+/// Skip a test when the specific fixture .wasm file is not present.
+fn fixture_exists(name: &str) -> bool {
+    let path = fixture_path(name);
+    if std::path::Path::new(&path).is_file() {
         true
     } else {
-        eprintln!("skipping: wit-bindgen fixtures not found at {FIXTURES_DIR}");
+        eprintln!("skipping: fixture not found at {path}");
         false
     }
 }
@@ -113,7 +114,7 @@ fn run_wasi_component(wasm: &[u8]) -> anyhow::Result<()> {
 
 #[test]
 fn test_fuse_wit_bindgen_numbers() {
-    if !fixtures_available() {
+    if !fixture_exists("numbers") {
         return;
     }
     let fused = fuse_fixture("numbers", OutputFormat::CoreModule).unwrap();
@@ -124,7 +125,7 @@ fn test_fuse_wit_bindgen_numbers() {
 
 #[test]
 fn test_fuse_wit_bindgen_strings() {
-    if !fixtures_available() {
+    if !fixture_exists("strings") {
         return;
     }
     let fused = fuse_fixture("strings", OutputFormat::CoreModule).unwrap();
@@ -135,7 +136,7 @@ fn test_fuse_wit_bindgen_strings() {
 
 #[test]
 fn test_fuse_wit_bindgen_lists() {
-    if !fixtures_available() {
+    if !fixture_exists("lists") {
         return;
     }
     let fused = fuse_fixture("lists", OutputFormat::CoreModule).unwrap();
@@ -146,7 +147,7 @@ fn test_fuse_wit_bindgen_lists() {
 
 #[test]
 fn test_fuse_wit_bindgen_records() {
-    if !fixtures_available() {
+    if !fixture_exists("records") {
         return;
     }
     let fused = fuse_fixture("records", OutputFormat::CoreModule).unwrap();
@@ -161,7 +162,7 @@ fn test_fuse_wit_bindgen_records() {
 
 #[test]
 fn test_fuse_component_wit_bindgen_numbers() {
-    if !fixtures_available() {
+    if !fixture_exists("numbers") {
         return;
     }
     let fused = fuse_fixture("numbers", OutputFormat::Component).unwrap();
@@ -172,7 +173,7 @@ fn test_fuse_component_wit_bindgen_numbers() {
 
 #[test]
 fn test_fuse_component_wit_bindgen_strings() {
-    if !fixtures_available() {
+    if !fixture_exists("strings") {
         return;
     }
     let fused = fuse_fixture("strings", OutputFormat::Component).unwrap();
@@ -183,7 +184,7 @@ fn test_fuse_component_wit_bindgen_strings() {
 
 #[test]
 fn test_fuse_component_wit_bindgen_lists() {
-    if !fixtures_available() {
+    if !fixture_exists("lists") {
         return;
     }
     let fused = fuse_fixture("lists", OutputFormat::Component).unwrap();
@@ -194,7 +195,7 @@ fn test_fuse_component_wit_bindgen_lists() {
 
 #[test]
 fn test_fuse_component_wit_bindgen_records() {
-    if !fixtures_available() {
+    if !fixture_exists("records") {
         return;
     }
     let fused = fuse_fixture("records", OutputFormat::Component).unwrap();
@@ -209,7 +210,7 @@ fn test_fuse_component_wit_bindgen_records() {
 
 #[test]
 fn test_runtime_wit_bindgen_numbers() {
-    if !fixtures_available() {
+    if !fixture_exists("numbers") {
         return;
     }
     let fused = fuse_fixture("numbers", OutputFormat::Component).unwrap();
@@ -218,7 +219,7 @@ fn test_runtime_wit_bindgen_numbers() {
 
 #[test]
 fn test_runtime_wit_bindgen_strings() {
-    if !fixtures_available() {
+    if !fixture_exists("strings") {
         return;
     }
     let fused = fuse_fixture("strings", OutputFormat::Component).unwrap();
@@ -227,7 +228,7 @@ fn test_runtime_wit_bindgen_strings() {
 
 #[test]
 fn test_runtime_wit_bindgen_lists() {
-    if !fixtures_available() {
+    if !fixture_exists("lists") {
         return;
     }
     let fused = fuse_fixture("lists", OutputFormat::Component).unwrap();
@@ -236,7 +237,7 @@ fn test_runtime_wit_bindgen_lists() {
 
 #[test]
 fn test_runtime_wit_bindgen_records() {
-    if !fixtures_available() {
+    if !fixture_exists("records") {
         return;
     }
     let fused = fuse_fixture("records", OutputFormat::Component).unwrap();

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1,0 +1,410 @@
+# Safety Requirements
+#
+# Derived from STPA controller constraints and loss scenarios.
+# Each requirement traces back to the STPA artifacts it addresses.
+#
+# Status values: draft | reviewed | approved | implemented | verified
+#
+# Verification methods:
+#   - test: automated test (unit, integration, or property-based)
+#   - proof: Rocq mechanized proof
+#   - inspection: manual code review
+#   - analysis: static analysis or model checking
+
+requirements:
+
+  # ==========================================================================
+  # Parsing requirements (from CC-P-* and LS-P-*)
+  # ==========================================================================
+
+  - id: SR-1
+    title: Complete core module extraction
+    description: >
+      The parser shall extract all core modules from a component,
+      including those nested within component instances at any depth.
+    derives-from:
+      constraints: [CC-P-1]
+      scenarios: [LS-P-1]
+    verification:
+      - method: test
+        description: >
+          Test with component containing 2+ nested instances; verify
+          all core modules appear in parser output
+      - method: proof
+        description: >
+          Parser completeness proof (proofs/parser/)
+    status: draft
+    implementation: meld-core/src/parser.rs
+
+  - id: SR-2
+    title: Complete import/export extraction
+    description: >
+      The parser shall extract every import and export entry declared
+      by a component, preserving names, types, and kind.
+    derives-from:
+      constraints: [CC-P-2]
+      scenarios: []
+    verification:
+      - method: test
+        description: >
+          Round-trip test: parse component, verify import/export counts
+          match wasmparser's independent count
+    status: draft
+    implementation: meld-core/src/parser.rs
+
+  - id: SR-3
+    title: Correct Canonical ABI element size computation
+    description: >
+      canonical_abi_element_size shall return the correctly aligned
+      element size for all Canonical ABI types, including records with
+      heterogeneous field alignments.
+    derives-from:
+      constraints: [CC-P-3, CC-P-5]
+      scenarios: [LS-P-2]
+    verification:
+      - method: test
+        description: >
+          Property-based test with random record types; compare output
+          to reference implementation of Component Model elem_size
+      - method: proof
+        description: >
+          Proof that canonical_abi_element_size matches Component Model
+          spec definition (proofs/parser/ or proofs/adapter/)
+    status: draft
+    implementation: meld-core/src/parser.rs
+    spec-reference: "Component Model commit deb0b0a, canonical ABI"
+
+  - id: SR-4
+    title: Reject malformed components
+    description: >
+      The parser shall reject components that do not pass wasmparser
+      validation with feature flags locked to the Component Model
+      baseline spec.
+    derives-from:
+      constraints: [CC-P-6]
+      scenarios: [LS-P-3]
+    verification:
+      - method: test
+        description: >
+          Test with intentionally malformed binaries (truncated, wrong
+          magic, invalid sections); verify parser returns error
+    status: draft
+    implementation: meld-core/src/parser.rs
+
+  # ==========================================================================
+  # Resolution requirements (from CC-R-* and LS-R-*)
+  # ==========================================================================
+
+  - id: SR-5
+    title: Complete and correct import resolution
+    description: >
+      The resolver shall match every import to exactly one export with
+      a matching interface name and compatible type. Ambiguous matches
+      (multiple exports with the same name) shall produce an error.
+    derives-from:
+      constraints: [CC-R-1, CC-R-3]
+      scenarios: [LS-R-1]
+    verification:
+      - method: test
+        description: >
+          Test with unambiguous matches, ambiguous matches, and
+          unresolvable imports; verify correct behavior for each
+      - method: proof
+        description: >
+          Resolver correctness proof (proofs/resolver/)
+    status: draft
+    implementation: meld-core/src/resolver.rs
+
+  - id: SR-6
+    title: Correct CopyLayout classification
+    description: >
+      The resolver shall classify each cross-component call parameter
+      type into the correct CopyLayout. Types with inner pointer fields
+      (strings, lists, records containing pointers) shall be classified
+      as Elements with inner_pointers, not as Bulk.
+    derives-from:
+      constraints: [CC-R-2, CC-R-4, CC-R-5]
+      scenarios: [LS-R-2]
+    verification:
+      - method: test
+        description: >
+          Test CopyLayout for: list<u32> (Bulk), list<string> (Elements),
+          list<record{name:string, val:u32}> (Elements with inner ptrs)
+      - method: proof
+        description: >
+          CopyLayout consistency proof (proofs/adapter/)
+    status: draft
+    implementation: meld-core/src/resolver.rs
+
+  - id: SR-7
+    title: Valid topological instantiation order
+    description: >
+      The resolver shall produce a topological order where every
+      component appears after all components it imports from. Dependency
+      cycles shall be detected and reported as an error (or handled by
+      cycle-tolerant sort with documented semantics).
+    derives-from:
+      constraints: [CC-R-6, CC-R-7]
+      scenarios: [LS-R-3, LS-R-4]
+    verification:
+      - method: test
+        description: >
+          Test with linear chains, diamonds, cycles, and self-imports;
+          verify correct ordering or error
+      - method: proof
+        description: >
+          Topological sort correctness proof (proofs/resolver/)
+    status: draft
+    implementation: meld-core/src/resolver.rs
+
+  # ==========================================================================
+  # Merge requirements (from CC-M-* and LS-M-*)
+  # ==========================================================================
+
+  - id: SR-8
+    title: Correct function base offset calculation
+    description: >
+      The merger shall compute each component's function base offset
+      as the cumulative sum of all preceding components' total function
+      counts (imports + defined functions).
+    derives-from:
+      constraints: [CC-M-3]
+      scenarios: [LS-M-1]
+    verification:
+      - method: test
+        description: >
+          Test with components having different import/defined function
+          ratios; verify base offsets
+      - method: proof
+        description: >
+          Merge layout correctness proof (proofs/transformations/merge/)
+    status: draft
+    implementation: meld-core/src/merger.rs
+
+  - id: SR-9
+    title: Complete instruction index rewriting
+    description: >
+      The rewriter shall remap indices in all instruction types that
+      reference functions, memories, tables, globals, or types. This
+      includes multi-index instructions (memory.copy, memory.init).
+    derives-from:
+      constraints: [CC-M-2, CC-M-4, CC-M-8]
+      scenarios: [LS-M-2, LS-M-3]
+    verification:
+      - method: test
+        description: >
+          Exhaustive test over all Wasm instruction variants that take
+          index operands; verify each is remapped
+      - method: proof
+        description: >
+          Rewriter completeness proof (proofs/rewriter/)
+    status: draft
+    implementation: meld-core/src/rewriter.rs
+
+  - id: SR-10
+    title: Correct segment reindexing
+    description: >
+      The merger shall reindex data segment memory indices, element
+      segment table indices, and global indices in init expressions
+      using the correct per-kind base offset.
+    derives-from:
+      constraints: [CC-M-5, CC-M-6]
+      scenarios: []
+    verification:
+      - method: test
+        description: >
+          Test with components using global.get in data segment offsets;
+          verify remapped indices
+      - method: proof
+        description: >
+          Segment reindexing proof (proofs/segments/)
+    status: draft
+    implementation: meld-core/src/segments.rs
+
+  - id: SR-11
+    title: Component processing order matches resolver order
+    description: >
+      The merger shall process components in the same order as the
+      resolver's topological sort output.
+    derives-from:
+      constraints: [CC-M-7]
+      scenarios: []
+    verification:
+      - method: test
+        description: >
+          Assert merger iteration order matches resolver output order
+    status: draft
+    implementation: meld-core/src/merger.rs
+
+  # ==========================================================================
+  # Adapter requirements (from CC-A-* and LS-A-*)
+  # ==========================================================================
+
+  - id: SR-12
+    title: Adapter generation for all pointer-passing cross-component calls
+    description: >
+      The adapter generator shall produce an adapter function for every
+      resolved cross-component call whose signature includes pointer
+      types (string, list, record with pointer fields) in multi-memory
+      mode.
+    derives-from:
+      constraints: [CC-A-1]
+      scenarios: []
+    verification:
+      - method: test
+        description: >
+          Test that fusion of components with string/list parameters in
+          multi-memory mode produces adapter functions
+    status: draft
+    implementation: meld-core/src/adapter/fact.rs
+
+  - id: SR-13
+    title: Correct cabi_realloc targeting
+    description: >
+      The adapter shall call cabi_realloc using the post-merge function
+      index of the destination component's allocator.
+    derives-from:
+      constraints: [CC-A-2, CC-A-6]
+      scenarios: [LS-A-1]
+    verification:
+      - method: test
+        description: >
+          Runtime test: fuse components, execute cross-component call
+          with list argument, verify callee receives correct data
+    status: draft
+    implementation: meld-core/src/adapter/fact.rs
+
+  - id: SR-14
+    title: Correct memory index usage in adapters
+    description: >
+      The adapter shall use the correct source and destination memory
+      indices for all memory.copy, i32.load, and i32.store instructions.
+      Source = caller's memory, destination = callee's memory for
+      arguments; reversed for return values.
+    derives-from:
+      constraints: [CC-A-4, CC-A-9]
+      scenarios: [LS-A-2, LS-A-4]
+    verification:
+      - method: test
+        description: >
+          Runtime test: fuse components, verify data arrives in correct
+          memory after cross-component call
+      - method: proof
+        description: >
+          Adapter memory index proof (proofs/adapter/)
+    status: draft
+    implementation: meld-core/src/adapter/fact.rs
+
+  - id: SR-15
+    title: Correct list copy length
+    description: >
+      The adapter shall compute list copy byte length as element_count
+      multiplied by canonical_abi_element_size of the element type.
+    derives-from:
+      constraints: [CC-A-5]
+      scenarios: []
+    verification:
+      - method: test
+        description: >
+          Test with list<record> types with known element sizes; verify
+          copy length
+      - method: proof
+        description: >
+          Copy length proof (proofs/adapter/)
+    status: draft
+    implementation: meld-core/src/adapter/fact.rs
+
+  - id: SR-16
+    title: Recursive inner pointer fixup
+    description: >
+      For list types whose elements contain pointer fields, the adapter
+      shall emit a fixup loop that iterates over all elements and adjusts
+      each inner pointer to reference the destination memory. The loop
+      stride shall equal canonical_abi_element_size. The loop shall
+      process exactly element_count iterations.
+    derives-from:
+      constraints: [CC-A-3, CC-A-7, CC-A-11]
+      scenarios: [LS-A-3]
+    verification:
+      - method: test
+        description: >
+          Runtime test with list<string>: fuse, execute, verify all
+          strings are accessible in callee
+      - method: proof
+        description: >
+          Fixup loop termination and correctness proof (proofs/adapter/)
+    status: draft
+    implementation: meld-core/src/adapter/fact.rs
+
+  - id: SR-17
+    title: Correct string transcoding
+    description: >
+      String transcoding adapters shall produce valid output encoding
+      for all valid input, including characters outside the BMP
+      (surrogate pair handling for UTF-16).
+    derives-from:
+      constraints: [CC-A-8]
+      scenarios: []
+    verification:
+      - method: test
+        description: >
+          Test with strings containing BMP and non-BMP characters;
+          verify round-trip correctness
+    status: draft
+    implementation: meld-core/src/adapter/fact.rs
+
+  - id: SR-18
+    title: Adapter instruction ordering
+    description: >
+      The adapter shall emit instructions in the correct order:
+      cabi_realloc before memory.copy, memory.copy before callee
+      function call.
+    derives-from:
+      constraints: [CC-A-10]
+      scenarios: []
+    verification:
+      - method: inspection
+        description: >
+          Code review of adapter emission order
+      - method: test
+        description: >
+          Runtime test exercises the full adapter path
+    status: draft
+    implementation: meld-core/src/adapter/fact.rs
+
+  # ==========================================================================
+  # Cross-cutting requirements
+  # ==========================================================================
+
+  - id: SR-19
+    title: Deterministic output
+    description: >
+      Given identical input component bytes and identical FuserConfig,
+      meld shall produce byte-identical output across invocations.
+    derives-from:
+      constraints: [SC-7]
+      scenarios: [LS-CP-2]
+    verification:
+      - method: test
+        description: >
+          Run fusion twice with same inputs; assert byte-equal outputs
+    status: draft
+    implementation: meld-core/src/lib.rs
+
+  - id: SR-20
+    title: Fail-fast on unresolvable state
+    description: >
+      If any stage encounters an unresolvable error (unresolved import,
+      out-of-bounds index, malformed input), meld shall abort with a
+      diagnostic error. Partial or best-effort output shall not be
+      produced.
+    derives-from:
+      constraints: [SC-8, SC-9]
+      scenarios: []
+    verification:
+      - method: test
+        description: >
+          Test error paths: unresolved imports, malformed binaries,
+          invalid indices
+    status: draft
+    implementation: meld-core/src/error.rs

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -1,0 +1,231 @@
+# Traceability Matrix
+#
+# Maps the full chain: Loss -> Hazard -> Constraint -> UCA -> Scenario -> Requirement
+# and forward: Requirement -> Implementation -> Verification
+#
+# This file is the authoritative record of traceability. A validation tool
+# should check that:
+#   1. Every hazard traces to at least one loss
+#   2. Every constraint traces to at least one hazard
+#   3. Every UCA traces to at least one hazard
+#   4. Every scenario traces to at least one UCA
+#   5. Every requirement traces to at least one constraint or scenario
+#   6. Every requirement has at least one verification method
+#   7. No dangling references (all IDs resolve)
+
+# Reverse traceability: which requirements address each loss
+loss-coverage:
+  L-1:
+    hazards: [H-1, H-2, H-3, H-4, H-5]
+    requirements: [SR-1, SR-2, SR-3, SR-4, SR-5, SR-7, SR-8, SR-9, SR-10, SR-11, SR-12, SR-20]
+  L-2:
+    hazards: [H-2, H-3, H-4]
+    requirements: [SR-6, SR-9, SR-13, SR-14, SR-15, SR-16]
+  L-3:
+    hazards: [H-6]
+    requirements: []
+    gap: "No safety requirements yet for attestation (SC-6)"
+  L-4:
+    hazards: [H-7]
+    requirements: [SR-19]
+  L-5:
+    hazards: []
+    gap: "No explicit hazard for certification evidence loss"
+
+# Forward traceability: requirement -> implementation -> verification evidence
+verification-status:
+  SR-1:
+    implementation-files: [meld-core/src/parser.rs]
+    tests: []
+    proofs: [proofs/parser/]
+    status: not-verified
+
+  SR-2:
+    implementation-files: [meld-core/src/parser.rs]
+    tests: []
+    proofs: [proofs/parser/]
+    status: not-verified
+
+  SR-3:
+    implementation-files: [meld-core/src/parser.rs]
+    tests:
+      - parser::tests::test_canonical_abi_element_size_primitive_types
+      - parser::tests::test_canonical_abi_element_size_string
+      - parser::tests::test_canonical_abi_element_size_record_with_padding
+      - parser::tests::test_canonical_abi_element_size_record_homogeneous
+      - parser::tests::test_canonical_abi_align_values
+    proofs: []
+    status: partial
+
+  SR-4:
+    implementation-files: [meld-core/src/parser.rs]
+    tests: []
+    proofs: []
+    status: not-verified
+
+  SR-5:
+    implementation-files: [meld-core/src/resolver.rs]
+    tests:
+      - resolver::tests::test_resolver_strict_mode
+      - resolver::tests::test_resolver_unresolved_import_error
+    proofs: [proofs/resolver/]
+    status: partial
+
+  SR-6:
+    implementation-files: [meld-core/src/resolver.rs]
+    tests:
+      - resolver::tests::test_copy_layout_flat_list
+      - resolver::tests::test_copy_layout_string_list
+      - resolver::tests::test_copy_layout_record_with_string
+      - resolver::tests::test_copy_layout_nested_list
+      - resolver::tests::test_copy_layout_flat_record
+    proofs: []
+    status: partial
+
+  SR-7:
+    implementation-files: [meld-core/src/resolver.rs]
+    tests:
+      - resolver::tests::test_topological_sort_linear
+      - resolver::tests::test_topological_sort_no_deps
+      - resolver::tests::test_topological_sort_circular_fallback
+      - resolver::tests::test_topological_sort_diamond
+      - resolver::tests::test_resolver_preserves_order_stability
+    proofs: [proofs/resolver/]
+    status: partial
+
+  SR-8:
+    implementation-files: [meld-core/src/merger.rs]
+    tests: []
+    proofs: [proofs/transformations/merge/]
+    status: partial
+
+  SR-9:
+    implementation-files: [meld-core/src/rewriter.rs]
+    tests:
+      - rewriter::tests::test_rewrite_memory_copy_rebased
+      - rewriter::tests::test_rewrite_memory_fill_rebased
+      - rewriter::tests::test_rewrite_memory_init_rebased
+      - rewriter::tests::test_rewrite_memory_size_rebased_const
+      - rewriter::tests::test_rewrite_call_remaps_function_index
+      - rewriter::tests::test_rewrite_call_indirect_remaps_type_and_table
+      - rewriter::tests::test_rewrite_global_get_set_remaps
+      - rewriter::tests::test_rewrite_table_ops_remap
+      - rewriter::tests::test_rewrite_table_copy_remaps_both
+      - rewriter::tests::test_rewrite_memory_copy_remaps_both_memories
+      - rewriter::tests::test_rewrite_memory_load_store_remaps_memory
+      - rewriter::tests::test_rewrite_ref_func_remaps
+    proofs: [proofs/rewriter/]
+    status: partial
+
+  SR-10:
+    implementation-files: [meld-core/src/segments.rs]
+    tests:
+      - segments::tests::test_reindex_data_segment_rebases_offset
+      - segments::tests::test_reindex_const_expr_global_get
+      - segments::tests::test_reindex_const_expr_ref_func
+      - segments::tests::test_reindex_element_segment_active_remaps_table
+      - segments::tests::test_reindex_element_segment_remaps_function_refs
+      - segments::tests::test_reindex_data_segment_remaps_memory_index
+      - segments::tests::test_reindex_data_segment_global_get_remaps_global
+      - segments::tests::test_reindex_element_segment_expression_remaps_ref_null_type
+    proofs: [proofs/segments/]
+    status: partial
+
+  SR-11:
+    implementation-files: [meld-core/src/merger.rs]
+    tests: []
+    proofs: []
+    status: not-verified
+
+  SR-12:
+    implementation-files: [meld-core/src/adapter/fact.rs]
+    tests: []
+    proofs: []
+    status: not-verified
+
+  SR-13:
+    implementation-files: [meld-core/src/adapter/fact.rs]
+    tests: []
+    proofs: []
+    status: not-verified
+
+  SR-14:
+    implementation-files: [meld-core/src/adapter/fact.rs]
+    tests: []
+    proofs: [proofs/adapter/]
+    status: partial
+
+  SR-15:
+    implementation-files: [meld-core/src/adapter/fact.rs]
+    tests: []
+    proofs: []
+    status: not-verified
+
+  SR-16:
+    implementation-files: [meld-core/src/adapter/fact.rs]
+    tests: []
+    proofs: []
+    status: not-verified
+
+  SR-17:
+    implementation-files: [meld-core/src/adapter/fact.rs]
+    tests: []
+    proofs: []
+    status: not-verified
+
+  SR-18:
+    implementation-files: [meld-core/src/adapter/fact.rs]
+    tests: []
+    proofs: []
+    status: not-verified
+
+  SR-19:
+    implementation-files: [meld-core/src/lib.rs]
+    tests:
+      - tests::test_deterministic_output
+      - resolver::tests::test_resolver_preserves_order_stability
+    proofs: []
+    status: partial
+
+  SR-20:
+    implementation-files: [meld-core/src/error.rs]
+    tests:
+      - tests::test_fuser_empty_components_error
+      - tests::test_fuser_rejects_core_module_input
+      - tests::test_fuser_address_rebasing_requires_shared_memory
+      - tests::test_fuser_rejects_invalid_wasm
+    proofs: []
+    status: partial
+
+# Identified gaps
+gaps:
+  - id: GAP-1
+    description: >
+      L-3 (supply chain integrity) has hazard H-6 and constraint SC-6
+      but no safety requirements or verification. Attestation module
+      exists but is not covered by STPA-derived requirements.
+    priority: medium
+    action: >
+      Add SR for attestation correctness; add tests for attestation
+      custom section content.
+
+  - id: GAP-2
+    description: >
+      L-5 (certification evidence) has no hazard. The STPA does not yet
+      model the proof pipeline or the traceability chain as a controlled
+      process.
+    priority: low
+    action: >
+      Consider extending control structure to include the proof
+      pipeline as a controller with feedback to the build system.
+
+  - id: GAP-3
+    description: >
+      SR-6 now has unit tests for CopyLayout classification. SR-12,
+      SR-13, SR-15, SR-16 still have no tests or proofs. These require
+      runtime integration tests with real cross-component calls (wit-bindgen
+      fixtures).
+    priority: high
+    action: >
+      Priority for issue #10 (more wit-bindgen fixtures) and issue #11
+      (Rocq proofs for CopyLayout).

--- a/safety/schema/stpa.schema.json
+++ b/safety/schema/stpa.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pulseengine.eu/schemas/stpa/v1",
+  "title": "STPA Artifact Schema",
+  "description": "Schema for validating STPA YAML artifacts (losses, hazards, constraints, UCAs, scenarios, requirements)",
+
+  "$defs": {
+    "id-pattern": {
+      "type": "string",
+      "pattern": "^[A-Z]+-[A-Z]*-?[0-9]+(\\.[0-9]+)?$",
+      "description": "Artifact ID: PREFIX-NUMBER or PREFIX-LETTER-NUMBER (e.g., L-1, H-3.2, UCA-P-4, SR-12)"
+    },
+
+    "id-ref-list": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/id-pattern" },
+      "minItems": 1,
+      "description": "List of artifact ID references"
+    },
+
+    "status": {
+      "type": "string",
+      "enum": ["draft", "reviewed", "approved", "implemented", "verified"],
+      "description": "Lifecycle status of the artifact"
+    },
+
+    "loss": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/$defs/id-pattern" },
+        "title": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "stakeholders": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["id", "title"],
+      "additionalProperties": false
+    },
+
+    "hazard": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/$defs/id-pattern" },
+        "title": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "losses": { "$ref": "#/$defs/id-ref-list" }
+      },
+      "required": ["id", "title", "losses"],
+      "additionalProperties": false
+    },
+
+    "sub-hazard": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/$defs/id-pattern" },
+        "parent": { "$ref": "#/$defs/id-pattern" },
+        "title": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" }
+      },
+      "required": ["id", "parent", "title"],
+      "additionalProperties": false
+    },
+
+    "system-constraint": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/$defs/id-pattern" },
+        "title": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "hazards": { "$ref": "#/$defs/id-ref-list" },
+        "spec-baseline": { "type": "string" }
+      },
+      "required": ["id", "title", "hazards"],
+      "additionalProperties": false
+    },
+
+    "uca": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/$defs/id-pattern" },
+        "description": { "type": "string", "minLength": 1 },
+        "context": { "type": "string" },
+        "hazards": { "$ref": "#/$defs/id-ref-list" },
+        "rationale": { "type": "string" }
+      },
+      "required": ["id", "description", "hazards"],
+      "additionalProperties": false
+    },
+
+    "loss-scenario": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/$defs/id-pattern" },
+        "title": { "type": "string", "minLength": 1 },
+        "uca": { "$ref": "#/$defs/id-pattern" },
+        "type": {
+          "type": "string",
+          "enum": [
+            "inadequate-control-algorithm",
+            "inadequate-process-model",
+            "controller-failure",
+            "unsafe-control-input",
+            "control-path",
+            "controlled-process"
+          ]
+        },
+        "scenario": { "type": "string" },
+        "hazards": { "$ref": "#/$defs/id-ref-list" },
+        "causal-factors": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "process-model-flaw": { "type": "string" }
+      },
+      "required": ["id", "title", "scenario"],
+      "additionalProperties": false
+    },
+
+    "verification-method": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": ["test", "proof", "inspection", "analysis"]
+        },
+        "description": { "type": "string" }
+      },
+      "required": ["method"],
+      "additionalProperties": false
+    },
+
+    "requirement": {
+      "type": "object",
+      "properties": {
+        "id": { "$ref": "#/$defs/id-pattern" },
+        "title": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "derives-from": {
+          "type": "object",
+          "properties": {
+            "constraints": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/id-pattern" }
+            },
+            "scenarios": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/id-pattern" }
+            }
+          },
+          "additionalProperties": false
+        },
+        "verification": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/verification-method" },
+          "minItems": 1
+        },
+        "status": { "$ref": "#/$defs/status" },
+        "implementation": { "type": "string" },
+        "spec-reference": { "type": "string" }
+      },
+      "required": ["id", "title", "description", "verification", "status"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/safety/stpa/control-structure-diagram.md
+++ b/safety/stpa/control-structure-diagram.md
@@ -1,0 +1,81 @@
+# Meld STPA Control Structure Diagram
+
+## High-Level Control Structure
+
+```mermaid
+flowchart TD
+    subgraph "External Environment"
+        BUILD["Build System / Developer<br/>(CTRL-BUILD)"]
+    end
+
+    subgraph "Meld System Boundary"
+        CLI["Meld CLI<br/>(CTRL-CLI)"]
+        PARSER["Parser<br/>(CTRL-PARSER)"]
+        RESOLVER["Resolver<br/>(CTRL-RESOLVER)"]
+        MERGER["Merger<br/>(CTRL-MERGER)"]
+        ADAPTER["Adapter Generator<br/>(CTRL-ADAPTER)"]
+
+        subgraph "Controlled Processes"
+            COMP["Component Binary Data"]
+            DEP["Dependency Graph"]
+            IDX["Merged Index Space"]
+            TRAMP["Adapter Trampoline Code"]
+            OUT["Output Encoding"]
+        end
+    end
+
+    BUILD -->|"config, components"| CLI
+    CLI -.->|"exit code, errors, stats"| BUILD
+
+    CLI -->|"component bytes"| PARSER
+    PARSER -.->|"parsed structures, errors"| CLI
+
+    CLI -->|"parsed components"| RESOLVER
+    RESOLVER -.->|"resolved graph, CopyLayouts"| CLI
+
+    CLI -->|"resolved graph"| MERGER
+    MERGER -.->|"merged module, index maps"| CLI
+
+    CLI -->|"merge result, CopyLayouts"| ADAPTER
+    ADAPTER -.->|"adapter functions"| CLI
+
+    CLI -->|"final module"| OUT
+
+    PARSER -->|"validate, extract"| COMP
+    COMP -.->|"sections, types"| PARSER
+
+    RESOLVER -->|"match, sort"| DEP
+    DEP -.->|"pairs, order"| RESOLVER
+
+    MERGER -->|"rebase, rewrite"| IDX
+    IDX -.->|"index maps"| MERGER
+
+    ADAPTER -->|"generate trampolines"| TRAMP
+    TRAMP -.->|"wasm instructions"| ADAPTER
+```
+
+## Adapter Generator Detail (CTRL-ADAPTER)
+
+```mermaid
+flowchart TD
+    ADAPT["Adapter Generator"]
+
+    ADAPT -->|"CA-ADAPT-1: generate adapter"| TRAMP["Trampoline Code"]
+    ADAPT -->|"CA-ADAPT-2: cabi_realloc"| CALLEEALLOC["Callee Memory Allocation"]
+    ADAPT -->|"CA-ADAPT-3: memory.copy"| DATACOPY["Cross-Memory Data Copy"]
+    ADAPT -->|"CA-ADAPT-4: fixup loop"| PTRFIX["Inner Pointer Fixup"]
+    ADAPT -->|"CA-ADAPT-5: transcode"| STRCONV["String Transcoding"]
+
+    TRAMP -.->|"function index"| ADAPT
+    CALLEEALLOC -.->|"dest pointer"| ADAPT
+    DATACOPY -.->|"bytes copied"| ADAPT
+    PTRFIX -.->|"pointers fixed"| ADAPT
+    STRCONV -.->|"transcoded bytes"| ADAPT
+```
+
+## Legend
+
+- **Solid arrows** (-->) = Control actions (commands flowing downward)
+- **Dashed arrows** (-..->) = Feedback (information flowing upward)
+- Each controller has a process model (internal beliefs) used to make decisions
+- STPA does not assume obedience: control actions may not be executed correctly

--- a/safety/stpa/control-structure.yaml
+++ b/safety/stpa/control-structure.yaml
@@ -1,0 +1,214 @@
+# STPA Step 2: Control Structure
+#
+# A hierarchical control structure is a system model composed of feedback
+# control loops. It captures functional relationships and interactions.
+#
+# Meld is a build-time tool. Its control structure models the transformation
+# pipeline where each stage controls the data flowing to the next stage.
+# The "controlled process" is the WebAssembly transformation itself.
+#
+# Reference: STPA Handbook (Leveson & Thomas, 2018), Chapter 2
+#
+# See control-structure-diagram.md for the Mermaid visualization.
+
+controllers:
+  - id: CTRL-BUILD
+    name: Build System / Developer
+    type: human-and-automated
+    description: >
+      The developer or build system (Bazel, Cargo) that invokes meld with
+      a specific configuration. Selects input components, memory strategy,
+      output format, and attestation settings.
+    control-actions:
+      - ca: CA-BUILD-1
+        target: CTRL-CLI
+        action: Invoke meld with configuration and input components
+      - ca: CA-BUILD-2
+        target: CTRL-CLI
+        action: Select memory strategy (multi-memory or shared)
+      - ca: CA-BUILD-3
+        target: CTRL-CLI
+        action: Select output format (CoreModule or Component)
+    feedback:
+      - from: CTRL-CLI
+        info: Exit code, error messages, fusion statistics
+    process-model:
+      - Input components are valid P2/P3 components
+      - Selected memory strategy is compatible with target runtime
+      - Output format matches downstream tool expectations
+
+  - id: CTRL-CLI
+    name: Meld CLI
+    type: automated
+    description: >
+      The meld binary that orchestrates the fusion pipeline. Parses CLI
+      arguments, constructs FuserConfig, invokes the Fuser, and writes
+      output.
+    control-actions:
+      - ca: CA-CLI-1
+        target: CTRL-PARSER
+        action: Submit component bytes for parsing
+      - ca: CA-CLI-2
+        target: CTRL-RESOLVER
+        action: Initiate dependency resolution
+      - ca: CA-CLI-3
+        target: CTRL-MERGER
+        action: Initiate index-space merging
+      - ca: CA-CLI-4
+        target: CTRL-ADAPTER
+        action: Initiate adapter generation
+      - ca: CA-CLI-5
+        target: PROC-ENCODE
+        action: Initiate output encoding
+    feedback:
+      - from: CTRL-PARSER
+        info: Parsed component structures, validation errors
+      - from: CTRL-RESOLVER
+        info: Resolved dependency graph, unresolved imports
+      - from: CTRL-MERGER
+        info: Merged module, index maps
+      - from: CTRL-ADAPTER
+        info: Generated adapter functions, adapter statistics
+      - from: PROC-ENCODE
+        info: Output bytes, validation result
+    process-model:
+      - All components parsed successfully
+      - All imports resolved
+      - Index spaces merged without conflict
+      - Adapters generated for all cross-component calls
+
+  - id: CTRL-PARSER
+    name: Parser
+    type: automated
+    description: >
+      Reads WebAssembly component binaries using wasmparser. Extracts core
+      modules, types, functions, memories, tables, globals, imports, exports,
+      and Canonical ABI metadata (canonical_abi_size, canonical_abi_align,
+      canonical_abi_element_size).
+    source-file: meld-core/src/parser.rs
+    control-actions:
+      - ca: CA-PARSE-1
+        target: PROC-COMPONENT
+        action: Validate component binary format
+      - ca: CA-PARSE-2
+        target: PROC-COMPONENT
+        action: Extract core modules and type information
+      - ca: CA-PARSE-3
+        target: PROC-COMPONENT
+        action: Compute Canonical ABI element sizes and alignments
+    feedback:
+      - from: PROC-COMPONENT
+        info: Parsed sections, type definitions, import/export maps
+    process-model:
+      - Input bytes are a valid WebAssembly component
+      - All sections are parsed in order
+      - Type indices in the component are consistent
+
+  - id: CTRL-RESOLVER
+    name: Resolver
+    type: automated
+    description: >
+      Builds the dependency graph from parsed components. Matches imports
+      to exports, computes topological sort for instantiation order,
+      detects cycles, and determines CopyLayout for cross-component data
+      transfer.
+    source-file: meld-core/src/resolver.rs
+    control-actions:
+      - ca: CA-RESOLVE-1
+        target: PROC-DEPGRAPH
+        action: Match component imports to component exports
+      - ca: CA-RESOLVE-2
+        target: PROC-DEPGRAPH
+        action: Compute topological instantiation order
+      - ca: CA-RESOLVE-3
+        target: PROC-DEPGRAPH
+        action: Determine CopyLayout for each cross-component call
+    feedback:
+      - from: PROC-DEPGRAPH
+        info: Resolved import/export pairs, instantiation order, CopyLayouts
+    process-model:
+      - All import names have a matching export in some component
+      - The dependency graph is a DAG (or cycles are handled)
+      - CopyLayout correctly reflects the type structure
+
+  - id: CTRL-MERGER
+    name: Merger
+    type: automated
+    description: >
+      Combines the index spaces of all components into a single module.
+      Computes base offsets for each component's functions, memories,
+      tables, globals, and types. Rewrites all instructions via the
+      Rewriter to update indices.
+    source-file: meld-core/src/merger.rs
+    control-actions:
+      - ca: CA-MERGE-1
+        target: PROC-INDEXSPACE
+        action: Compute base offsets for each component's index space
+      - ca: CA-MERGE-2
+        target: PROC-INDEXSPACE
+        action: Rewrite all instructions with remapped indices
+      - ca: CA-MERGE-3
+        target: PROC-INDEXSPACE
+        action: Reindex data segments and element segments
+    feedback:
+      - from: PROC-INDEXSPACE
+        info: Index maps (old index -> new index), merged sections
+    process-model:
+      - Base offsets are computed as cumulative sums
+      - Every instruction referencing an index is visited by the rewriter
+      - Segment offsets are rebased to the correct memory
+
+  - id: CTRL-ADAPTER
+    name: Adapter Generator (FACT)
+    type: automated
+    description: >
+      Generates Canonical ABI adapter functions (trampolines) for
+      cross-component calls. Handles memory allocation via cabi_realloc,
+      data copying via memory.copy, string transcoding, list element
+      sizing, and recursive inner pointer fixup.
+    source-file: meld-core/src/adapter/fact.rs
+    control-actions:
+      - ca: CA-ADAPT-1
+        target: PROC-TRAMPOLINE
+        action: Generate adapter function for a resolved import/export pair
+      - ca: CA-ADAPT-2
+        target: PROC-TRAMPOLINE
+        action: Emit memory allocation via cabi_realloc in callee memory
+      - ca: CA-ADAPT-3
+        target: PROC-TRAMPOLINE
+        action: Emit data copy via memory.copy between memories
+      - ca: CA-ADAPT-4
+        target: PROC-TRAMPOLINE
+        action: Emit recursive inner pointer fixup loop
+      - ca: CA-ADAPT-5
+        target: PROC-TRAMPOLINE
+        action: Emit string transcoding (UTF-8/UTF-16, Latin-1/UTF-8)
+    feedback:
+      - from: PROC-TRAMPOLINE
+        info: Generated wasm instructions, adapter function index
+    process-model:
+      - Source and destination memory indices are correct
+      - Element sizes match the Canonical ABI specification
+      - Inner pointer offsets are correctly computed with alignment
+      - cabi_realloc function index is correct for the callee component
+
+controlled-processes:
+  - id: PROC-COMPONENT
+    name: Component Binary Data
+    description: Raw WebAssembly component bytes being parsed
+
+  - id: PROC-DEPGRAPH
+    name: Dependency Graph
+    description: Import/export resolution and instantiation ordering
+
+  - id: PROC-INDEXSPACE
+    name: Merged Index Space
+    description: Combined function/memory/table/global/type index space
+
+  - id: PROC-TRAMPOLINE
+    name: Adapter Trampoline Code
+    description: Generated WebAssembly instructions for cross-component calls
+
+  - id: PROC-ENCODE
+    name: Output Encoding
+    description: Serialization of the fused module to WebAssembly binary

--- a/safety/stpa/controller-constraints.yaml
+++ b/safety/stpa/controller-constraints.yaml
@@ -1,0 +1,284 @@
+# STPA Step 3b: Controller Constraints
+#
+# Each UCA is inverted to define a constraint on the controller's behavior.
+# Format: <Controller> must/must not <behavior> [UCA-x]
+#
+# Reference: STPA Handbook (Leveson & Thomas, 2018), Chapter 2
+
+controller-constraints:
+
+  # Parser constraints
+  - id: CC-P-1
+    controller: CTRL-PARSER
+    constraint: >
+      Parser must extract all core modules present in a component,
+      including nested instances
+    ucas: [UCA-P-1]
+    hazards: [H-1, H-3]
+
+  - id: CC-P-2
+    controller: CTRL-PARSER
+    constraint: >
+      Parser must extract all import and export entries from each
+      component
+    ucas: [UCA-P-2]
+    hazards: [H-1, H-5]
+
+  - id: CC-P-3
+    controller: CTRL-PARSER
+    constraint: >
+      Parser must compute canonical_abi_element_size for all types
+      that may appear in cross-component function signatures
+    ucas: [UCA-P-3]
+    hazards: [H-4, H-4.1, H-4.2]
+
+  - id: CC-P-4
+    controller: CTRL-PARSER
+    constraint: >
+      Parser must extract correct type signatures for all functions,
+      including those referencing recursive type groups
+    ucas: [UCA-P-4]
+    hazards: [H-1, H-4]
+
+  - id: CC-P-5
+    controller: CTRL-PARSER
+    constraint: >
+      Parser must compute canonical_abi_element_size with correct
+      alignment padding for record types
+    ucas: [UCA-P-5]
+    hazards: [H-4, H-4.1]
+
+  - id: CC-P-6
+    controller: CTRL-PARSER
+    constraint: >
+      Parser must reject malformed component binaries with a
+      diagnostic error
+    ucas: [UCA-P-6]
+    hazards: [H-1, H-3]
+
+  - id: CC-P-7
+    controller: CTRL-PARSER
+    constraint: >
+      Parser must process sections in the order specified by the
+      WebAssembly binary format
+    ucas: [UCA-P-7]
+    hazards: [H-3, H-3.4]
+
+  - id: CC-P-8
+    controller: CTRL-PARSER
+    constraint: >
+      Parser must process all sections of a component, including
+      code and data sections
+    ucas: [UCA-P-8]
+    hazards: [H-1, H-3]
+
+  # Resolver constraints
+  - id: CC-R-1
+    controller: CTRL-RESOLVER
+    constraint: >
+      Resolver must match every import to its corresponding export
+      when a valid match exists
+    ucas: [UCA-R-1]
+    hazards: [H-1, H-5]
+
+  - id: CC-R-2
+    controller: CTRL-RESOLVER
+    constraint: >
+      Resolver must produce a CopyLayout for every cross-component
+      call whose signature contains pointer types
+    ucas: [UCA-R-2]
+    hazards: [H-4, H-4.2]
+
+  - id: CC-R-3
+    controller: CTRL-RESOLVER
+    constraint: >
+      Resolver must not match an import to an export with a different
+      interface or type
+    ucas: [UCA-R-3]
+    hazards: [H-1]
+
+  - id: CC-R-4
+    controller: CTRL-RESOLVER
+    constraint: >
+      Resolver must compute CopyLayout byte_multiplier consistent with
+      canonical_abi_element_size
+    ucas: [UCA-R-4]
+    hazards: [H-4, H-4.1]
+
+  - id: CC-R-5
+    controller: CTRL-RESOLVER
+    constraint: >
+      Resolver must classify types with inner pointers as Elements
+      copy, not Bulk copy
+    ucas: [UCA-R-5]
+    hazards: [H-4, H-4.2]
+
+  - id: CC-R-6
+    controller: CTRL-RESOLVER
+    constraint: >
+      Resolver must produce an instantiation order where every
+      component appears after all components it depends on
+    ucas: [UCA-R-6]
+    hazards: [H-5, H-1]
+
+  - id: CC-R-7
+    controller: CTRL-RESOLVER
+    constraint: >
+      Resolver must detect dependency cycles and either report an
+      error or apply cycle-tolerant ordering with correct semantics
+    ucas: [UCA-R-7]
+    hazards: [H-5, H-1]
+
+  # Merger constraints
+  - id: CC-M-1
+    controller: CTRL-MERGER
+    constraint: >
+      Merger must include all functions from all components in the
+      merged function section
+    ucas: [UCA-M-1]
+    hazards: [H-1, H-3]
+
+  - id: CC-M-2
+    controller: CTRL-MERGER
+    constraint: >
+      Merger must rewrite every memory-referencing instruction to
+      use the rebased memory index
+    ucas: [UCA-M-2]
+    hazards: [H-2, H-3.2]
+
+  - id: CC-M-3
+    controller: CTRL-MERGER
+    constraint: >
+      Merger must compute function base offsets as cumulative sums
+      of preceding components' function counts (including imports)
+    ucas: [UCA-M-3]
+    hazards: [H-3, H-3.1]
+
+  - id: CC-M-4
+    controller: CTRL-MERGER
+    constraint: >
+      Merger must rewrite call_indirect type indices using the type
+      index offset, not the function index offset
+    ucas: [UCA-M-4]
+    hazards: [H-3, H-3.4]
+
+  - id: CC-M-5
+    controller: CTRL-MERGER
+    constraint: >
+      Merger must rebase data segment offsets using the memory base
+      address, not the function base offset
+    ucas: [UCA-M-5]
+    hazards: [H-2, H-1]
+
+  - id: CC-M-6
+    controller: CTRL-MERGER
+    constraint: >
+      Merger must remap global indices in data/element segment init
+      expressions
+    ucas: [UCA-M-6]
+    hazards: [H-3, H-3.3]
+
+  - id: CC-M-7
+    controller: CTRL-MERGER
+    constraint: >
+      Merger must process components in the same order as the
+      resolver's topological sort
+    ucas: [UCA-M-7]
+    hazards: [H-3, H-5]
+
+  - id: CC-M-8
+    controller: CTRL-MERGER
+    constraint: >
+      Rewriter must visit all instruction types that reference indices,
+      including multi-argument bulk memory instructions
+    ucas: [UCA-M-8]
+    hazards: [H-2, H-3.2]
+
+  # Adapter Generator constraints
+  - id: CC-A-1
+    controller: CTRL-ADAPTER
+    constraint: >
+      Adapter generator must produce an adapter for every cross-component
+      call that passes pointer arguments in multi-memory mode
+    ucas: [UCA-A-1]
+    hazards: [H-2, H-4]
+
+  - id: CC-A-2
+    controller: CTRL-ADAPTER
+    constraint: >
+      Adapter must emit cabi_realloc call to allocate destination buffer
+      before any memory.copy
+    ucas: [UCA-A-2]
+    hazards: [H-2, H-4, H-4.3]
+
+  - id: CC-A-3
+    controller: CTRL-ADAPTER
+    constraint: >
+      Adapter must emit inner pointer fixup loop for every list type
+      whose elements contain pointer fields
+    ucas: [UCA-A-3]
+    hazards: [H-4, H-4.2]
+
+  - id: CC-A-4
+    controller: CTRL-ADAPTER
+    constraint: >
+      Adapter must emit memory.copy with correct source and destination
+      memory indices
+    ucas: [UCA-A-4]
+    hazards: [H-2, H-4]
+
+  - id: CC-A-5
+    controller: CTRL-ADAPTER
+    constraint: >
+      Adapter must compute copy length using the correct
+      canonical_abi_element_size for the list element type
+    ucas: [UCA-A-5]
+    hazards: [H-4, H-4.1]
+
+  - id: CC-A-6
+    controller: CTRL-ADAPTER
+    constraint: >
+      Adapter must call cabi_realloc with the function index of the
+      destination component's allocator
+    ucas: [UCA-A-6]
+    hazards: [H-2, H-4, H-4.3]
+
+  - id: CC-A-7
+    controller: CTRL-ADAPTER
+    constraint: >
+      Adapter must compute inner pointer offsets within record elements
+      using correct alignment rules
+    ucas: [UCA-A-7]
+    hazards: [H-4, H-4.2]
+
+  - id: CC-A-8
+    controller: CTRL-ADAPTER
+    constraint: >
+      String transcoding must correctly handle surrogate pairs in
+      UTF-16 to UTF-8 conversion
+    ucas: [UCA-A-8]
+    hazards: [H-4, H-4.4]
+
+  - id: CC-A-9
+    controller: CTRL-ADAPTER
+    constraint: >
+      Return value lifting must read from the callee's memory, not
+      the caller's memory
+    ucas: [UCA-A-9]
+    hazards: [H-2, H-4]
+
+  - id: CC-A-10
+    controller: CTRL-ADAPTER
+    constraint: >
+      Adapter must emit cabi_realloc before memory.copy in the
+      instruction sequence
+    ucas: [UCA-A-10]
+    hazards: [H-4]
+
+  - id: CC-A-11
+    controller: CTRL-ADAPTER
+    constraint: >
+      Inner pointer fixup loop must iterate over all elements in
+      the list (loop counter must equal element count)
+    ucas: [UCA-A-11]
+    hazards: [H-4, H-4.2]

--- a/safety/stpa/hazards.yaml
+++ b/safety/stpa/hazards.yaml
@@ -1,0 +1,142 @@
+# STPA Step 1b: System-Level Hazards
+#
+# A hazard is a system state or set of conditions that, together with a
+# particular set of worst-case environmental conditions, will lead to a loss.
+#
+# Format: <System> & <Unsafe Condition> & <Link to Losses>
+#
+# Reference: STPA Handbook (Leveson & Thomas, 2018), Chapter 2
+# Hazards are system states, not component failures or environmental states.
+# Keep to ~7-10 system-level hazards; refine into sub-hazards as needed.
+
+hazards:
+  - id: H-1
+    title: Fused module produces different observable behavior than the original composition
+    description: >
+      Meld produces a fused module whose execution semantics diverge from
+      the composed component graph. This includes wrong return values, calls
+      dispatched to incorrect functions, missing or spurious traps, or
+      incorrect control flow.
+    losses: [L-1]
+
+  - id: H-2
+    title: Cross-component memory access violates isolation boundaries
+    description: >
+      Meld produces a fused module where one component's code can read from
+      or write to another component's linear memory without going through
+      a correctly generated adapter. In multi-memory mode, this means
+      instructions reference the wrong memory index. In shared-memory mode,
+      this means address ranges overlap or rebase incorrectly.
+    losses: [L-1, L-2]
+
+  - id: H-3
+    title: Index remapping produces references to incorrect entities
+    description: >
+      During merger, function/memory/table/global/type indices are rebased
+      incorrectly, causing instructions in the fused module to reference
+      the wrong entity. A call instruction targets the wrong function, a
+      memory.load uses the wrong memory, or a table.get accesses the wrong
+      table.
+    losses: [L-1, L-2]
+
+  - id: H-4
+    title: Adapter generates incorrect Canonical ABI trampoline code
+    description: >
+      The generated adapter function for a cross-component call does not
+      correctly implement the Canonical ABI lifting/lowering. This includes
+      incorrect memory allocation via cabi_realloc, wrong copy sizes or
+      offsets, incorrect string transcoding, incorrect list element sizing,
+      or missing recursive pointer fixup.
+    losses: [L-1, L-2]
+
+  - id: H-5
+    title: Dependency resolution produces incorrect instantiation order
+    description: >
+      The resolver computes an incorrect topological order of component
+      instantiation, causing a component to be instantiated before a
+      component it depends on. This can cause imports to bind to the wrong
+      exports or initialization to observe uninitialized state.
+    losses: [L-1]
+
+  - id: H-6
+    title: Transformation provenance is lost or falsified
+    description: >
+      The attestation custom section is missing, contains incorrect input
+      hashes, records the wrong tool version, or omits configuration
+      parameters that affected the transformation. Downstream verification
+      by Sigil cannot confirm the transformation chain.
+    losses: [L-3]
+
+  - id: H-7
+    title: Output is non-deterministic for identical inputs
+    description: >
+      The fusion pipeline produces different output bytes when given the
+      same input components and configuration. Sources include iteration
+      over hash maps with non-deterministic order, timestamp-dependent
+      behavior, or ASLR-dependent pointer comparisons.
+    losses: [L-4]
+
+# Sub-hazards: optional refinement for complex hazards
+sub-hazards:
+  # Refinements of H-3 (index remapping)
+  - id: H-3.1
+    parent: H-3
+    title: Function index offset computed incorrectly
+    description: >
+      The base offset for a component's function indices in the merged
+      index space is wrong, shifting all function references by an
+      incorrect amount.
+
+  - id: H-3.2
+    parent: H-3
+    title: Memory index not remapped in multi-memory mode
+    description: >
+      An instruction that references a memory (load, store, memory.size,
+      memory.grow, memory.copy, memory.fill, memory.init) retains its
+      original per-component memory index instead of being remapped to the
+      merged memory index space.
+
+  - id: H-3.3
+    parent: H-3
+    title: Global index remapping misses imported globals
+    description: >
+      Imported globals are renumbered during merge but references to them
+      in init expressions or instructions are not updated.
+
+  - id: H-3.4
+    parent: H-3
+    title: Type index remapping misses call_indirect signatures
+    description: >
+      Type indices used in call_indirect instructions or table element
+      segments are not updated after type section merging.
+
+  # Refinements of H-4 (adapter generation)
+  - id: H-4.1
+    parent: H-4
+    title: Adapter computes wrong byte length for list copy
+    description: >
+      The adapter multiplies element count by incorrect element size when
+      computing the byte length argument to memory.copy for list types.
+
+  - id: H-4.2
+    parent: H-4
+    title: Adapter omits recursive inner pointer fixup
+    description: >
+      For list elements containing pointers (strings, nested lists), the
+      adapter copies raw bytes but does not walk the element structure to
+      fixup inner pointers that reference the source memory.
+
+  - id: H-4.3
+    parent: H-4
+    title: Adapter allocates in wrong component memory
+    description: >
+      The adapter calls cabi_realloc in the source component's memory
+      instead of the destination component's memory (or vice versa),
+      causing the allocated buffer to be inaccessible to the callee.
+
+  - id: H-4.4
+    parent: H-4
+    title: String transcoding produces incorrect UTF-8/UTF-16 conversion
+    description: >
+      The adapter's string transcoding logic miscounts code units, does not
+      handle surrogate pairs correctly, or produces invalid UTF-8 sequences.

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -1,0 +1,285 @@
+# STPA Step 4: Loss Scenarios
+#
+# A loss scenario describes the causal factors that can lead to unsafe
+# control actions and to hazards. Two types:
+#   a) Why would UCAs occur? (controller behavior, process model flaws)
+#   b) Why would control actions be improperly executed? (control path,
+#      controlled process)
+#
+# Each scenario traces from causal factor -> UCA -> hazard -> loss.
+#
+# Reference: STPA Handbook (Leveson & Thomas, 2018), Chapter 2
+
+loss-scenarios:
+
+  # ==========================================================================
+  # Parser scenarios
+  # ==========================================================================
+
+  - id: LS-P-1
+    title: Nested component instances not recognized
+    uca: UCA-P-1
+    type: inadequate-control-algorithm
+    scenario: >
+      A component contains multiple nested component instances (each with
+      their own core module). The parser's component traversal does not
+      recurse into nested instances, extracting only the outermost core
+      module. As a result, functions from inner instances are missing from
+      the fused output [UCA-P-1], and calls to those functions are
+      misrouted [H-3] or trap [H-1].
+    causal-factors:
+      - Parser implementation only handles single-instance components
+      - Component Model nesting depth not bounded in parser loop
+
+  - id: LS-P-2
+    title: Canonical ABI size computation ignores alignment padding
+    uca: UCA-P-5
+    type: inadequate-control-algorithm
+    scenario: >
+      A record type has fields {u8, string} where u8 occupies 1 byte and
+      the string pointer-pair requires 4-byte alignment. The
+      canonical_abi_element_size function sums field sizes without padding
+      (1 + 8 = 9) instead of computing the correctly padded size (4 + 8 =
+      12). The adapter generator uses the wrong element size [UCA-P-5],
+      computing incorrect copy lengths [H-4.1].
+    causal-factors:
+      - Alignment rounding not applied between fields
+      - Missing alignment test cases for heterogeneous record types
+
+  - id: LS-P-3
+    title: Malformed component accepted due to wasmparser configuration
+    uca: UCA-P-6
+    type: inadequate-process-model
+    scenario: >
+      The parser instantiates wasmparser::Validator with permissive
+      feature flags that accept proposals not yet standardized. A
+      component using a non-standard extension is accepted as valid. The
+      resolver and merger operate on structures they were not designed to
+      handle [UCA-P-6], producing incorrect index mappings [H-3].
+    causal-factors:
+      - Validator feature flags not locked to Component Model baseline
+      - No integration test with adversarial/malformed inputs
+    process-model-flaw: >
+      Parser believes the component is valid because the validator
+      accepted it, but the validator was configured too permissively.
+
+  # ==========================================================================
+  # Resolver scenarios
+  # ==========================================================================
+
+  - id: LS-R-1
+    title: Import matched to wrong export due to name normalization
+    uca: UCA-R-3
+    type: inadequate-control-algorithm
+    scenario: >
+      Component A imports "wasi:http/handler@0.2.0" and two components
+      (B and C) both export interfaces matching that name. The resolver
+      selects the first match found during iteration, which may be
+      component C instead of the intended component B. The caller invokes
+      the wrong implementation [UCA-R-3], producing different behavior
+      [H-1].
+    causal-factors:
+      - Resolver uses first-match strategy without disambiguation
+      - No error on ambiguous matches
+
+  - id: LS-R-2
+    title: CopyLayout misclassifies pointer-containing record as Bulk
+    uca: UCA-R-5
+    type: inadequate-process-model
+    scenario: >
+      A function parameter is list<record { name: string, value: u32 }>.
+      The resolver's type analysis inspects only the outer list type and
+      determines it can use Bulk copy (byte_multiplier). It does not
+      recurse into the record's fields to discover the string field
+      (pointer pair). The adapter performs a bulk memory.copy [UCA-R-5]
+      without inner pointer fixup [H-4.2]. The callee dereferences
+      string pointers that reference the source memory and reads garbage.
+    causal-factors:
+      - CopyLayout construction does not recurse into record fields
+      - Missing test case for records with pointer fields inside lists
+    process-model-flaw: >
+      Resolver believes the type is a flat byte buffer because it only
+      examined the outermost type structure.
+
+  - id: LS-R-3
+    title: Topological sort produces wrong order with diamond dependencies
+    uca: UCA-R-6
+    type: inadequate-control-algorithm
+    scenario: >
+      Four components form a diamond dependency: A depends on B and C,
+      both B and C depend on D. The topological sort visits B before D
+      because the adjacency list iteration order places B first. Component
+      B is instantiated before D [UCA-R-6], and B's imports from D bind
+      to absent exports [H-5], causing the fused module to trap [H-1].
+    causal-factors:
+      - Topological sort does not enforce total ordering among peers
+      - Adjacency list iteration depends on insertion order
+
+  - id: LS-R-4
+    title: Cycle detection fails on self-importing component
+    uca: UCA-R-7
+    type: inadequate-control-algorithm
+    scenario: >
+      A component imports an interface that it also exports (self-cycle).
+      The cycle detection logic checks for cycles of length >= 2 but not
+      self-loops. The resolver produces an order without error [UCA-R-7],
+      and the component's import binds to its own export before
+      initialization completes [H-5].
+    causal-factors:
+      - Cycle detection skips self-edges in the dependency graph
+      - No test for self-importing components
+
+  # ==========================================================================
+  # Merger scenarios
+  # ==========================================================================
+
+  - id: LS-M-1
+    title: Function base offset does not account for imported functions
+    uca: UCA-M-3
+    type: inadequate-control-algorithm
+    scenario: >
+      Component B has 3 imported functions and 5 defined functions.
+      The merger computes B's function base offset by counting only
+      defined functions from preceding components, ignoring imports.
+      The base offset is too small by the number of imports. All
+      function references in B are shifted incorrectly [UCA-M-3],
+      and calls in B target wrong functions [H-3.1].
+    causal-factors:
+      - Base offset calculation uses defined_function_count instead of
+        total_function_count (imports + defined)
+      - Imports and defined functions share the same index space in
+        WebAssembly but are counted separately in some data structures
+
+  - id: LS-M-2
+    title: Rewriter misses memory index in memory.copy instruction
+    uca: UCA-M-8
+    type: inadequate-control-algorithm
+    scenario: >
+      The rewriter handles memory.load, memory.store, memory.size, and
+      memory.grow by remapping the memory index. However, memory.copy
+      takes two memory indices (source and destination). The rewriter
+      only remaps the first argument, leaving the second as the original
+      per-component index [UCA-M-8]. In multi-memory mode, the copy
+      reads from or writes to the wrong memory [H-3.2, H-2].
+    causal-factors:
+      - memory.copy has unusual two-memory-index encoding
+      - Rewriter instruction visitor does not match on MemoryCopy variant
+
+  - id: LS-M-3
+    title: Element segment type indices remapped with wrong offset
+    uca: UCA-M-4
+    type: inadequate-control-algorithm
+    scenario: >
+      An element segment references function types for call_indirect.
+      The merger applies the function index offset instead of the type
+      index offset when rewriting the element segment's type index
+      [UCA-M-4]. At runtime, call_indirect compares against the wrong
+      type, causing spurious traps [H-3.4].
+    causal-factors:
+      - Element segment reindexing code uses func_base instead of type_base
+      - Element segments and function references share similar syntax
+
+  # ==========================================================================
+  # Adapter scenarios
+  # ==========================================================================
+
+  - id: LS-A-1
+    title: cabi_realloc function index not remapped after merge
+    uca: UCA-A-6
+    type: inadequate-process-model
+    scenario: >
+      The adapter generator records the cabi_realloc function index from
+      the resolver's pre-merge analysis. After merging, function indices
+      are rebased, but the adapter generator uses the stale pre-merge
+      index for cabi_realloc [UCA-A-6]. The adapter calls the wrong
+      function, which may not be an allocator, causing memory corruption
+      [H-4.3] or a trap.
+    causal-factors:
+      - Adapter generation uses resolver output directly without applying
+        index maps from the merger
+      - No assertion that cabi_realloc index is within valid range
+    process-model-flaw: >
+      Adapter generator believes the cabi_realloc index is still valid
+      because it was correct before merging.
+
+  - id: LS-A-2
+    title: Memory indices swapped in cross-memory copy
+    uca: UCA-A-4
+    type: inadequate-control-algorithm
+    scenario: >
+      The adapter copies argument data from caller (memory 0) to callee
+      (memory 1). The code emits memory.copy with src_mem=1 and
+      dst_mem=0 (swapped) [UCA-A-4]. The copy reads uninitialized data
+      from the callee's memory and writes it into the caller's memory,
+      corrupting both [H-2].
+    causal-factors:
+      - Source/destination parameter ordering inconsistency between
+        memory.copy wasm encoding and the adapter's internal API
+      - No runtime test that verifies data actually arrives in callee memory
+
+  - id: LS-A-3
+    title: Inner pointer fixup loop uses wrong element stride
+    uca: UCA-A-7
+    type: inadequate-control-algorithm
+    scenario: >
+      For list<record { name: string, age: u32 }>, the adapter fixup loop
+      must step through elements at stride = canonical_abi_element_size
+      (which includes alignment padding). The loop uses the unpadded sum
+      of field sizes as stride [UCA-A-7]. After the first element, the
+      loop reads pointer fields at incorrect offsets, corrupting the
+      callee's data [H-4.2].
+    causal-factors:
+      - Element stride computed from raw field sizes, not
+        canonical_abi_element_size
+      - canonical_abi_element_size returns correct value but is not used
+        in the fixup loop
+
+  - id: LS-A-4
+    title: Return value pointers read from caller memory instead of callee
+    uca: UCA-A-9
+    type: inadequate-process-model
+    scenario: >
+      A cross-component call returns a string via retptr convention. The
+      adapter reads the (ptr, len) pair from the caller's memory index
+      instead of the callee's memory index [UCA-A-9]. The values at those
+      addresses in the caller's memory are unrelated data, causing the
+      caller to interpret garbage as a string [H-2, H-4].
+    causal-factors:
+      - Return path uses caller_mem_idx variable instead of callee_mem_idx
+      - Asymmetry between argument lowering (caller->callee) and result
+        lifting (callee->caller) is error-prone
+    process-model-flaw: >
+      Adapter generator believes the return pointer is in the caller's
+      memory because the caller is the one who will use the result.
+
+  # ==========================================================================
+  # Control path scenarios (type b: improperly executed control actions)
+  # ==========================================================================
+
+  - id: LS-CP-1
+    title: Rewriter produces invalid wasm encoding
+    type: control-path
+    scenario: >
+      The rewriter correctly determines the new index for an instruction
+      but emits the LEB128 encoding incorrectly (e.g., uses signed
+      encoding where unsigned is required). The wasm binary is malformed,
+      causing validation failure or undefined behavior in the runtime.
+    hazards: [H-1]
+    causal-factors:
+      - LEB128 encoding logic bug
+      - No round-trip validation of rewritten instructions
+
+  - id: LS-CP-2
+    title: Hash map iteration order causes non-deterministic output
+    type: control-path
+    scenario: >
+      The merger or resolver iterates over a HashMap to emit exports or
+      resolve imports. HashMap iteration order is non-deterministic across
+      runs (Rust's default hasher uses randomization). The output module
+      contains sections in different orders [H-7], breaking
+      reproducibility [L-4].
+    hazards: [H-7]
+    causal-factors:
+      - Use of HashMap instead of BTreeMap or IndexMap for order-sensitive
+        data
+      - No byte-level reproducibility test

--- a/safety/stpa/losses.yaml
+++ b/safety/stpa/losses.yaml
@@ -1,0 +1,62 @@
+# STPA Step 1a: Losses
+#
+# A loss involves something of value to stakeholders.
+# Losses define what the analysis aims to prevent.
+#
+# Reference: STPA Handbook (Leveson & Thomas, 2018), Chapter 2
+#
+# System: Meld - Static WebAssembly Component Fusion Tool
+# System boundary: Meld accepts composed P2/P3 WebAssembly components and
+#   produces a single fused core module (or wrapped P2 component). The system
+#   boundary includes all transformation stages (parse, resolve, merge, adapt,
+#   encode) and excludes the runtime environment, upstream compilers, and
+#   downstream tools (Loom, Synth).
+#
+# Stakeholders:
+#   - Developers building safety-critical systems with WebAssembly
+#   - End-users of systems whose behavior depends on correct fusion
+#   - Certification authorities (ISO 26262, DO-178C, IEC 61508)
+#   - PulseEngine toolchain (Loom, Synth, Kiln, Sigil)
+
+losses:
+  - id: L-1
+    title: Loss of semantic correctness
+    description: >
+      The fused module exhibits different observable behavior than the original
+      composed components. Functions return wrong values, calls reach wrong
+      targets, or traps occur where none should.
+    stakeholders: [developers, end-users, certification-authorities]
+
+  - id: L-2
+    title: Loss of memory safety
+    description: >
+      The fused module permits cross-component memory corruption: one
+      component reads or writes another component's linear memory without
+      proper adapter mediation, or adapter-generated code computes incorrect
+      addresses.
+    stakeholders: [developers, end-users]
+
+  - id: L-3
+    title: Loss of supply chain integrity
+    description: >
+      Transformation provenance is lost, falsified, or unverifiable. The
+      output module cannot be traced back to its input components and the
+      exact tool version and configuration that produced it.
+    stakeholders: [developers, certification-authorities]
+
+  - id: L-4
+    title: Loss of build reproducibility
+    description: >
+      Identical inputs (same component binaries, same configuration) produce
+      different output binaries across builds, machines, or toolchain versions.
+      Non-determinism in the fusion pipeline breaks hermetic build guarantees.
+    stakeholders: [developers, certification-authorities]
+
+  - id: L-5
+    title: Loss of certification evidence
+    description: >
+      The transformation cannot be demonstrated correct to a certification
+      authority. Formal proofs do not cover the actual code paths exercised,
+      test coverage is insufficient, or traceability from requirements to
+      implementation is broken.
+    stakeholders: [certification-authorities, developers]

--- a/safety/stpa/system-constraints.yaml
+++ b/safety/stpa/system-constraints.yaml
@@ -1,0 +1,93 @@
+# STPA Step 1c: System-Level Constraints
+#
+# A system-level constraint specifies conditions or behaviors that need to
+# be satisfied to prevent hazards (and ultimately prevent losses).
+#
+# Format: <System> & <Condition to Enforce> & <Link to Hazards>
+# Each constraint is the inversion of a hazard.
+#
+# Reference: STPA Handbook (Leveson & Thomas, 2018), Chapter 2
+
+system-constraints:
+  - id: SC-1
+    title: Fused module must preserve observable behavior of the original composition
+    description: >
+      For every possible execution, the fused module must produce the same
+      observable behavior (return values, traps, side effects) as running
+      the original composed components through a conformant runtime.
+    hazards: [H-1]
+
+  - id: SC-2
+    title: Component memory isolation must be maintained in the fused module
+    description: >
+      In multi-memory mode, each component's code must only access its own
+      linear memory unless mediated by a correctly generated adapter. No
+      instruction in component A may reference component B's memory index.
+    hazards: [H-2]
+
+  - id: SC-3
+    title: All index references must be correctly remapped after merging
+    description: >
+      Every function, memory, table, global, and type index in the fused
+      module must point to the correct entity. Index remapping must account
+      for all reference sites: instructions, init expressions, element
+      segments, data segments, and export entries.
+    hazards: [H-3]
+
+  - id: SC-4
+    title: Generated adapters must correctly implement the Canonical ABI
+    description: >
+      Every adapter function must faithfully implement the lifting and
+      lowering operations specified by the Component Model Canonical ABI.
+      This includes correct allocation, copy sizes, string transcoding,
+      list element sizing, and recursive pointer fixup.
+    hazards: [H-4]
+    spec-baseline: "Component Model commit deb0b0a"
+
+  - id: SC-5
+    title: Dependency resolution must produce a valid instantiation order
+    description: >
+      The resolver must compute a topological order such that every
+      component is instantiated after all components it imports from. If
+      a cycle exists, it must be detected and reported as an error (or
+      handled by the cycle-tolerant sort with correct semantics).
+    hazards: [H-5]
+
+  - id: SC-6
+    title: Transformation provenance must be complete and accurate
+    description: >
+      When attestation is enabled, the output module's custom section must
+      contain: cryptographic hashes of all input components, meld version,
+      all configuration parameters, and a timestamp. The attestation must
+      be verifiable by Sigil.
+    hazards: [H-6]
+
+  - id: SC-7
+    title: Fusion must be deterministic for identical inputs
+    description: >
+      Given the same input component bytes and the same FuserConfig, meld
+      must produce byte-identical output. No internal data structure
+      iteration order, timestamp, or environment-dependent value may
+      influence the output bytes.
+    hazards: [H-7]
+
+  # Mitigation constraints (what to do if a hazard occurs)
+  - id: SC-8
+    title: >
+      If index remapping cannot be verified, fusion must fail with a
+      diagnostic error
+    description: >
+      If the merger detects an index that cannot be remapped (e.g., an
+      out-of-bounds reference in the input component), fusion must abort
+      with a clear error message identifying the component, section, and
+      index. Partial or best-effort output must not be produced.
+    hazards: [H-3, H-1]
+
+  - id: SC-9
+    title: >
+      If an import cannot be resolved, fusion must fail with a diagnostic
+      error
+    description: >
+      Unresolved imports must be reported as errors. Meld must not silently
+      drop imports or substitute default implementations.
+    hazards: [H-1, H-5]

--- a/safety/stpa/ucas.yaml
+++ b/safety/stpa/ucas.yaml
@@ -1,0 +1,435 @@
+# STPA Step 3: Unsafe Control Actions (UCAs)
+#
+# An Unsafe Control Action is a control action that, in a particular context
+# and worst-case environment, will lead to a hazard.
+#
+# Four types (provably complete):
+#   1. Not providing the control action leads to a hazard
+#   2. Providing the control action leads to a hazard
+#   3. Providing too early, too late, or in the wrong order
+#   4. Control action lasts too long or is stopped too soon
+#
+# UCA format: <Source> <Type> <Control Action> <Context> [<Hazards>]
+#
+# Reference: STPA Handbook (Leveson & Thomas, 2018), Chapter 2
+
+# ============================================================================
+# Parser UCAs
+# ============================================================================
+parser-ucas:
+  control-action: "Parse and extract component structure"
+  controller: CTRL-PARSER
+
+  not-providing:
+    - id: UCA-P-1
+      description: >
+        Parser does not extract a core module that exists in the component
+        when the component contains multiple core modules
+      context: Component contains multiple core modules (nested instances)
+      hazards: [H-1, H-3]
+      rationale: >
+        Missing a core module means its functions are absent from the fused
+        output. Calls targeting those functions will fail or be misrouted.
+
+    - id: UCA-P-2
+      description: >
+        Parser does not extract an import or export entry when the component
+        declares cross-instance imports/exports
+      context: Component has imports that should be resolved by another component
+      hazards: [H-1, H-5]
+      rationale: >
+        Missing imports/exports prevents the resolver from matching them,
+        leaving calls unresolved or incorrectly resolved.
+
+    - id: UCA-P-3
+      description: >
+        Parser does not compute Canonical ABI element size for a type that
+        contains inner pointers (e.g., list<string>, list<list<u8>>)
+      context: Component has function signatures with compound list types
+      hazards: [H-4, H-4.1, H-4.2]
+      rationale: >
+        Without correct element size, the adapter generator cannot compute
+        copy lengths or determine whether inner pointer fixup is needed.
+
+  providing:
+    - id: UCA-P-4
+      description: >
+        Parser extracts an incorrect type signature for a function
+      context: >
+        Component uses type indices that reference a recursive type group
+        or alias chain
+      hazards: [H-1, H-4]
+      rationale: >
+        Wrong type signature causes the adapter to generate incorrect
+        lifting/lowering code or causes call_indirect type mismatch traps.
+
+    - id: UCA-P-5
+      description: >
+        Parser computes incorrect canonical_abi_element_size for a record
+        type with alignment padding
+      context: Record type has fields with different alignments
+      hazards: [H-4, H-4.1]
+      rationale: >
+        Incorrect element size causes memory.copy to copy too few or too
+        many bytes, corrupting adjacent data.
+
+    - id: UCA-P-6
+      description: >
+        Parser reports a component as valid when it contains malformed
+        sections
+      context: Input bytes are a corrupted or adversarial component binary
+      hazards: [H-1, H-3]
+      rationale: >
+        Accepting malformed input propagates errors through the entire
+        pipeline. Downstream stages operate on inconsistent data.
+
+  too-early-too-late:
+    - id: UCA-P-7
+      description: >
+        Parser processes sections out of the order specified by the
+        WebAssembly binary format, causing type indices to be resolved
+        before the type section is fully parsed
+      context: Component binary has standard section ordering
+      hazards: [H-3, H-3.4]
+      rationale: >
+        Out-of-order parsing could assign wrong type indices to functions,
+        propagating through merge and adapter generation.
+
+  stopped-too-soon:
+    - id: UCA-P-8
+      description: >
+        Parser stops processing a component before reaching the code
+        section or data section
+      context: Component binary is well-formed but large
+      hazards: [H-1, H-3]
+      rationale: >
+        Missing code bodies or data segments means the fused module lacks
+        function implementations or initialized memory.
+
+# ============================================================================
+# Resolver UCAs
+# ============================================================================
+resolver-ucas:
+  control-action: "Resolve dependencies and compute instantiation order"
+  controller: CTRL-RESOLVER
+
+  not-providing:
+    - id: UCA-R-1
+      description: >
+        Resolver does not match an import to its corresponding export when
+        a valid match exists
+      context: >
+        Two components where component A imports an interface that
+        component B exports, with matching names and types
+      hazards: [H-1, H-5]
+      rationale: >
+        Unresolved import means the call site has no target. The fused
+        module will trap or reference a nonexistent function.
+
+    - id: UCA-R-2
+      description: >
+        Resolver does not produce a CopyLayout for a cross-component call
+        that passes pointer-containing arguments
+      context: >
+        Cross-component function signature includes string, list, or record
+        with inner pointers
+      hazards: [H-4, H-4.2]
+      rationale: >
+        Without CopyLayout, the adapter generator cannot determine whether
+        bulk copy or element-wise copy with pointer fixup is needed.
+
+  providing:
+    - id: UCA-R-3
+      description: >
+        Resolver matches an import to the wrong export (name collision
+        across components)
+      context: >
+        Multiple components export functions with the same interface name
+        but different semantics
+      hazards: [H-1]
+      rationale: >
+        Binding to the wrong export causes the caller to invoke a function
+        with different behavior than intended.
+
+    - id: UCA-R-4
+      description: >
+        Resolver computes CopyLayout with incorrect byte_multiplier for
+        a list type
+      context: >
+        List element type has alignment padding (e.g., record with mixed
+        field sizes)
+      hazards: [H-4, H-4.1]
+      rationale: >
+        Wrong byte_multiplier causes the adapter to allocate and copy the
+        wrong number of bytes for the list payload.
+
+    - id: UCA-R-5
+      description: >
+        Resolver classifies a pointer-containing type as Bulk copy when
+        it requires Elements copy with inner pointer fixup
+      context: >
+        List element type contains string or nested list fields
+      hazards: [H-4, H-4.2]
+      rationale: >
+        Bulk copy without pointer fixup leaves inner pointers referencing
+        the source memory, causing use-after-copy corruption.
+
+  too-early-too-late:
+    - id: UCA-R-6
+      description: >
+        Resolver produces an instantiation order where a component appears
+        before a component it depends on
+      context: >
+        Three or more components with a transitive dependency chain
+      hazards: [H-5, H-1]
+      rationale: >
+        Wrong order means exports are not yet available when imports are
+        bound, potentially binding to uninitialized or absent functions.
+
+    - id: UCA-R-7
+      description: >
+        Resolver does not detect a dependency cycle and produces an
+        arbitrary order
+      context: Components have circular imports
+      hazards: [H-5, H-1]
+      rationale: >
+        Silent cycle non-detection can produce an order where some
+        components observe uninitialized state.
+
+  stopped-too-soon: []
+    # N/A: Resolution is a batch computation, not a continuous process
+
+# ============================================================================
+# Merger UCAs
+# ============================================================================
+merger-ucas:
+  control-action: "Merge index spaces and rewrite instructions"
+  controller: CTRL-MERGER
+
+  not-providing:
+    - id: UCA-M-1
+      description: >
+        Merger does not include a function from a component in the merged
+        function section
+      context: Component has internal (non-exported, non-imported) functions
+      hazards: [H-1, H-3]
+      rationale: >
+        Missing function causes call instructions targeting it to reference
+        a wrong or nonexistent function in the merged module.
+
+    - id: UCA-M-2
+      description: >
+        Merger does not rewrite a memory instruction (load/store) to use
+        the rebased memory index
+      context: Multi-memory mode with more than one component
+      hazards: [H-2, H-3.2]
+      rationale: >
+        Unrewritten memory instruction accesses the wrong component's
+        memory, violating isolation.
+
+  providing:
+    - id: UCA-M-3
+      description: >
+        Merger computes incorrect function base offset for a component
+      context: >
+        Three or more components where the second component has imported
+        functions that affect the base offset calculation
+      hazards: [H-3, H-3.1]
+      rationale: >
+        Wrong base offset shifts all function indices for that component,
+        misdirecting every call.
+
+    - id: UCA-M-4
+      description: >
+        Merger rewrites a call_indirect type index using function index
+        offset instead of type index offset
+      context: Component uses indirect calls via function tables
+      hazards: [H-3, H-3.4]
+      rationale: >
+        Wrong type index causes call_indirect to trap with type mismatch
+        or, worse, call a function with a compatible but wrong signature.
+
+    - id: UCA-M-5
+      description: >
+        Merger rebases data segment offset using function base offset
+        instead of memory base offset
+      context: >
+        Component has active data segments with i32.const offset
+        expressions
+      hazards: [H-2, H-1]
+      rationale: >
+        Data written to wrong address in memory, corrupting initialized
+        state.
+
+    - id: UCA-M-6
+      description: >
+        Merger does not remap global.get/global.set indices in init
+        expressions of data or element segments
+      context: >
+        Component uses global.get in data segment offset expression
+      hazards: [H-3, H-3.3]
+      rationale: >
+        Unrewritten global reference reads from the wrong global, placing
+        data at the wrong memory offset.
+
+  too-early-too-late:
+    - id: UCA-M-7
+      description: >
+        Merger processes components in a different order than the resolver's
+        topological sort
+      context: >
+        Resolver produces a specific instantiation order that affects base
+        offset calculation
+      hazards: [H-3, H-5]
+      rationale: >
+        Processing in wrong order produces different base offsets than what
+        the adapter generator expects, causing index mismatches.
+
+  stopped-too-soon:
+    - id: UCA-M-8
+      description: >
+        Rewriter does not visit all instruction types that reference
+        indices (e.g., misses memory.copy's two memory arguments)
+      context: >
+        Component uses bulk memory instructions (memory.copy, memory.init,
+        memory.fill)
+      hazards: [H-2, H-3.2]
+      rationale: >
+        Unrewritten memory arguments cause bulk operations to read/write
+        the wrong memory.
+
+# ============================================================================
+# Adapter Generator UCAs
+# ============================================================================
+adapter-ucas:
+  control-action: "Generate Canonical ABI adapter trampolines"
+  controller: CTRL-ADAPTER
+
+  not-providing:
+    - id: UCA-A-1
+      description: >
+        Adapter generator does not produce an adapter for a cross-component
+        call that passes pointer arguments in multi-memory mode
+      context: >
+        Cross-component call has string or list parameters with source and
+        destination in different memories
+      hazards: [H-2, H-4]
+      rationale: >
+        Without adapter, the callee receives pointers into the caller's
+        memory which it cannot access, causing traps or silent corruption.
+
+    - id: UCA-A-2
+      description: >
+        Adapter does not emit cabi_realloc call to allocate destination
+        buffer before memory.copy
+      context: Callee's memory has no pre-allocated space for the argument
+      hazards: [H-2, H-4, H-4.3]
+      rationale: >
+        Copying to unallocated memory corrupts the callee's heap or
+        overwrites existing data.
+
+    - id: UCA-A-3
+      description: >
+        Adapter does not emit inner pointer fixup loop for list elements
+        containing pointers
+      context: >
+        List<string> or list<record-with-strings> argument in
+        cross-component call
+      hazards: [H-4, H-4.2]
+      rationale: >
+        Copied list elements retain pointers into source memory. Callee
+        dereferences them and reads garbage or traps.
+
+  providing:
+    - id: UCA-A-4
+      description: >
+        Adapter emits memory.copy with source and destination memory
+        indices swapped
+      context: >
+        Multi-memory mode, adapter copying argument data from caller to
+        callee
+      hazards: [H-2, H-4]
+      rationale: >
+        Copy goes in wrong direction: either overwrites caller's memory
+        with callee's data, or reads from callee's (uninitialized) memory.
+
+    - id: UCA-A-5
+      description: >
+        Adapter computes copy length as element_count * wrong_element_size
+      context: >
+        List type where canonical_abi_element_size differs from the naive
+        field-size sum due to alignment padding
+      hazards: [H-4, H-4.1]
+      rationale: >
+        Too-small copy truncates elements. Too-large copy reads past the
+        source buffer or wastes destination memory.
+
+    - id: UCA-A-6
+      description: >
+        Adapter calls cabi_realloc with the wrong function index (targets
+        the source component's allocator instead of the destination's)
+      context: >
+        Multi-memory mode with two or more components each exporting
+        cabi_realloc
+      hazards: [H-2, H-4, H-4.3]
+      rationale: >
+        Allocation happens in wrong memory. Subsequent memory.copy writes
+        to an address that doesn't exist in the intended memory.
+
+    - id: UCA-A-7
+      description: >
+        Adapter computes incorrect inner pointer offset within a record
+        element due to alignment miscalculation
+      context: >
+        Record type with fields of different alignments (e.g., u8 followed
+        by pointer-pair for a string)
+      hazards: [H-4, H-4.2]
+      rationale: >
+        Fixup loop reads/writes pointer values at wrong offsets within
+        each element, corrupting non-pointer fields or missing pointer
+        fields entirely.
+
+    - id: UCA-A-8
+      description: >
+        Adapter emits string transcoding that does not handle surrogate
+        pairs correctly in UTF-16 to UTF-8 conversion
+      context: >
+        String argument contains characters outside the Basic Multilingual
+        Plane (codepoints > U+FFFF)
+      hazards: [H-4, H-4.4]
+      rationale: >
+        Surrogate pairs decoded incorrectly produce invalid UTF-8 or wrong
+        characters.
+
+    - id: UCA-A-9
+      description: >
+        Adapter emits return value lifting that reads from the wrong memory
+      context: >
+        Cross-component call returns a string or list (retptr convention)
+      hazards: [H-2, H-4]
+      rationale: >
+        Return value adapter reads result pointer from wrong memory,
+        returning garbage to the caller.
+
+  too-early-too-late:
+    - id: UCA-A-10
+      description: >
+        Adapter emits memory.copy before cabi_realloc returns (instructions
+        in wrong order)
+      context: Any cross-component call with pointer arguments
+      hazards: [H-4]
+      rationale: >
+        Copying before allocation means destination pointer is undefined.
+        Data is written to address 0 or whatever was on the stack.
+
+  stopped-too-soon:
+    - id: UCA-A-11
+      description: >
+        Recursive inner pointer fixup loop terminates before processing
+        all elements in the list
+      context: >
+        List with many elements where fixup loop counter is incorrect
+      hazards: [H-4, H-4.2]
+      rationale: >
+        Later elements retain stale source-memory pointers. Callee
+        dereferences them and reads wrong data.


### PR DESCRIPTION
## Summary

- Complete STPA for the meld fusion pipeline: 5 losses, 7 hazards, 9 system constraints, 30 UCAs, 14 loss scenarios, 20 safety requirements with full traceability
- Add 30 unit tests derived from STPA loss scenarios covering parser (SR-3), resolver (SR-5/6/7), rewriter (SR-9), segments (SR-10), lib (SR-19/20)
- Fix non-deterministic topological sort in resolver — adjacency list sorting in Kahn's algorithm (LS-CP-2)
- Fix wit_bindgen_runtime test guards to use per-fixture file checks

## Test plan

- [x] All 100 unit tests pass
- [x] All 12 integration tests pass (skip gracefully when fixtures absent)
- [x] Non-determinism bug verified fixed by stability test (`test_resolver_preserves_order_stability`)
- [x] Traceability matrix updated with new test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)