### PR TITLE
fix: use resource_definer for graph override instead of is_reexporter

### DIFF
--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -2113,8 +2113,12 @@ impl Resolver {
                                                         .unwrap_or(&op.import_field);
                                                     if rg.defines_resource(*to_comp, iface, rn) {
                                                         op.callee_defines_resource = true;
-                                                    } else if rg.is_reexporter(*to_comp, iface, rn)
+                                                    } else if rg
+                                                        .resource_definer(iface, rn)
+                                                        .is_some()
                                                     {
+                                                        // Graph knows about this resource and says
+                                                        // this component is NOT the definer.
                                                         op.callee_defines_resource = false;
                                                     }
                                                 }
@@ -2125,7 +2129,9 @@ impl Resolver {
                                                         .unwrap_or(&op.import_field);
                                                     if rg.defines_resource(*to_comp, iface, rn) {
                                                         op.callee_defines_resource = true;
-                                                    } else if rg.is_reexporter(*to_comp, iface, rn)
+                                                    } else if rg
+                                                        .resource_definer(iface, rn)
+                                                        .is_some()
                                                     {
                                                         op.callee_defines_resource = false;
                                                     }
@@ -2324,7 +2330,7 @@ impl Resolver {
                                                 .unwrap_or(&op.import_field);
                                             if rg.defines_resource(*to_comp, iface, rn) {
                                                 op.callee_defines_resource = true;
-                                            } else if rg.is_reexporter(*to_comp, iface, rn) {
+                                            } else if rg.resource_definer(iface, rn).is_some() {
                                                 op.callee_defines_resource = false;
                                             }
                                         }
@@ -2335,7 +2341,7 @@ impl Resolver {
                                                 .unwrap_or(&op.import_field);
                                             if rg.defines_resource(*to_comp, iface, rn) {
                                                 op.callee_defines_resource = true;
-                                            } else if rg.is_reexporter(*to_comp, iface, rn) {
+                                            } else if rg.resource_definer(iface, rn).is_some() {
                                                 op.callee_defines_resource = false;
                                             }
                                         }


### PR DESCRIPTION
## Summary

Replace `is_reexporter` (broken for cross-name re-exports like resource_floats) with
`!defines_resource && resource_definer.is_some()` — if the graph knows about this
resource and says the callee is NOT the definer, force `callee_defines_resource=false`.

This is infrastructure for fixing resource_floats (the adapter wiring still needs work).
No regressions — xcrate and all existing tests pass.

## Test plan

- [x] All 78 tests pass
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)