### PR TITLE
fix: strip $N suffix from resource name in resource tracking maps

### DIFF
--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -1673,16 +1673,22 @@ impl Merger {
                     });
 
                     // Track per-component resource import indices.
+                    // Strip $N suffix (multi-memory dedup) from the resource name
+                    // so the adapter can look up by bare name (e.g., "float" not "float$5").
                     let merged_func_idx = func_position - 1;
                     let eff_field = &dedup_key.1;
                     if let Some(rn) = eff_field.strip_prefix("[resource-rep]") {
-                        merged
-                            .resource_rep_by_component
-                            .insert((unresolved.component_idx, rn.to_string()), merged_func_idx);
+                        let bare_rn = rn.rsplit_once('$').map_or(rn, |(base, _)| base);
+                        merged.resource_rep_by_component.insert(
+                            (unresolved.component_idx, bare_rn.to_string()),
+                            merged_func_idx,
+                        );
                     } else if let Some(rn) = eff_field.strip_prefix("[resource-new]") {
-                        merged
-                            .resource_new_by_component
-                            .insert((unresolved.component_idx, rn.to_string()), merged_func_idx);
+                        let bare_rn = rn.rsplit_once('$').map_or(rn, |(base, _)| base);
+                        merged.resource_new_by_component.insert(
+                            (unresolved.component_idx, bare_rn.to_string()),
+                            merged_func_idx,
+                        );
                     }
                 }
                 ImportKind::Table(t) => {

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -673,6 +673,9 @@ runtime_test!(
 );
 // 3-component chain: resource type mismatch fixed (H-11.8), but handle
 // table values still trap in wit-bindgen's ResourceTable slab code.
+// 3-component chain: adapter function body references wrong import (H-11.8).
+// The adapter calls resource.rep with comp 0's type instead of comp 5's type,
+// AND the adapter's call signature doesn't match (f64 param vs i32 expected).
 fuse_only_test!(test_fuse_wit_bindgen_resource_floats, "resource_floats");
 runtime_test!(
     test_runtime_wit_bindgen_resource_borrow_in_record,


### PR DESCRIPTION
## Summary

- Strip `$N` multi-memory dedup suffix from resource names when recording in `resource_rep_by_component` and `resource_new_by_component` maps
- Without this, the adapter generator looks up `(5, "float")` but the map contains `(5, "float$5")`, causing fallback to the wrong component's import
- This is one of several layers needed for 3-component resource chain support

### Debugging findings

The adapter function body for the runner→intermediate call currently references `canon resource.rep 21` (comp 0's type) instead of `canon resource.rep 36` (comp 5's type). The `$N` suffix stripping fixes the map lookup, but the adapter code generation (`fact.rs`) also needs work — the adapter call signature doesn't match the canonical function type for some adapters. This is the next layer to investigate.

Part of #69.

## Test plan

- [x] 276 tests pass, 0 failures
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)