### PR TITLE
fix: prevent resource map overwrites and remove unsafe graph upgrades

### DIFF
--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -1719,16 +1719,16 @@ impl Merger {
                     let eff_field = &dedup_key.1;
                     if let Some(rn) = eff_field.strip_prefix("[resource-rep]") {
                         let bare_rn = rn.rsplit_once('$').map_or(rn, |(base, _)| base);
-                        merged.resource_rep_by_component.insert(
-                            (unresolved.component_idx, bare_rn.to_string()),
-                            merged_func_idx,
-                        );
+                        merged
+                            .resource_rep_by_component
+                            .entry((unresolved.component_idx, bare_rn.to_string()))
+                            .or_insert(merged_func_idx);
                     } else if let Some(rn) = eff_field.strip_prefix("[resource-new]") {
                         let bare_rn = rn.rsplit_once('$').map_or(rn, |(base, _)| base);
-                        merged.resource_new_by_component.insert(
-                            (unresolved.component_idx, bare_rn.to_string()),
-                            merged_func_idx,
-                        );
+                        merged
+                            .resource_new_by_component
+                            .entry((unresolved.component_idx, bare_rn.to_string()))
+                            .or_insert(merged_func_idx);
                     }
                 }
                 ImportKind::Table(t) => {

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -2279,37 +2279,39 @@ impl Resolver {
                                                 );
 
                                             // Graph-based override for callee_defines_resource.
-                                            // Only UPGRADE (false→true) or DOWNGRADE (true→false)
-                                            // when the graph has a definitive answer. If the graph
-                                            // has no entry, leave the heuristic value unchanged.
+                                            // Only DOWNGRADE (true→false) when the graph has a
+                                            // definitive answer that the callee does NOT define
+                                            // the resource. Never UPGRADE (false→true) — the
+                                            // heuristic's type_defs check (Import vs Defined) is
+                                            // authoritative for that direction, and upgrading
+                                            // would break re-exporters whose ResourceRep makes
+                                            // the graph think they define the resource.
                                             if let Some(ref rg) = graph.resource_graph {
                                                 let iface = import_name.as_str();
                                                 for op in &mut requirements.resource_params {
+                                                    if !op.callee_defines_resource {
+                                                        continue;
+                                                    }
                                                     let rn = op
                                                         .import_field
                                                         .strip_prefix("[resource-rep]")
                                                         .unwrap_or(&op.import_field);
-                                                    if rg.defines_resource(*to_comp, iface, rn) {
-                                                        op.callee_defines_resource = true;
-                                                    } else if rg
-                                                        .resource_definer(iface, rn)
-                                                        .is_some()
+                                                    if !rg.defines_resource(*to_comp, iface, rn)
+                                                        && rg.resource_definer(iface, rn).is_some()
                                                     {
-                                                        // Graph knows about this resource and says
-                                                        // this component is NOT the definer.
                                                         op.callee_defines_resource = false;
                                                     }
                                                 }
                                                 for op in &mut requirements.resource_results {
+                                                    if !op.callee_defines_resource {
+                                                        continue;
+                                                    }
                                                     let rn = op
                                                         .import_field
                                                         .strip_prefix("[resource-new]")
                                                         .unwrap_or(&op.import_field);
-                                                    if rg.defines_resource(*to_comp, iface, rn) {
-                                                        op.callee_defines_resource = true;
-                                                    } else if rg
-                                                        .resource_definer(iface, rn)
-                                                        .is_some()
+                                                    if !rg.defines_resource(*to_comp, iface, rn)
+                                                        && rg.resource_definer(iface, rn).is_some()
                                                     {
                                                         op.callee_defines_resource = false;
                                                     }
@@ -2525,29 +2527,34 @@ impl Resolver {
                                             true,
                                         );
 
-                                    // Graph-based override for fallback path.
-                                    // Only change when the graph has a definitive answer.
+                                    // Graph-based override for fallback path (downgrade only).
                                     if let Some(ref rg) = graph.resource_graph {
                                         let iface = import_name.as_str();
                                         for op in &mut requirements.resource_params {
+                                            if !op.callee_defines_resource {
+                                                continue;
+                                            }
                                             let rn = op
                                                 .import_field
                                                 .strip_prefix("[resource-rep]")
                                                 .unwrap_or(&op.import_field);
-                                            if rg.defines_resource(*to_comp, iface, rn) {
-                                                op.callee_defines_resource = true;
-                                            } else if rg.resource_definer(iface, rn).is_some() {
+                                            if !rg.defines_resource(*to_comp, iface, rn)
+                                                && rg.resource_definer(iface, rn).is_some()
+                                            {
                                                 op.callee_defines_resource = false;
                                             }
                                         }
                                         for op in &mut requirements.resource_results {
+                                            if !op.callee_defines_resource {
+                                                continue;
+                                            }
                                             let rn = op
                                                 .import_field
                                                 .strip_prefix("[resource-new]")
                                                 .unwrap_or(&op.import_field);
-                                            if rg.defines_resource(*to_comp, iface, rn) {
-                                                op.callee_defines_resource = true;
-                                            } else if rg.resource_definer(iface, rn).is_some() {
+                                            if !rg.defines_resource(*to_comp, iface, rn)
+                                                && rg.resource_definer(iface, rn).is_some()
+                                            {
                                                 op.callee_defines_resource = false;
                                             }
                                         }


### PR DESCRIPTION
## Summary

Two targeted fixes for 3-component re-exporter resource chain correctness (Epic #69):

- **merger.rs**: Change `.insert()` to `.entry().or_insert()` for `resource_rep_by_component` and `resource_new_by_component` maps. Re-exporter components have multiple `[resource-rep/new]` imports for the same resource name across different interfaces — the first mapping must be preserved.

- **resolver.rs**: Change resource graph override to downgrade-only. The graph's `defines_resource()` returns true for re-exporters (they have ResourceRep), incorrectly upgrading `callee_defines_resource` from false back to true. Now the graph can only downgrade (true→false), never upgrade (false→true).

These are safe infrastructure improvements — 73/73 tests pass. The 3 fuse-only re-exporter tests remain fuse-only pending a re-exporter shim module (#69).

## Test plan

- [x] `cargo test --package meld-core` — 73/73 pass, 0 regressions
- [x] All existing runtime tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)