### PR TITLE
fix: propagate resource type aliases in resource import map

### DIFF
--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -838,17 +838,17 @@ fn build_resource_type_to_import(
             let alias_id = idx as u32;
             let target_id = *target;
             for kind in &["[resource-rep]", "[resource-new]"] {
-                if known_resource_types.contains(&target_id) && !map.contains_key(&(alias_id, kind))
+                if known_resource_types.contains(&target_id)
+                    && !map.contains_key(&(alias_id, kind))
+                    && let Some(entry) = map.get(&(target_id, kind)).cloned()
                 {
-                    if let Some(entry) = map.get(&(target_id, kind)).cloned() {
-                        map.insert((alias_id, kind), entry);
-                    }
+                    map.insert((alias_id, kind), entry);
                 }
-                if known_resource_types.contains(&alias_id) && !map.contains_key(&(target_id, kind))
+                if known_resource_types.contains(&alias_id)
+                    && !map.contains_key(&(target_id, kind))
+                    && let Some(entry) = map.get(&(alias_id, kind)).cloned()
                 {
-                    if let Some(entry) = map.get(&(alias_id, kind)).cloned() {
-                        map.insert((target_id, kind), entry);
-                    }
+                    map.insert((target_id, kind), entry);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds Step 6 to `build_resource_type_to_import` that propagates resource map entries through `ExportAlias` type chains
- When a function's param type references `Borrow(24)` but the canonical `ResourceRep` uses type 25 (where 24 is ExportAlias(25)), the map now includes both type IDs
- Partially fixes resource detection in 3-component chains (resource_floats still needs fallback path work for bare exports)

## Test plan
- [x] 73 tests pass, 0 failures
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)