### PR TITLE
fix: prevent subtraction overflow in attestation size_reduction calc

### DIFF
--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -772,7 +772,7 @@ impl Fuser {
             serde_json::json!(stats.imports_resolved),
         );
         let size_reduction = if stats.input_size > 0 {
-            ((stats.input_size - stats.output_size) as f64 / stats.input_size as f64) * 100.0
+            ((stats.input_size as f64 - stats.output_size as f64) / stats.input_size as f64) * 100.0
         } else {
             0.0
         };


### PR DESCRIPTION
## Summary

- Fix panic in `build_wsc_attestation` at `lib.rs:775` when fused output is larger than input
- `input_size - output_size` overflows on unsigned integers (usize); convert to f64 before subtracting
- This was the root cause of the Coverage CI failure on main

## Test plan

- [x] `test_address_rebasing_end_to_end` now passes (was panicking with subtraction overflow)
- [x] Full test suite: 276 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)