### PR TITLE
fix: set caller_already_converted for re-exporter adapter chains

### DIFF
--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -1174,6 +1174,20 @@ impl Resolver {
             graph.reexporter_components = reexporter_set.into_iter().collect();
         }
 
+        // For adapters FROM a re-exporter TO the resource definer: the
+        // re-exporter's generated code already extracts rep via its handle
+        // table (ht_rep). The downstream adapter must not call resource.rep
+        // again, or it would double-extract.
+        for site in &mut graph.adapter_sites {
+            if graph.reexporter_components.contains(&site.from_component) {
+                for op in &mut site.requirements.resource_params {
+                    if !op.is_owned && op.callee_defines_resource {
+                        op.caller_already_converted = true;
+                    }
+                }
+            }
+        }
+
         // Synthesize missing resource imports.
         //
         // The component model's `canon lift` handles `resource.rep` and


### PR DESCRIPTION
## Summary

- For adapters FROM a re-exporter TO the resource definer, set `caller_already_converted=true` on borrow params
- The re-exporter's handle table code (ht_rep) already extracts rep from the handle — the downstream adapter must not call `resource.rep` again
- Without this, 3-component resource chains would double-extract the rep, producing corrupt handles

Part of #69, closes #73. Task 6 (#74, resource graph propagation) is already implemented on main.

## Test plan

- [x] 276 tests pass, 0 failures
- [x] No regressions — only affects adapter sites where from_component is a re-exporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)