### PR TITLE
safety: STPA analysis of resource type dedup in 3-component chains

### DIFF
--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -1051,11 +1051,14 @@ fn assemble_component(
     let mut component_type_idx = count_replayed_types(source);
     let mut lowered_func_indices: Vec<u32> = Vec::new();
 
-    // Cache: (interface_name, resource_name) → component type index.
-    // Each interface gets its own resource type, giving per-component handle
-    // tables. This is required for 3-component chains where an intermediary
-    // re-exports a resource — the importer and exporter need separate tables.
-    let mut local_resource_types: std::collections::HashMap<(String, String), u32> =
+    // Cache: (component_idx, interface_name, resource_name) → component type index.
+    //
+    // When re-exporter handle tables are active, each component needs its own
+    // resource type to avoid wasmtime's handle type validation rejecting handles
+    // that cross component boundaries (H-11.7, UCA-A-21). Without handle tables
+    // (2-component chains), all components share one type per (interface, resource).
+    let has_handle_tables = !merged.handle_tables.is_empty();
+    let mut local_resource_types: std::collections::HashMap<(Option<usize>, String, String), u32> =
         std::collections::HashMap::new();
 
     for (i, resolution) in import_resolutions.iter().enumerate() {
@@ -1162,8 +1165,15 @@ fn assemble_component(
                     lowered_func_indices.push(core_func_idx);
                     core_func_idx += 1;
                 } else {
-                    // Standard path: define resource type and use canon resource ops
-                    let res_type_key = (interface_name.clone(), resource_name.clone());
+                    // Standard path: define resource type and use canon resource ops.
+                    // Per-component keying when handle tables are active prevents
+                    // type reuse across components that need separate handle tables.
+                    let comp_key = if has_handle_tables {
+                        *component_idx
+                    } else {
+                        None
+                    };
+                    let res_type_key = (comp_key, interface_name.clone(), resource_name.clone());
                     let res_type_idx =
                         if let Some(&existing) = local_resource_types.get(&res_type_key) {
                             existing

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -671,13 +671,14 @@ runtime_test!(
     test_runtime_wit_bindgen_resource_aggregates,
     "resource_aggregates"
 );
-// 3-component chain: needs handle table wiring fix (epic #69, #75)
+// 3-component chain: merger deduplicates [export] resource imports across
+// components, causing resource type identity mismatch at runtime (H-11.7).
+// Needs per-component resource import dedup in merger to fix.
 fuse_only_test!(test_fuse_wit_bindgen_resource_floats, "resource_floats");
 runtime_test!(
     test_runtime_wit_bindgen_resource_borrow_in_record,
     "resource_borrow_in_record"
 );
-// 3-component chain: needs handle table wiring fix (epic #69, #75)
 fuse_only_test!(
     test_fuse_wit_bindgen_resource_with_lists,
     "resource_with_lists"
@@ -685,7 +686,6 @@ fuse_only_test!(
 runtime_test!(test_runtime_wit_bindgen_ownership, "ownership");
 runtime_test!(test_runtime_wit_bindgen_xcrate, "xcrate");
 
-// 3-component chain: needs handle table wiring fix (epic #69, #75)
 fuse_only_test!(
     test_fuse_wit_bindgen_resource_import_and_export,
     "resource-import-and-export"

--- a/safety/stpa/resource-handle-stpa.yaml
+++ b/safety/stpa/resource-handle-stpa.yaml
@@ -119,6 +119,23 @@ sub-hazards:
 
   - id: H-11.8
     parent: H-11
+    title: Resource import dedup merges per-component resource types
+    description: >
+      The merger deduplicates [export]-prefixed resource imports (resource.new,
+      resource.rep, resource.drop) across components when they share the same
+      (module, field) name. In 3-component chains (definer → re-exporter →
+      runner), the definer and runner may both import [resource-rep]float under
+      [export]test:resource-floats/test. The merger emits only one import, and
+      the P2 wrapper creates one canonical resource type for it. At runtime,
+      wasmtime rejects handles with "used with the wrong type" because the
+      definer's and runner's handles are in different per-type tables but the
+      wrapper routes them through the same type.
+      Fix: the merger must emit per-component [export] resource imports (with
+      $N suffixes) when handle tables are active, so each component gets its
+      own canonical resource type in the P2 wrapper.
+
+  - id: H-11.9
+    parent: H-11
     title: Destructor not forwarded for locally-defined resources in P2 wrapper
     description: >
       When the P2 wrapper defines a local resource type, it must connect the


### PR DESCRIPTION
## Summary

- Add per-component resource type keying in P2 wrapper when handle tables are active
- Document new STPA sub-hazard **H-11.8**: merger deduplicates `[export]` resource imports across components, causing resource type identity mismatch at runtime
- 3 resource chain tests remain fuse-only — the root cause is in the merger's import dedup logic, not the wrapper

### Root Cause Analysis

In 3-component chains (definer → re-exporter → runner), the definer and runner both import `[resource-rep]float` under `[export]test:resource-floats/test`. The merger deduplicates these into **one import** (no `$N` suffix). The P2 wrapper then creates one canonical resource type, but wasmtime needs separate per-component types. Result: "handle index 1 used with the wrong type".

### Fix Path

The merger needs to emit per-component `[export]` resource imports with `$N` suffixes when handle tables are active, so each component gets its own canonical resource type. This is tracked as H-11.8 in the STPA analysis.

Part of #69, documents remaining work for #75.

## Test plan

- [x] 276 tests pass, 0 failures
- [x] No regressions — per-component keying only activates when `handle_tables` is non-empty
- [x] 2-component resource tests unaffected (no handle tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)