### PR TITLE
fix: reject multiply-instantiated modules in resolver

### DIFF
--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -1581,6 +1581,20 @@ impl Resolver {
             }
         }
 
+        // Reject multiply-instantiated modules before building the
+        // module→instance map, which would silently drop duplicates.
+        {
+            let mut seen_modules = HashSet::new();
+            for info in instantiate_infos.values() {
+                if !seen_modules.insert(info.module_idx) {
+                    return Err(Error::DuplicateModuleInstantiation {
+                        component_idx: comp_idx,
+                        module_idx: info.module_idx,
+                    });
+                }
+            }
+        }
+
         // Step 2: Build module → instance map (which instance instantiated which module).
         let mut module_to_instance: HashMap<u32, u32> = HashMap::new();
         for (inst_idx, info) in &instantiate_infos {
@@ -3773,5 +3787,70 @@ mod tests {
             0,
             "SR-17: scalar-only results should produce zero copy layouts"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Multiply-instantiated module rejection (issue #24)
+    // ---------------------------------------------------------------
+
+    use crate::parser::{ComponentInstance, InstanceKind};
+
+    #[test]
+    fn test_multiply_instantiated_module_rejected() {
+        let mut comp = empty_parsed_component();
+        comp.instances = vec![
+            ComponentInstance {
+                index: 0,
+                kind: InstanceKind::Instantiate {
+                    module_idx: 0,
+                    args: vec![],
+                },
+            },
+            ComponentInstance {
+                index: 1,
+                kind: InstanceKind::Instantiate {
+                    module_idx: 0, // duplicate — same module
+                    args: vec![],
+                },
+            },
+        ];
+
+        let resolver = Resolver::new();
+        let result = resolver.resolve(&[comp]);
+        assert!(
+            result.is_err(),
+            "should reject multiply-instantiated module"
+        );
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("instantiates core module 0 more than once"),
+            "error should identify the duplicate module: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_distinct_module_instantiations_accepted() {
+        let mut comp = empty_parsed_component();
+        comp.instances = vec![
+            ComponentInstance {
+                index: 0,
+                kind: InstanceKind::Instantiate {
+                    module_idx: 0,
+                    args: vec![],
+                },
+            },
+            ComponentInstance {
+                index: 1,
+                kind: InstanceKind::Instantiate {
+                    module_idx: 1,
+                    args: vec![],
+                },
+            },
+        ];
+
+        let resolver = Resolver::new();
+        let result = resolver.resolve(&[comp]);
+        assert!(result.is_ok(), "distinct modules should be accepted");
     }
 }


### PR DESCRIPTION
## Summary

- Add early detection of multiply-instantiated modules in the resolver's `resolve_via_instances`, before the `module_to_instance` HashMap is built (which silently drops duplicates via last-write-wins)
- Defense-in-depth: the merger already has `check_no_duplicate_instantiations`, but the resolver runs first and would produce a corrupted dependency graph
- Reuses the existing `DuplicateModuleInstantiation` error variant for consistent error messages

Closes #24

## Test plan

- [x] `test_multiply_instantiated_module_rejected` — verifies duplicate module instantiation is caught with correct error message
- [x] `test_distinct_module_instantiations_accepted` — verifies distinct modules pass validation
- [x] All 166 unit tests pass (4 pre-existing failures on main unrelated to this change)
- [x] Existing merger tests (`test_duplicate_module_instantiation_rejected`, `test_single_instantiation_accepted`, `test_no_instances_accepted`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)