### PR TITLE
fix: restrict handle table routing to exports interface only

### DIFF
--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -1141,9 +1141,14 @@ fn assemble_component(
                 interface_name,
                 component_idx,
             } => {
-                // Check if this import belongs to a re-exporter with a handle table.
-                // If so, route to the handle table function instead of canon resource ops.
-                let ht_info = component_idx.and_then(|ci| merged.handle_tables.get(&ci));
+                // Check if this import belongs to a re-exporter with a handle table
+                // AND the interface is the re-exporter's own export interface.
+                // Only `[export]exports` uses the handle table — other interfaces
+                // (like `[export]imports` or `[export]test:…`) are for resources
+                // the re-exporter CONSUMES, which use canonical resource types.
+                let ht_info = component_idx
+                    .and_then(|ci| merged.handle_tables.get(&ci))
+                    .filter(|_| interface_name == "exports");
 
                 if let Some(ht) = ht_info {
                     // Route to handle table function exported from fused module
@@ -1166,9 +1171,11 @@ fn assemble_component(
                     core_func_idx += 1;
                 } else {
                     // Standard path: define resource type and use canon resource ops.
-                    // Per-component keying when handle tables are active prevents
-                    // type reuse across components that need separate handle tables.
-                    let comp_key = if has_handle_tables {
+                    // Per-component keying only for "exports" interface when handle
+                    // tables are active. Other interfaces (like "imports") are shared
+                    // resources that must use the same canonical resource type across
+                    // all components that reference them.
+                    let comp_key = if has_handle_tables && interface_name == "exports" {
                         *component_idx
                     } else {
                         None

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -673,9 +673,8 @@ runtime_test!(
 );
 // 3-component chain: resource type mismatch fixed (H-11.8), but handle
 // table values still trap in wit-bindgen's ResourceTable slab code.
-// 3-component chain: adapter function body references wrong import (H-11.8).
-// The adapter calls resource.rep with comp 0's type instead of comp 5's type,
-// AND the adapter's call signature doesn't match (f64 param vs i32 expected).
+// 3-component: resource type identity fixed, but handle table values
+// trap in wit-bindgen's ResourceTable slab (unreachable in re-exporter code).
 fuse_only_test!(test_fuse_wit_bindgen_resource_floats, "resource_floats");
 runtime_test!(
     test_runtime_wit_bindgen_resource_borrow_in_record,


### PR DESCRIPTION
## Summary

- Handle table functions now only route `[export]exports` resource ops (the re-exporter's own exported interface)
- Other `[export]` interfaces (`[export]imports`, `[export]test:…/test`) use canonical resource types — they're for resources the re-exporter consumes from the definer
- Per-component resource type keying also restricted to `exports` interface, so shared resources use the same canonical type across components

This fully fixes the resource type identity mismatch (H-11.8). The 3 resource chain tests now pass type validation. Remaining failure is an `unreachable` trap in wit-bindgen's ResourceTable slab code inside the re-exporter — the handle table values (memory addresses) reach the slab correctly but trigger an internal assertion.

Part of #69.

## Test plan

- [x] 276 tests pass, 0 failures
- [x] No regressions — routing filter only affects re-exporter components

🤖 Generated with [Claude Code](https://claude.com/claude-code)