### PR TITLE
fix: synthesize caller's resource imports for per-component type identity

### DIFF
--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -1237,6 +1237,21 @@ impl Resolver {
                     needed.push((op.import_module.clone(), new_field, site.to_component));
                 }
             }
+            // Synthesize CALLER's [resource-rep] and [resource-new] so the P2
+            // wrapper creates a per-component resource type for the caller.
+            // Without this, the caller reuses the callee's resource type and
+            // wasmtime rejects handles with "used with the wrong type" (H-11.8).
+            for op in &site.requirements.resource_params {
+                if op.callee_defines_resource && site.from_component != site.to_component {
+                    needed.push((
+                        op.import_module.clone(),
+                        op.import_field.clone(),
+                        site.from_component,
+                    ));
+                    let new_field = op.import_field.replace("[resource-rep]", "[resource-new]");
+                    needed.push((op.import_module.clone(), new_field, site.from_component));
+                }
+            }
             // For 3-component chains: synthesize callee's [resource-rep] for own results.
             // The adapter calls resource.rep on the callee's handle before resource.new.
             for op in &site.requirements.resource_results {

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -671,9 +671,8 @@ runtime_test!(
     test_runtime_wit_bindgen_resource_aggregates,
     "resource_aggregates"
 );
-// 3-component chain: merger deduplicates [export] resource imports across
-// components, causing resource type identity mismatch at runtime (H-11.7).
-// Needs per-component resource import dedup in merger to fix.
+// 3-component chain: resource type mismatch fixed (H-11.8), but handle
+// table values still trap in wit-bindgen's ResourceTable slab code.
 fuse_only_test!(test_fuse_wit_bindgen_resource_floats, "resource_floats");
 runtime_test!(
     test_runtime_wit_bindgen_resource_borrow_in_record,


### PR DESCRIPTION
## Summary

- Synthesize `[resource-rep]` and `[resource-new]` imports for the **caller** component in cross-component adapter sites
- This ensures the P2 wrapper creates a separate resource type per component, fixing the "handle index used with the wrong type" error (H-11.8)
- The 3 resource chain tests now get past wasmtime's type validation (was: type mismatch, now: trap in wit-bindgen slab code — next layer to fix)

### Progress on resource chain tests

| Stage | Before | After |
|-------|--------|-------|
| Resource type validation | Fails ("wrong type") | Passes |
| wit-bindgen ResourceTable slab | Not reached | Fails (unreachable trap) |

The remaining trap is in wit-bindgen's `ResourceTable` code — the handle values from the handle table functions need further investigation to match what the slab expects.

Part of #69.

## Test plan

- [x] 276 tests pass, 0 failures
- [x] No regressions — synthesis only adds imports when `from_component != to_component`
- [x] 3 resource chain tests remain fuse-only (next failure layer documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)