### PR TITLE
fix: per-component resource types — all 45 fixtures pass at runtime

### DIFF
--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -1039,11 +1039,11 @@ fn assemble_component(
     let mut component_type_idx = count_replayed_types(source);
     let mut lowered_func_indices: Vec<u32> = Vec::new();
 
-    // Cache: resource_name → component type index.
-    // ALL interfaces sharing the same resource name get the same type.
-    // This is correct because different interface names (imports, exports,
-    // test:X/test) may reference the same underlying resource type.
-    let mut local_resource_types: std::collections::HashMap<String, u32> =
+    // Cache: (interface_name, resource_name) → component type index.
+    // Each interface gets its own resource type, giving per-component handle
+    // tables. This is required for 3-component chains where an intermediary
+    // re-exports a resource — the importer and exporter need separate tables.
+    let mut local_resource_types: std::collections::HashMap<(String, String), u32> =
         std::collections::HashMap::new();
 
     for (i, resolution) in import_resolutions.iter().enumerate() {
@@ -1125,12 +1125,10 @@ fn assemble_component(
                 resource_name,
                 interface_name,
             } => {
-                // Get or create the resource type for this (component, interface, resource).
-                // [export]-prefixed imports (Category A) get per-component types using
-                // memory index as component identity. Category B imports (bare module drops)
-                // reuse an existing type for the same (interface, resource) — they find
-                // the first matching entry regardless of memory index.
-                let res_type_key = resource_name.clone();
+                // Get or create the resource type for this (interface, resource) pair.
+                // Each interface gets its own resource type, so e.g. imports/float
+                // and exports/float have separate handle tables.
+                let res_type_key = (interface_name.clone(), resource_name.clone());
                 let res_type_idx = if let Some(&existing) = local_resource_types.get(&res_type_key)
                 {
                     existing

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -641,29 +641,25 @@ runtime_test!(
 );
 runtime_test!(test_runtime_wit_bindgen_resource_alias, "resource_alias");
 
-// Resource fixtures — known failures (graceful degradation)
-// resource_borrow_in_record: borrow<T> inside record not detected as flat param
-// resource_with_lists: data corruption in resource+list combination
-// ownership: resource ownership transfer issue
+// Resource fixtures — all promoted to runtime tests with per-component resource types
 runtime_test!(
     test_runtime_wit_bindgen_resource_aggregates,
     "resource_aggregates"
 );
-fuse_only_test!(test_fuse_wit_bindgen_resource_floats, "resource_floats");
+runtime_test!(test_runtime_wit_bindgen_resource_floats, "resource_floats");
 runtime_test!(
     test_runtime_wit_bindgen_resource_borrow_in_record,
     "resource_borrow_in_record"
 );
-fuse_only_test!(
-    test_fuse_wit_bindgen_resource_with_lists,
+runtime_test!(
+    test_runtime_wit_bindgen_resource_with_lists,
     "resource_with_lists"
 );
 runtime_test!(test_runtime_wit_bindgen_ownership, "ownership");
 runtime_test!(test_runtime_wit_bindgen_xcrate, "xcrate");
 
-// resource-import-and-export: core fusion works, P2 wrapping fails on toplevel-import
-fuse_only_test!(
-    test_fuse_wit_bindgen_resource_import_and_export,
+runtime_test!(
+    test_runtime_wit_bindgen_resource_import_and_export,
     "resource-import-and-export"
 );
 


### PR DESCRIPTION
## Summary

Change `local_resource_types` key from `resource_name` to `(interface_name, resource_name)`,
giving each interface its own resource type and handle table in the P2 wrapper.

This fixes the fundamental issue with 3-component resource chains: a re-exporting
intermediate needs separate handle spaces from the definer and consumer. The previous
shared-type optimization caused wit-bindgen's internal slabs to go out of sync.

**Promotes 3 fixtures from fuse-only to runtime: resource_floats, resource_with_lists,
resource-import-and-export. All 45 wit-bindgen fixtures now pass at runtime (45/45).**

## Test plan

- [x] All 279 tests pass (164 unit + 73 wit-bindgen + 5 osxcar + others)
- [x] Zero regressions
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)