### PR TITLE
fix: resolve imported resource types in resource position lookup

### DIFF
--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -870,9 +870,25 @@ fn resolve_resource_positions(
 ) -> Vec<ResolvedResourceOp> {
     let mut resolved = Vec::new();
     for pos in positions {
-        if let Some((module_name, field_name)) =
-            resource_map.get(&(pos.resource_type_id, field_prefix))
-        {
+        // Try exact match first
+        let entry = resource_map
+            .get(&(pos.resource_type_id, field_prefix))
+            .or_else(|| {
+                // Fallback: the resource type ID from the function signature may differ
+                // from the canonical entry's type ID (e.g., imported type 24 vs defined
+                // type 25). If there's exactly one resource with this prefix, use it.
+                let candidates: Vec<_> = resource_map
+                    .iter()
+                    .filter(|((_, k), _)| *k == field_prefix)
+                    .map(|(_, v)| v)
+                    .collect();
+                if candidates.len() == 1 {
+                    Some(candidates[0])
+                } else {
+                    None
+                }
+            });
+        if let Some((module_name, field_name)) = entry {
             resolved.push(ResolvedResourceOp {
                 flat_idx: pos.flat_idx,
                 byte_offset: pos.byte_offset,

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -643,7 +643,6 @@ runtime_test!(test_runtime_wit_bindgen_resource_alias, "resource_alias");
 
 // Resource fixtures — known failures (graceful degradation)
 // resource_aggregates: own<T> handle leak (handle != 0 assertion)
-// resource_floats: 3-component resource chain — wrong resource table for [resource-rep]
 // resource_borrow_in_record: borrow<T> inside record not detected as flat param
 // resource_with_lists: data corruption in resource+list combination
 // ownership: resource ownership transfer issue
@@ -651,6 +650,8 @@ fuse_only_test!(
     test_fuse_wit_bindgen_resource_aggregates,
     "resource_aggregates"
 );
+// resource_floats: 3-component chain — adapter uses callee's [resource-rep] but handle
+// is in caller's resource table (needs caller-side resource map lookup)
 fuse_only_test!(test_fuse_wit_bindgen_resource_floats, "resource_floats");
 fuse_only_test!(
     test_fuse_wit_bindgen_resource_borrow_in_record,


### PR DESCRIPTION
## Summary
- `resolve_resource_positions` now falls back to single-candidate matching when exact resource type ID lookup fails
- Handles the common case where an imported resource type (e.g., `Import(15)` at type 24) has a different type ID than the canonical `ResourceRep`/`ResourceNew` entry (type 25, `Defined`)
- Documents the 3-component resource table routing issue for `resource_floats`

## Context
The `resource_floats` fixture progressed through 3 error states:
1. "misaligned pointer" (no resource.rep called) → fixed by PR #30 fallback path
2. "unknown handle index 2" (resource.rep called, type mismatch) → fixed by PR #31 alias propagation  
3. "handle used with wrong type" (resource.rep called with correct type, wrong table) → documented, needs caller-side resource lookup

## Test plan
- [x] 73 tests pass, 0 failures
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)