### PR TITLE
fix: export dedup + shared resource types + disable handle tables

### DIFF
--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -153,7 +153,8 @@ enum ImportResolution {
         /// For `[export]imports`, this is `"imports"`.
         /// For plain `exports`, this is `"exports"`.
         interface_name: String,
-        /// Source component index (used for handle table routing)
+        /// Source component index (reserved for future handle table routing)
+        #[allow(dead_code)]
         component_idx: Option<usize>,
     },
 }
@@ -1051,14 +1052,12 @@ fn assemble_component(
     let mut component_type_idx = count_replayed_types(source);
     let mut lowered_func_indices: Vec<u32> = Vec::new();
 
-    // Cache: (component_idx, interface_name, resource_name) → component type index.
-    //
-    // When re-exporter handle tables are active, each component needs its own
-    // resource type to avoid wasmtime's handle type validation rejecting handles
-    // that cross component boundaries (H-11.7, UCA-A-21). Without handle tables
-    // (2-component chains), all components share one type per (interface, resource).
-    let has_handle_tables = !merged.handle_tables.is_empty();
-    let mut local_resource_types: std::collections::HashMap<(Option<usize>, String, String), u32> =
+    // Cache: resource_name → component type index.
+    // All components share one canonical resource type per resource name,
+    // regardless of interface. Re-exporters import and export the same
+    // resource under different interface names (imports, exports, test:…/test)
+    // but must share one wasmtime handle table.
+    let mut local_resource_types: std::collections::HashMap<String, u32> =
         std::collections::HashMap::new();
 
     for (i, resolution) in import_resolutions.iter().enumerate() {
@@ -1139,48 +1138,13 @@ fn assemble_component(
                 operation,
                 resource_name,
                 interface_name,
-                component_idx,
+                component_idx: _,
             } => {
-                // Check if this import belongs to a re-exporter with a handle table
-                // AND the interface is the re-exporter's own export interface.
-                // Only `[export]exports` uses the handle table — other interfaces
-                // (like `[export]imports` or `[export]test:…`) are for resources
-                // the re-exporter CONSUMES, which use canonical resource types.
-                let ht_info = component_idx
-                    .and_then(|ci| merged.handle_tables.get(&ci))
-                    .filter(|_| interface_name == "exports");
-
-                if let Some(ht) = ht_info {
-                    // Route to handle table function exported from fused module
-                    let export_name = match operation {
-                        ResourceOp::New => format!("$ht_new_{}", component_idx.unwrap()),
-                        ResourceOp::Rep => format!("$ht_rep_{}", component_idx.unwrap()),
-                        ResourceOp::Drop => format!("$ht_drop_{}", component_idx.unwrap()),
-                    };
-                    let _ = ht; // suppress unused warning
-
-                    let mut aliases = ComponentAliasSection::new();
-                    aliases.alias(Alias::CoreInstanceExport {
-                        instance: fused_instance,
-                        kind: ExportKind::Func,
-                        name: &export_name,
-                    });
-                    component.section(&aliases);
-
-                    lowered_func_indices.push(core_func_idx);
-                    core_func_idx += 1;
-                } else {
-                    // Standard path: define resource type and use canon resource ops.
-                    // Per-component keying only for "exports" interface when handle
-                    // tables are active. Other interfaces (like "imports") are shared
-                    // resources that must use the same canonical resource type across
-                    // all components that reference them.
-                    let comp_key = if has_handle_tables && interface_name == "exports" {
-                        *component_idx
-                    } else {
-                        None
-                    };
-                    let res_type_key = (comp_key, interface_name.clone(), resource_name.clone());
+                {
+                    // All components share one canonical resource type per
+                    // resource name. Re-exporters forward handles through the
+                    // same wasmtime-managed handle table as the definer.
+                    let res_type_key = resource_name.clone();
                     let res_type_idx =
                         if let Some(&existing) = local_resource_types.get(&res_type_key) {
                             existing

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -440,6 +440,7 @@ impl Merger {
     /// For each re-exporter, grows its memory by 1 page and places a handle
     /// table at the start of the new page. Adds a mutable global for the
     /// next-allocation pointer and generates ht_new/ht_rep/ht_drop functions.
+    #[allow(dead_code)]
     fn allocate_handle_tables(graph: &DependencyGraph, merged: &mut MergedModule) -> Result<()> {
         // Handle table capacity: 256 entries = 1024 bytes (fits in 1 page)
         const HT_CAPACITY: u32 = 256;
@@ -592,6 +593,7 @@ impl Merger {
     }
 
     /// Find an existing function type or add a new one, returning its index.
+    #[allow(dead_code)]
     fn find_or_add_type(
         types: &mut Vec<MergedFuncType>,
         params: &[ValType],
@@ -681,10 +683,12 @@ impl Merger {
         // Handle start functions
         self.resolve_start_functions(components, &mut merged)?;
 
-        // Allocate per-component handle tables for re-exporter components.
-        if !graph.reexporter_components.is_empty() {
-            Self::allocate_handle_tables(graph, &mut merged)?;
-        }
+        // Handle table allocation disabled: with resource-name-only keying,
+        // all components share one canonical resource type per resource name.
+        // The wasmtime runtime manages handle tables — no custom tables needed.
+        // if !graph.reexporter_components.is_empty() {
+        //     Self::allocate_handle_tables(graph, &mut merged)?;
+        // }
 
         if let Some(plan) = shared_memory_plan {
             if plan.import.is_none() {
@@ -1156,9 +1160,33 @@ impl Merger {
                                 res.to_module,
                                 export.index,
                             )) {
+                                log::debug!(
+                                    "intra-comp func resolve: comp {} mod {} import {}({}) -> comp {} mod {} export {}[{}] = merged {}",
+                                    comp_idx,
+                                    mod_idx,
+                                    imp.name,
+                                    import_func_idx,
+                                    res.component_idx,
+                                    res.to_module,
+                                    res.export_name,
+                                    export.index,
+                                    target_idx,
+                                );
                                 merged
                                     .function_index_map
                                     .insert((comp_idx, mod_idx, import_func_idx), target_idx);
+                            } else {
+                                log::warn!(
+                                    "intra-comp func resolve MISS: comp {} mod {} import {}({}) -> comp {} mod {} export {}[{}] NOT IN function_index_map",
+                                    comp_idx,
+                                    mod_idx,
+                                    imp.name,
+                                    import_func_idx,
+                                    res.component_idx,
+                                    res.to_module,
+                                    res.export_name,
+                                    export.index,
+                                );
                             }
                         }
                     }
@@ -1175,7 +1203,25 @@ impl Merger {
                         imp.module.clone(),
                         imp.name.clone(),
                     )) {
+                        log::debug!(
+                            "unresolved func assign: comp {} mod {} import {}::{}({}) = merged import {}",
+                            comp_idx,
+                            mod_idx,
+                            imp.module,
+                            imp.name,
+                            import_func_idx,
+                            import_index,
+                        );
                         e.insert(import_index);
+                    } else {
+                        log::warn!(
+                            "UNMAPPED func import: comp {} mod {} import {}::{}({})",
+                            comp_idx,
+                            mod_idx,
+                            imp.module,
+                            imp.name,
+                            import_func_idx,
+                        );
                     }
                 }
 
@@ -1284,33 +1330,27 @@ impl Merger {
                 }
             };
 
-            // Export deduplication: first-wins strategy.
-            //
-            // When multiple modules export the same name, the first export
-            // (in topological/instantiation order) wins and subsequent
-            // duplicates are silently dropped.  This matches the component
-            // model's semantics where earlier instantiations take priority.
-            //
-            // If this behavior is ever made configurable (e.g. error on
-            // conflict, or prefix with component name), update both this
-            // check and the MergedExport documentation.
-            if let Some(existing) = merged.exports.iter().find(|e| e.name == export.name) {
-                log::warn!(
-                    "Duplicate export \"{}\": keeping {:?} index {} (from earlier module), \
-                     skipping {:?} index {} from component {} module {}",
-                    export.name,
-                    existing.kind,
-                    existing.index,
-                    kind,
-                    old_idx,
-                    comp_idx,
-                    mod_idx,
-                );
-                continue;
-            }
+            // Export deduplication: in multi-memory mode, suffix duplicate
+            // export names with the component index. Each component's shim
+            // module exports numeric function names ("0", "1", ...) and a
+            // "$imports" table that must remain distinct — deduplication
+            // would wire the fixup module to the wrong component's indirect
+            // table. In shared-memory mode, first-wins dedup is correct
+            // since all components share one memory.
+            let export_name = if self.memory_strategy == MemoryStrategy::MultiMemory
+                && merged.exports.iter().any(|e| e.name == export.name)
+            {
+                format!("{}${}", export.name, comp_idx)
+            } else if self.memory_strategy != MemoryStrategy::MultiMemory
+                && merged.exports.iter().any(|e| e.name == export.name)
+            {
+                continue; // first-wins dedup in shared-memory mode
+            } else {
+                export.name.clone()
+            };
 
             merged.exports.push(MergedExport {
-                name: export.name.clone(),
+                name: export_name,
                 kind,
                 index: old_idx,
             });

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -1428,8 +1428,19 @@ impl Resolver {
     ) -> Result<()> {
         for (comp_idx, component) in components.iter().enumerate() {
             if !component.instances.is_empty() {
+                log::debug!(
+                    "resolve_module_imports: comp {} using resolve_via_instances ({} instances, {} modules)",
+                    comp_idx,
+                    component.instances.len(),
+                    component.core_modules.len()
+                );
                 self.resolve_via_instances(comp_idx, component, graph)?;
             } else {
+                log::debug!(
+                    "resolve_module_imports: comp {} using resolve_via_flat_names ({} modules)",
+                    comp_idx,
+                    component.core_modules.len()
+                );
                 self.resolve_via_flat_names(comp_idx, component, graph)?;
             }
         }
@@ -1692,6 +1703,13 @@ impl Resolver {
                             && let Some(to_mod_idx) =
                                 find_module_with_export(component, &import.name, from_mod_idx)
                         {
+                            log::debug!(
+                                "comp {} mod {} __main_module__::{} → mod {}",
+                                comp_idx,
+                                from_mod_idx,
+                                import.name,
+                                to_mod_idx
+                            );
                             graph.module_resolutions.push(ModuleResolution {
                                 component_idx: comp_idx,
                                 from_module: from_mod_idx,
@@ -1807,7 +1825,7 @@ impl Resolver {
         if let Some(exports) = from_exports_infos.get(&instance_idx) {
             for (name, kind, entity_idx) in exports {
                 if name == export_name {
-                    return match kind {
+                    let result = match kind {
                         ExportKind::Function => provenance
                             .func_source
                             .get(entity_idx)
@@ -1825,6 +1843,15 @@ impl Resolver {
                             .get(entity_idx)
                             .map(|(mod_idx, exp_name)| (*mod_idx, exp_name.clone())),
                     };
+                    log::debug!(
+                        "trace_instance_export: inst {} export '{}' ({:?}) entity_idx {} -> {:?}",
+                        instance_idx,
+                        export_name,
+                        kind,
+                        entity_idx,
+                        result
+                    );
+                    return result;
                 }
             }
         }

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -671,10 +671,8 @@ runtime_test!(
     test_runtime_wit_bindgen_resource_aggregates,
     "resource_aggregates"
 );
-// 3-component chain: resource type mismatch fixed (H-11.8), but handle
-// table values still trap in wit-bindgen's ResourceTable slab code.
-// 3-component: resource type identity fixed, but handle table values
-// trap in wit-bindgen's ResourceTable slab (unreachable in re-exporter code).
+// 3-component chain: resource type identity fully unified, but leaf's
+// allocator traps when called from the intermediate's code path.
 fuse_only_test!(test_fuse_wit_bindgen_resource_floats, "resource_floats");
 runtime_test!(
     test_runtime_wit_bindgen_resource_borrow_in_record,


### PR DESCRIPTION
## Summary

Three interconnected fixes for 3-component resource chain support:

1. **Export dedup suffixing**: In multi-memory mode, suffix duplicate export names with `$comp_idx` instead of silently dropping them. Previously, the fixup module's indirect table was wired to the wrong component's functions due to export name collisions ("0", "1", "$imports" etc.).

2. **Shared resource types**: Key resource types by resource name only (not interface+name). Re-exporters import and export the same resource under different interface names but must share one canonical wasmtime handle table.

3. **Disable handle table allocation**: With shared canonical resource types, all components use wasmtime's built-in handle tables. Custom per-component handle tables are no longer needed (code preserved with `#[allow(dead_code)]` for potential future use).

Part of #69.

## Test plan

- [x] 276 tests pass, 0 failures
- [x] SharedMemory test still passes (first-wins dedup preserved)
- [x] 3 resource chain tests remain fuse-only (separate allocator issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)