### PR TITLE
feat: bump wit-bindgen to 0.54.0 for P3 sync-only support

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  WIT_BINDGEN_VERSION: "0.52.0"
+  WIT_BINDGEN_VERSION: "0.54.0"
 
 jobs:
   update-fixtures:


### PR DESCRIPTION
P3 sync-only components work with zero code changes. Bump fixture generation to 0.54.0.