### PR TITLE
fix: remove incorrect caller_already_converted for re-exporter adapters

### DIFF
--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -1174,19 +1174,10 @@ impl Resolver {
             graph.reexporter_components = reexporter_set.into_iter().collect();
         }
 
-        // For adapters FROM a re-exporter TO the resource definer: the
-        // re-exporter's generated code already extracts rep via its handle
-        // table (ht_rep). The downstream adapter must not call resource.rep
-        // again, or it would double-extract.
-        for site in &mut graph.adapter_sites {
-            if graph.reexporter_components.contains(&site.from_component) {
-                for op in &mut site.requirements.resource_params {
-                    if !op.is_owned && op.callee_defines_resource {
-                        op.caller_already_converted = true;
-                    }
-                }
-            }
-        }
+        // Note: the re-exporter caller_already_converted logic (from PR #81)
+        // was removed because handle tables are disabled. With canonical
+        // resource types, the re-exporter passes handles (not reps) and the
+        // downstream adapter MUST call resource.rep to convert.
 
         // Synthesize missing resource imports.
         //

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -671,8 +671,8 @@ runtime_test!(
     test_runtime_wit_bindgen_resource_aggregates,
     "resource_aggregates"
 );
-// 3-component chain: resource type identity fully unified, but leaf's
-// allocator traps when called from the intermediate's code path.
+// 3-component chain: resource.rep conversion now works, but leaf's internal
+// ResourceTable::get returns None — needs further adapter investigation.
 fuse_only_test!(test_fuse_wit_bindgen_resource_floats, "resource_floats");
 runtime_test!(
     test_runtime_wit_bindgen_resource_borrow_in_record,


### PR DESCRIPTION
## Summary

Remove the re-exporter `caller_already_converted` logic from PR #81. With handle tables disabled (PR #89), re-exporters pass canonical handles through wasmtime's built-in handle table. The downstream adapter must call `resource.rep` to convert handles to representations.

**Root cause found via wasmtime 43**: the error was `misaligned pointer dereference: address must be a multiple of 0x8 but is 0x3` — the adapter passed handle index 3 directly to the leaf's code which expected an 8-byte-aligned heap pointer.

The 3 resource chain tests now get past the pointer conversion layer. Remaining failure is `Option::unwrap() on None` in the leaf's internal ResourceTable lookup.

Part of #69.

## Test plan

- [x] 276 tests pass, 0 failures
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)