### PR TITLE
feat: per-resource handle tables + alias-fallback (1/3 trio runtime passes)

### DIFF
--- a/meld-cli/src/main.rs
+++ b/meld-cli/src/main.rs
@@ -81,6 +81,19 @@ enum Commands {
         /// Write a JSON import map to the given path (for synth/kiln integration)
         #[arg(long, value_name = "PATH")]
         emit_import_map: Option<String>,
+
+        /// Mark a resource as opaque-rep (for re-exporters whose representation
+        /// is treated as a `u32` rather than a boxed pointer). Repeatable.
+        ///
+        /// Format: `<interface>.<resource>` (qualified). Example:
+        /// `--opaque-rep test:resource-floats-opaque/chain.float`
+        ///
+        /// Opaque-rep resources skip meld's per-resource handle table layer
+        /// and get their own wasmtime resource type per component (rather
+        /// than the shared-by-name default). This matches the architecture
+        /// of pulseengine/wit-bindgen `feat/opaque-rep-attribute`.
+        #[arg(long, value_name = "IFACE.RESOURCE")]
+        opaque_rep: Vec<String>,
     },
 
     /// Inspect a WebAssembly component
@@ -124,6 +137,7 @@ fn main() -> Result<()> {
             validate,
             component,
             emit_import_map,
+            opaque_rep,
         }) => {
             fuse_command(
                 inputs,
@@ -136,6 +150,7 @@ fn main() -> Result<()> {
                 validate,
                 component,
                 emit_import_map,
+                opaque_rep,
             )?;
         }
 
@@ -190,6 +205,7 @@ fn fuse_command(
     validate: bool,
     component: bool,
     emit_import_map: Option<String>,
+    opaque_rep: Vec<String>,
 ) -> Result<()> {
     println!(
         "Meld v{} - Static Component Fusion",
@@ -221,12 +237,34 @@ fn fuse_command(
     } else {
         OutputFormat::CoreModule
     };
+    // Parse --opaque-rep <iface>.<resource> values into (iface, resource)
+    // tuples. Split on the LAST '.' so qualified interface names like
+    // `test:resource-floats-opaque/chain` (which contain no '.') are kept
+    // intact and only the trailing resource name is split off.
+    let opaque_resources: Vec<(String, String)> = opaque_rep
+        .iter()
+        .map(|s| match s.rsplit_once('.') {
+            Some((iface, rn)) => Ok((iface.to_string(), rn.to_string())),
+            None => Err(anyhow!(
+                "--opaque-rep value '{}' must be 'iface.resource' (e.g. 'test:foo/bar.baz')",
+                s
+            )),
+        })
+        .collect::<Result<_>>()?;
+    if !opaque_resources.is_empty() {
+        println!("Opaque-rep resources:");
+        for (iface, rn) in &opaque_resources {
+            println!("  {}.{}", iface, rn);
+        }
+    }
+
     let config = FuserConfig {
         memory_strategy,
         attestation: !no_attestation,
         address_rebasing: address_rebase,
         preserve_names,
         output_format,
+        opaque_resources,
         ..Default::default()
     };
 

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -23,6 +23,27 @@ use crate::resolver::{AdapterSite, DependencyGraph};
 use wasm_encoder::{Function, Instruction};
 
 /// Convert a canonical string encoding from the parser to the adapter's encoding enum
+/// Parse a wit-bindgen-style `(import_module, import_field)` pair to extract
+/// the interface name and (when present) the resource name.
+///
+/// `import_module` may carry the wit-bindgen `[export]` prefix when the
+/// import refers to the importer's own export resource — strip it.
+/// `import_field` looks like `[resource-rep]X`, `[resource-new]X`, or
+/// `[resource-drop]X` for resource helpers; otherwise no resource name
+/// is returned.
+fn parse_resource_import(import_module: &str, import_field: &str) -> (String, Option<String>) {
+    let iface = import_module
+        .strip_prefix("[export]")
+        .unwrap_or(import_module)
+        .to_string();
+    let rn = import_field
+        .strip_prefix("[resource-rep]")
+        .or_else(|| import_field.strip_prefix("[resource-new]"))
+        .or_else(|| import_field.strip_prefix("[resource-drop]"))
+        .map(|s| s.to_string());
+    (iface, rn)
+}
+
 fn canon_to_string_encoding(enc: CanonStringEncoding) -> StringEncoding {
     match enc {
         CanonStringEncoding::Utf8 => StringEncoding::Utf8,
@@ -578,12 +599,19 @@ impl FactStyleGenerator {
                 // Callee defines the resource — convert handle→rep.
                 // Skip if upstream adapter already converted (avoids double resource.rep).
                 if !op.caller_already_converted {
-                    // If the caller has a handle table, use ht_rep to extract rep
-                    // from the memory-pointer handle. Otherwise use canonical resource.rep.
-                    let rep_func = merged
-                        .handle_tables
-                        .get(&site.from_component)
-                        .map(|ht| ht.rep_func)
+                    // If the caller has a handle table for THIS specific
+                    // resource, use ht_rep to extract rep from the memory-
+                    // pointer handle. Otherwise use canonical resource.rep.
+                    let (iface, rn_opt) =
+                        parse_resource_import(&op.import_module, &op.import_field);
+                    let rep_func = rn_opt
+                        .as_deref()
+                        .and_then(|rn| {
+                            merged
+                                .handle_tables
+                                .get(&(site.from_component, iface.to_string(), rn.to_string()))
+                                .map(|ht| ht.rep_func)
+                        })
                         .or_else(|| {
                             resource_rep_imports
                                 .get(&(op.import_module.clone(), op.import_field.clone()))
@@ -637,9 +665,16 @@ impl FactStyleGenerator {
 
                 // For re-exporter callees with handle tables, use ht_new
                 // which returns memory-pointer handles that wit-bindgen expects.
+                // Look up by (to_component, iface, resource_name) so multi-resource
+                // re-exporters route per-resource, not per-component.
+                let (callee_iface, _) = parse_resource_import(&op.import_module, &op.import_field);
                 let callee_new_func = merged
                     .handle_tables
-                    .get(&site.to_component)
+                    .get(&(
+                        site.to_component,
+                        callee_iface.to_string(),
+                        resource_name.to_string(),
+                    ))
                     .map(|ht| ht.new_func)
                     .or_else(|| {
                         merged
@@ -698,11 +733,17 @@ impl FactStyleGenerator {
                 });
 
             // Callee's [resource-rep] (callee handle → rep).
-            // For re-exporter callees with handle tables, use ht_rep.
+            // For re-exporter callees with handle tables, use ht_rep —
+            // per-resource lookup so multi-resource re-exporters work.
+            let (callee_iface_r, _) = parse_resource_import(&op.import_module, &op.import_field);
             let rep_field = format!("[resource-rep]{}", resource_name);
             let rep_func = merged
                 .handle_tables
-                .get(&site.to_component)
+                .get(&(
+                    site.to_component,
+                    callee_iface_r.to_string(),
+                    resource_name.to_string(),
+                ))
                 .map(|ht| ht.rep_func)
                 .or_else(|| {
                     merged

--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -1305,10 +1305,29 @@ fn assemble_component(
                 });
                 let ht_export: Option<String> = direct.or_else(|| {
                     if *is_definer {
-                        // Definer with no own handle table: must use
-                        // canonical resource ops. Don't borrow another
-                        // component's handle table.
-                        return None;
+                        // Definer with no own handle table: try the
+                        // resource-alias fallback first. When another
+                        // component re-exports THIS resource via `use`
+                        // (intermediate's `use test.{float}` re-exports
+                        // leaf's test.float as exports.float), wasmtime
+                        // unifies both into one canonical type but the
+                        // re-exporter's handle table is the only storage
+                        // that knows the memory-pointer handles. The
+                        // definer's [resource-rep]/[resource-new]/
+                        // [resource-drop] must route through that same
+                        // table or peer components hand it pointers it
+                        // cannot dereference. Match by resource_name only
+                        // since the iface differs across the alias.
+                        let alias_tail = format!("_{}", resource_name);
+                        return fused_info
+                            .exports
+                            .iter()
+                            .find(|(n, k, _)| {
+                                *k == wasmparser::ExternalKind::Func
+                                    && n.starts_with(op_prefix)
+                                    && n.ends_with(&alias_tail)
+                            })
+                            .map(|(n, _, _)| n.clone());
                     }
                     // Consumer-side. If THIS component itself owns a handle
                     // table for the same (iface, rn), this import is its

--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -50,6 +50,7 @@ pub fn wrap_as_component(
     _graph: &DependencyGraph,
     merged: &MergedModule,
     memory_strategy: MemoryStrategy,
+    opaque_resources: &[(String, String)],
 ) -> Result<Vec<u8>> {
     // Pick the component with the most depth_0_sections (widest interface).
     // Prefer original (un-flattened) components since flattening may drop
@@ -106,6 +107,7 @@ pub fn wrap_as_component(
         merged,
         memory_strategy,
         components,
+        opaque_resources,
     )
 }
 
@@ -771,6 +773,10 @@ fn assemble_component(
     merged: &MergedModule,
     memory_strategy: MemoryStrategy,
     all_components: &[ParsedComponent],
+    // Currently consumed only by debug logging — the conditional behavior is
+    // not yet implemented. Threaded through the API so future work can use
+    // it without re-doing the plumbing.
+    _opaque_resources: &[(String, String)],
 ) -> Result<Vec<u8>> {
     use wasm_encoder::*;
 
@@ -1168,12 +1174,23 @@ fn assemble_component(
     // Shared between import resolution (P3 task-return types) and export lifting.
     let mut type_remap: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
 
-    // Cache: resource_name → component type index.
+    // Cache: (Option<component_idx>, resource_name) → component type index.
+    //
+    // STANDARD resources (Box-pattern wit-bindgen): keyed by `(None, name)`.
     // All components share one canonical resource type per resource name,
     // regardless of interface. Re-exporters import and export the same
     // resource under different interface names (imports, exports, test:…/test)
-    // but must share one wasmtime handle table.
-    let mut local_resource_types: std::collections::HashMap<String, u32> =
+    // but must share one wasmtime handle table so Box-pointer reps round-trip
+    // through the re-exporter chain.
+    //
+    // OPAQUE-REP resources (pulseengine/wit-bindgen feat/opaque-rep-attribute):
+    // keyed by `(Some(component_idx), name)`. Each component gets its OWN
+    // wasmtime resource type and table. The opaque-rep pattern relies on
+    // intermediate's small-integer rep being stored in its OWN table —
+    // sharing a table with leaf would mix value spaces (intermediate's rep=1
+    // would be retrieved by leaf as the rep for its own handle=1, then
+    // dereferenced as a Box pointer → trap).
+    let mut local_resource_types: std::collections::HashMap<(Option<usize>, String), u32> =
         std::collections::HashMap::new();
 
     // Pre-define component function types for async lift/lower imports.
@@ -1349,7 +1366,7 @@ fn assemble_component(
                     core_func_idx += 1;
                 } else {
                     // Standard path: canonical resource operations.
-                    let res_type_key = resource_name.clone();
+                    let res_type_key = (None, resource_name.clone());
                     let res_type_idx =
                         if let Some(&existing) = local_resource_types.get(&res_type_key) {
                             existing

--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -157,6 +157,14 @@ enum ImportResolution {
         /// Source component index (reserved for future handle table routing)
         #[allow(dead_code)]
         component_idx: Option<usize>,
+        /// `true` when the import came from an `[export]`-prefixed module —
+        /// meaning the importer is the DEFINER of the resource (its own
+        /// export). `false` when the importer is a CONSUMER of someone
+        /// else's resource (just calls into it). The two cases route
+        /// differently: definers must use canonical resource ops or their
+        /// own handle table; consumers may fall back to any re-exporter's
+        /// handle table for the same (interface, resource).
+        is_definer: bool,
     },
     /// Import resolves to a P3 task/async canonical built-in.
     ///
@@ -844,6 +852,7 @@ fn assemble_component(
                 resource_name,
                 interface_name: inner_module.to_string(),
                 component_idx: comp_idx,
+                is_definer: true,
             });
             continue;
         }
@@ -892,6 +901,7 @@ fn assemble_component(
                 resource_name,
                 interface_name: module_name.clone(),
                 component_idx: comp_idx,
+                is_definer: false,
             });
             continue;
         }
@@ -1246,53 +1256,77 @@ fn assemble_component(
                 resource_name,
                 interface_name,
                 component_idx,
+                is_definer,
             } => {
-                // Check if any component has a handle table export for this
-                // (interface, resource) — the export naming is per-(component,
-                // interface, resource) so we look first at the importer's own
-                // index, then fall back to ANY component that exports a
-                // handle table for the same (iface, rn). Consumers (like the
-                // runner in a 3-component chain) hold handles allocated by
-                // the re-exporter's ht_new and must drop them through that
-                // same table — even though they don't own a handle table
-                // themselves. See meld-core/src/merger.rs::ht_export_suffix.
+                // Look up a handle table export for this (interface, resource).
+                //
+                // Definers (importer owns the resource — `[export]`-prefixed
+                // import) MUST use either their OWN component's handle table
+                // or canonical resource ops. Falling back to a re-exporter's
+                // ht_new would store the rep in the wrong table; the definer's
+                // own canonical [resource-rep] would later return whatever was
+                // there (a small handle integer, not the actual Box pointer)
+                // and the user code's deref would trap.
+                //
+                // Consumers (importer holds someone else's handle — no
+                // `[export]` prefix) MUST route to whoever allocated the
+                // handle. After fusion that's the re-exporter component, so
+                // fall back to ANY handle table matching (iface, rn).
                 let op_prefix = match operation {
                     ResourceOp::New => "$ht_new_",
                     ResourceOp::Rep => "$ht_rep_",
                     ResourceOp::Drop => "$ht_drop_",
                 };
-                let ht_export: Option<String> = component_idx
-                    .and_then(|cidx| {
-                        let suffix = ht_export_suffix(cidx, interface_name, resource_name);
-                        let name = format!("{}{}", op_prefix, suffix);
-                        fused_info
-                            .exports
-                            .iter()
-                            .find(|(n, k, _)| *k == wasmparser::ExternalKind::Func && *n == name)
-                            .map(|_| name)
-                    })
-                    .or_else(|| {
-                        // Resource is owned by a different component (e.g. a
-                        // re-exporter); find any handle-table export matching
-                        // _<iface_safe>_<rn>.
-                        let safe_iface: String = interface_name
-                            .chars()
-                            .map(|c| match c {
-                                ':' | '/' | '@' | '.' | '-' => '_',
-                                other => other,
-                            })
-                            .collect();
-                        let tail = format!("_{}_{}", safe_iface, resource_name);
-                        fused_info
-                            .exports
-                            .iter()
-                            .find(|(n, k, _)| {
-                                *k == wasmparser::ExternalKind::Func
-                                    && n.starts_with(op_prefix)
-                                    && n.ends_with(&tail)
-                            })
-                            .map(|(n, _, _)| n.clone())
-                    });
+                let direct = component_idx.and_then(|cidx| {
+                    let suffix = ht_export_suffix(cidx, interface_name, resource_name);
+                    let name = format!("{}{}", op_prefix, suffix);
+                    fused_info
+                        .exports
+                        .iter()
+                        .find(|(n, k, _)| *k == wasmparser::ExternalKind::Func && *n == name)
+                        .map(|_| name)
+                });
+                let ht_export: Option<String> = direct.or_else(|| {
+                    if *is_definer {
+                        // Definer with no own handle table: must use
+                        // canonical resource ops. Don't borrow another
+                        // component's handle table.
+                        return None;
+                    }
+                    // Consumer-side. If THIS component itself owns a handle
+                    // table for the same (iface, rn), this import is its
+                    // own inner-component view (e.g. a re-exporter that
+                    // also imports the resource from its leaf). Use
+                    // canonical resource ops, not the re-exporter's table.
+                    let safe_iface: String = interface_name
+                        .chars()
+                        .map(|c| match c {
+                            ':' | '/' | '@' | '.' | '-' => '_',
+                            other => other,
+                        })
+                        .collect();
+                    let tail = format!("_{}_{}", safe_iface, resource_name);
+                    if let Some(cidx) = component_idx {
+                        let self_prefix = format!("$ht_new_{}_{}", cidx, safe_iface);
+                        let owns_for_resource = fused_info.exports.iter().any(|(n, k, _)| {
+                            *k == wasmparser::ExternalKind::Func
+                                && n.starts_with(&self_prefix)
+                                && n.ends_with(&tail)
+                        });
+                        if owns_for_resource {
+                            return None;
+                        }
+                    }
+                    fused_info
+                        .exports
+                        .iter()
+                        .find(|(n, k, _)| {
+                            *k == wasmparser::ExternalKind::Func
+                                && n.starts_with(op_prefix)
+                                && n.ends_with(&tail)
+                        })
+                        .map(|(n, _, _)| n.clone())
+                });
 
                 if let Some(ht_name) = ht_export {
                     // Re-exporter: alias the handle table function directly

--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -33,7 +33,7 @@
 //! 3. `canon lower` uses the fused module's real `cabi_realloc`.
 //! 4. A fixup module fills the indirect table with the lowered functions.
 
-use crate::merger::MergedModule;
+use crate::merger::{MergedModule, ht_export_suffix};
 use crate::parser::{self, ParsedComponent};
 use crate::resolver::DependencyGraph;
 use crate::{Error, MemoryStrategy, Result};
@@ -1248,12 +1248,15 @@ fn assemble_component(
                 component_idx,
             } => {
                 // Check if this component has handle table exports
-                // ($ht_new_N, $ht_rep_N, $ht_drop_N) for re-exporter routing.
+                // ($ht_new_{cidx}_{iface}_{rn}, etc.) for re-exporter routing.
+                // The export naming is per-(component, interface, resource);
+                // see meld-core/src/merger.rs::ht_export_suffix.
                 let ht_export = component_idx.and_then(|cidx| {
+                    let suffix = ht_export_suffix(cidx, interface_name, resource_name);
                     let name = match operation {
-                        ResourceOp::New => format!("$ht_new_{}", cidx),
-                        ResourceOp::Rep => format!("$ht_rep_{}", cidx),
-                        ResourceOp::Drop => format!("$ht_drop_{}", cidx),
+                        ResourceOp::New => format!("$ht_new_{}", suffix),
+                        ResourceOp::Rep => format!("$ht_rep_{}", suffix),
+                        ResourceOp::Drop => format!("$ht_drop_{}", suffix),
                     };
                     if fused_info
                         .exports

--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -1203,26 +1203,61 @@ fn assemble_component(
                 let field_name = &fused_info.func_imports[i].1;
 
                 if field_name.starts_with("[resource-drop]") {
-                    // Resource-drop from an external instance: alias the TYPE
-                    // from the instance, then canon resource.drop.
-                    let type_name = func_name
+                    // Resource-drop from an external instance.
+                    //
+                    // First check if a re-exporter handle table exists for
+                    // this resource (any iface, matching by name only). If
+                    // so, alias its ht_drop instead of emitting canonical
+                    // resource.drop — same alias-fallback as LocalResource.
+                    let resource_name = func_name
                         .strip_prefix("[resource-drop]")
                         .unwrap_or(func_name);
-                    let mut alias_section = ComponentAliasSection::new();
-                    alias_section.alias(Alias::InstanceExport {
-                        instance: *instance_idx,
-                        kind: ComponentExportKind::Type,
-                        name: type_name,
-                    });
-                    component.section(&alias_section);
+                    let stripped_rn = crate::merger::strip_dollar_suffix(resource_name);
+                    let alias_tail = format!("_{}", stripped_rn);
+                    let ht_drop_alias = fused_info
+                        .exports
+                        .iter()
+                        .find(|(n, k, _)| {
+                            *k == wasmparser::ExternalKind::Func
+                                && n.starts_with("$ht_drop_")
+                                && n.ends_with(&alias_tail)
+                        })
+                        .map(|(n, _, _)| n.clone());
+                    if let Some(ht_name) = ht_drop_alias {
+                        log::debug!(
+                            "Instance::ResourceDrop alias-fallback: import {} → {}",
+                            field_name,
+                            ht_name
+                        );
+                        let mut aliases = ComponentAliasSection::new();
+                        aliases.alias(Alias::CoreInstanceExport {
+                            instance: fused_instance,
+                            kind: ExportKind::Func,
+                            name: &ht_name,
+                        });
+                        component.section(&aliases);
+                        lowered_func_indices.push(core_func_idx);
+                        core_func_idx += 1;
+                    } else {
+                        let type_name = func_name
+                            .strip_prefix("[resource-drop]")
+                            .unwrap_or(func_name);
+                        let mut alias_section = ComponentAliasSection::new();
+                        alias_section.alias(Alias::InstanceExport {
+                            instance: *instance_idx,
+                            kind: ComponentExportKind::Type,
+                            name: type_name,
+                        });
+                        component.section(&alias_section);
 
-                    let mut canon = CanonicalFunctionSection::new();
-                    canon.resource_drop(component_type_idx);
-                    component.section(&canon);
+                        let mut canon = CanonicalFunctionSection::new();
+                        canon.resource_drop(component_type_idx);
+                        component.section(&canon);
 
-                    component_type_idx += 1;
-                    lowered_func_indices.push(core_func_idx);
-                    core_func_idx += 1;
+                        component_type_idx += 1;
+                        lowered_func_indices.push(core_func_idx);
+                        core_func_idx += 1;
+                    }
                 } else {
                     // Regular function: alias from instance, then canon lower
                     // with correct memory and realloc for the importing component.
@@ -1342,17 +1377,28 @@ fn assemble_component(
                         })
                         .collect();
                     let tail = format!("_{}_{}", safe_iface, resource_name);
+                    let alias_tail = format!("_{}", resource_name);
                     if let Some(cidx) = component_idx {
-                        let self_prefix = format!("$ht_new_{}_{}", cidx, safe_iface);
-                        let owns_for_resource = fused_info.exports.iter().any(|(n, k, _)| {
-                            *k == wasmparser::ExternalKind::Func
-                                && n.starts_with(&self_prefix)
-                                && n.ends_with(&tail)
+                        // Self-owns check: this component owns a handle table
+                        // for the SPECIFIC (iface, resource) pair. Don't
+                        // borrow another component's ht for that exact pair.
+                        // We do NOT block when the iface differs but the
+                        // resource is the same — those are `use`-aliased
+                        // resources unified at canon-type level, and they
+                        // SHOULD route through the re-exporter's ht.
+                        let self_specific = format!(
+                            "$ht_new_{}",
+                            ht_export_suffix(*cidx, interface_name, resource_name)
+                        );
+                        let owns_specific = fused_info.exports.iter().any(|(n, k, _)| {
+                            *k == wasmparser::ExternalKind::Func && *n == self_specific
                         });
-                        if owns_for_resource {
+                        if owns_specific {
                             return None;
                         }
                     }
+                    // Strict iface match first; alias-fallback by resource_name
+                    // only if strict misses (mirrors the definer-side fix).
                     fused_info
                         .exports
                         .iter()
@@ -1362,6 +1408,17 @@ fn assemble_component(
                                 && n.ends_with(&tail)
                         })
                         .map(|(n, _, _)| n.clone())
+                        .or_else(|| {
+                            fused_info
+                                .exports
+                                .iter()
+                                .find(|(n, k, _)| {
+                                    *k == wasmparser::ExternalKind::Func
+                                        && n.starts_with(op_prefix)
+                                        && n.ends_with(&alias_tail)
+                                })
+                                .map(|(n, _, _)| n.clone())
+                        })
                 });
 
                 if let Some(ht_name) = ht_export {

--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -1247,27 +1247,52 @@ fn assemble_component(
                 interface_name,
                 component_idx,
             } => {
-                // Check if this component has handle table exports
-                // ($ht_new_{cidx}_{iface}_{rn}, etc.) for re-exporter routing.
-                // The export naming is per-(component, interface, resource);
-                // see meld-core/src/merger.rs::ht_export_suffix.
-                let ht_export = component_idx.and_then(|cidx| {
-                    let suffix = ht_export_suffix(cidx, interface_name, resource_name);
-                    let name = match operation {
-                        ResourceOp::New => format!("$ht_new_{}", suffix),
-                        ResourceOp::Rep => format!("$ht_rep_{}", suffix),
-                        ResourceOp::Drop => format!("$ht_drop_{}", suffix),
-                    };
-                    if fused_info
-                        .exports
-                        .iter()
-                        .any(|(n, k, _)| *k == wasmparser::ExternalKind::Func && *n == name)
-                    {
-                        Some(name)
-                    } else {
-                        None
-                    }
-                });
+                // Check if any component has a handle table export for this
+                // (interface, resource) — the export naming is per-(component,
+                // interface, resource) so we look first at the importer's own
+                // index, then fall back to ANY component that exports a
+                // handle table for the same (iface, rn). Consumers (like the
+                // runner in a 3-component chain) hold handles allocated by
+                // the re-exporter's ht_new and must drop them through that
+                // same table — even though they don't own a handle table
+                // themselves. See meld-core/src/merger.rs::ht_export_suffix.
+                let op_prefix = match operation {
+                    ResourceOp::New => "$ht_new_",
+                    ResourceOp::Rep => "$ht_rep_",
+                    ResourceOp::Drop => "$ht_drop_",
+                };
+                let ht_export: Option<String> = component_idx
+                    .and_then(|cidx| {
+                        let suffix = ht_export_suffix(cidx, interface_name, resource_name);
+                        let name = format!("{}{}", op_prefix, suffix);
+                        fused_info
+                            .exports
+                            .iter()
+                            .find(|(n, k, _)| *k == wasmparser::ExternalKind::Func && *n == name)
+                            .map(|_| name)
+                    })
+                    .or_else(|| {
+                        // Resource is owned by a different component (e.g. a
+                        // re-exporter); find any handle-table export matching
+                        // _<iface_safe>_<rn>.
+                        let safe_iface: String = interface_name
+                            .chars()
+                            .map(|c| match c {
+                                ':' | '/' | '@' | '.' | '-' => '_',
+                                other => other,
+                            })
+                            .collect();
+                        let tail = format!("_{}_{}", safe_iface, resource_name);
+                        fused_info
+                            .exports
+                            .iter()
+                            .find(|(n, k, _)| {
+                                *k == wasmparser::ExternalKind::Func
+                                    && n.starts_with(op_prefix)
+                                    && n.ends_with(&tail)
+                            })
+                            .map(|(n, _, _)| n.clone())
+                    });
 
                 if let Some(ht_name) = ht_export {
                     // Re-exporter: alias the handle table function directly

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -82,6 +82,21 @@ pub struct FuserConfig {
 
     /// Output format: core module (default) or P2 component
     pub output_format: OutputFormat,
+
+    /// Resources whose representation is opaque to wit-bindgen-rust user code
+    /// (constructed by `pulseengine/wit-bindgen feat/opaque-rep-attribute` with
+    /// `--opaque-export-resources`). Each entry is `(interface, resource_name)`.
+    ///
+    /// Opaque-rep resources are routed differently than standard Box-pattern
+    /// resources:
+    /// 1. `merger.rs::allocate_handle_tables` skips them — their reps are
+    ///    already valid integer handles, no parallel handle table needed.
+    /// 2. `component_wrap.rs::local_resource_types` keys them by
+    ///    `(component_idx, resource_name)` rather than `resource_name` alone,
+    ///    giving each component its own wasmtime resource type. This matches
+    ///    the un-fused composition's semantics where each component owns
+    ///    its own resource table.
+    pub opaque_resources: Vec<(String, String)>,
 }
 
 impl Default for FuserConfig {
@@ -93,6 +108,7 @@ impl Default for FuserConfig {
             preserve_names: false,
             custom_sections: CustomSectionHandling::Merge,
             output_format: OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
         }
     }
 }
@@ -274,7 +290,8 @@ impl Fuser {
 
         // Step 2: Merge modules
         log::info!("Merging {} core modules", stats.modules_merged);
-        let merger = Merger::new(self.config.memory_strategy, self.config.address_rebasing);
+        let merger = Merger::new(self.config.memory_strategy, self.config.address_rebasing)
+            .with_opaque_resources(self.config.opaque_resources.clone());
         let mut merged = merger.merge(&self.components, &graph)?;
         stats.total_functions = merged.functions.len();
         stats.total_exports = merged.exports.len();
@@ -336,6 +353,7 @@ impl Fuser {
                 &graph,
                 &merged,
                 self.config.memory_strategy,
+                &self.config.opaque_resources,
             )?
         } else {
             output

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -862,9 +862,39 @@ impl Merger {
                             .strip_prefix("[export]")
                             .unwrap_or(iface_with_prefix);
                         let key_target = if iface_with_prefix.starts_with("[export]") {
-                            // Importer's own export — look up by self.
+                            // Importer's own export — look up by self first.
                             let key = (comp_idx, iface.to_string(), rn.to_string());
-                            merged.handle_tables.get(&key)
+                            merged.handle_tables.get(&key).or_else(|| {
+                                // Resource-alias fallback: when a different
+                                // component re-exports THIS resource via
+                                // `use` (e.g., intermediate has `use
+                                // test.{float}` re-exporting leaf's
+                                // test.float as exports.float), wasmtime
+                                // unifies them into one canonical type. The
+                                // re-exporter's handle table is the only
+                                // storage that knows the memory-pointer
+                                // handles minted by ht_new — definer-side
+                                // [resource-*] must route there too, or
+                                // peers will hand it pointers it can't
+                                // dereference. Match by resource_name only
+                                // since the iface differs across the alias.
+                                let found = merged
+                                    .handle_tables
+                                    .iter()
+                                    .find(|((_, _, r), _)| r == rn)
+                                    .map(|(_, ht)| ht);
+                                if found.is_some() {
+                                    log::info!(
+                                        "alias-fallback: comp {} mod {} import {}/{} → ht for resource '{}'",
+                                        comp_idx,
+                                        mod_idx,
+                                        iface,
+                                        imp.name,
+                                        rn,
+                                    );
+                                }
+                                found
+                            })
                         } else {
                             // Consumer-side import. If THIS component itself
                             // re-exports (iface, rn) — has its own handle

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -636,14 +636,68 @@ impl Merger {
                 });
             }
 
-            // Generate ht_drop: mem[handle] = 0
+            // Find the resource's dtor function (if any) so ht_drop can
+            // invoke it before zeroing the slot. wit-bindgen-rust emits
+            // `<iface>#[dtor]<rn>` as a core export for each component that
+            // owns a Box-backed rep. For the re-exporter that owns this
+            // handle table, the matching dtor is the one whose function
+            // origin component matches `comp_idx` (in the dedup-suffixed
+            // export list, multiple variants exist; we want the one
+            // belonging to comp_idx specifically).
+            let dtor_export_pattern = format!("#[dtor]{}", rn);
+            let dtor_func_idx: Option<u32> = merged
+                .exports
+                .iter()
+                .filter(|e| {
+                    matches!(e.kind, EncoderExportKind::Func)
+                        && e.name.contains(&dtor_export_pattern)
+                })
+                .find_map(|e| {
+                    let import_count = merged.import_counts.func;
+                    if e.index < import_count {
+                        return None;
+                    }
+                    let local_idx = (e.index - import_count) as usize;
+                    let func = merged.functions.get(local_idx)?;
+                    if func.origin.0 == comp_idx {
+                        Some(e.index)
+                    } else {
+                        None
+                    }
+                });
+            if let Some(idx) = dtor_func_idx {
+                log::info!(
+                    "ht_drop for {}/{} in component {} will invoke dtor func {}",
+                    iface,
+                    rn,
+                    comp_idx,
+                    idx,
+                );
+            }
+
+            // Generate ht_drop: load rep, optionally call dtor(rep), zero slot.
+            // Skip the dtor invocation when ht_drop is called with handle=0
+            // (used as a sentinel by the canonical ABI). Using if-then to
+            // avoid double-free if the same handle is dropped twice.
             let drop_func_idx = merged.import_counts.func + merged.functions.len() as u32;
             {
                 let mut body = Function::new([]);
                 body.instruction(&Instruction::LocalGet(0)); // [handle]
+                body.instruction(&Instruction::I32Eqz); // [handle == 0]
+                body.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                body.instruction(&Instruction::Else);
+                if let Some(dtor_idx) = dtor_func_idx {
+                    // Load the rep stored at this handle slot, then call dtor(rep).
+                    body.instruction(&Instruction::LocalGet(0));
+                    body.instruction(&Instruction::I32Load(mem_arg));
+                    body.instruction(&Instruction::Call(dtor_idx));
+                }
+                // Zero the slot regardless of whether a dtor was called.
+                body.instruction(&Instruction::LocalGet(0));
                 body.instruction(&Instruction::I32Const(0));
-                body.instruction(&Instruction::I32Store(mem_arg)); // mem[handle] = 0
-                body.instruction(&Instruction::End);
+                body.instruction(&Instruction::I32Store(mem_arg));
+                body.instruction(&Instruction::End); // end if
+                body.instruction(&Instruction::End); // end function
                 merged.functions.push(MergedFunction {
                     type_idx: type_i32_to_void,
                     body,

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -832,16 +832,24 @@ impl Merger {
                             let key = (comp_idx, iface.to_string(), rn.to_string());
                             merged.handle_tables.get(&key)
                         } else {
-                            // Consumer-side import — find any handle table for
-                            // this (iface, rn) regardless of which component
-                            // owns it. In well-formed compositions there's at
-                            // most one re-exporter per resource so this is
-                            // unambiguous.
-                            merged
-                                .handle_tables
-                                .iter()
-                                .find(|((_, i, r), _)| i == iface && r == rn)
-                                .map(|(_, ht)| ht)
+                            // Consumer-side import. If THIS component itself
+                            // re-exports (iface, rn) — has its own handle
+                            // table for the same resource — then this import
+                            // is the inner-component (definer) view, NOT the
+                            // re-exporter view. Use canonical resource ops
+                            // (don't redirect). Otherwise the importer is a
+                            // pure consumer and the handle was minted by the
+                            // re-exporter's ht_new — route through that table.
+                            let self_key = (comp_idx, iface.to_string(), rn.to_string());
+                            if merged.handle_tables.contains_key(&self_key) {
+                                None
+                            } else {
+                                merged
+                                    .handle_tables
+                                    .iter()
+                                    .find(|((_, i, r), _)| i == iface && r == rn)
+                                    .map(|(_, ht)| ht)
+                            }
                         };
                         if let Some(ht) = key_target {
                             let target = match op_kind.unwrap() {

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -374,6 +374,10 @@ fn effective_module_name(unresolved: &crate::resolver::UnresolvedImport) -> &str
 pub struct Merger {
     memory_strategy: MemoryStrategy,
     address_rebasing: bool,
+    /// (interface, resource_name) tuples marked opaque-rep — skip handle
+    /// table allocation for these resources because their reps are already
+    /// valid integer handles (no Box dereferencing in user code).
+    opaque_resources: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone)]
@@ -389,7 +393,14 @@ impl Merger {
         Self {
             memory_strategy,
             address_rebasing,
+            opaque_resources: Vec::new(),
         }
+    }
+
+    /// Mark resources as opaque-rep so handle table allocation skips them.
+    pub fn with_opaque_resources(mut self, opaque: Vec<(String, String)>) -> Self {
+        self.opaque_resources = opaque;
+        self
     }
 
     fn compute_shared_memory_plan(
@@ -508,13 +519,36 @@ impl Merger {
     /// table at the start of the new page. Adds a mutable global for the
     /// next-allocation pointer and generates ht_new/ht_rep/ht_drop functions.
     #[allow(dead_code)]
-    fn allocate_handle_tables(graph: &DependencyGraph, merged: &mut MergedModule) -> Result<()> {
+    fn allocate_handle_tables(
+        graph: &DependencyGraph,
+        merged: &mut MergedModule,
+        opaque_resources: &[(String, String)],
+    ) -> Result<()> {
         // Handle table capacity: 256 entries = 1024 bytes (fits in 1 page)
         const HT_CAPACITY: u32 = 256;
         const ENTRY_SIZE: u32 = 4; // i32
 
         for (comp_idx, iface, rn) in &graph.reexporter_resources {
             let comp_idx = *comp_idx;
+            // Opaque-rep resources still get ht_* slots in handle_tables, but
+            // the function bodies are pure identity (no memory storage):
+            //   ht_new(rep)  → rep   (the rep IS the handle)
+            //   ht_rep(h)    → h     (the handle IS the rep)
+            //   ht_drop(h)   → ()    (no cleanup needed)
+            // Path B's redirect routes [resource-*] imports through these
+            // same ht_* functions whether opaque or not, so opaque imports
+            // bypass wasmtime's canonical resource layer entirely (which
+            // would otherwise reject cross-component handle passing for
+            // per-component-typed resources).
+            // Opaque-rep gets the same memory-backed ht_* as standard
+            // resources — the rep storage semantics are the same (ht_new
+            // allocates a fresh handle and stores the rep, ht_rep reads
+            // it back). The DIFFERENCE with --opaque-rep is in the wrapper:
+            // opaque resources use a separate-typed local_resource_types
+            // entry so wasmtime's canonical resource layer doesn't conflate
+            // them with standard Box-pattern reps.
+            let _is_opaque = opaque_resources.iter().any(|(i, r)| i == iface && r == rn);
+
             // Find merged memory index for this component's memory 0
             let memory_idx = match merged.memory_index_map.get(&(comp_idx, 0, 0)) {
                 Some(&idx) => idx,
@@ -765,7 +799,7 @@ impl Merger {
         // re-exporter's wit-bindgen code expects 4-byte-aligned memory
         // pointers as handles, not sequential canonical ABI handles.
         if !graph.reexporter_resources.is_empty() {
-            Self::allocate_handle_tables(graph, &mut merged)?;
+            Self::allocate_handle_tables(graph, &mut merged, &self.opaque_resources)?;
 
             // Remap [resource-*] imports to handle-table functions, with
             // per-resource discrimination. For each component that owns a

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -904,8 +904,28 @@ impl Merger {
                             // (don't redirect). Otherwise the importer is a
                             // pure consumer and the handle was minted by the
                             // re-exporter's ht_new — route through that table.
-                            let self_key = (comp_idx, iface.to_string(), rn.to_string());
-                            if merged.handle_tables.contains_key(&self_key) {
+                            //
+                            // Same alias-fallback as the definer branch: when
+                            // strict `(i, r)` matches no handle table, fall
+                            // back to matching by resource_name only. This
+                            // catches consumer imports of resources unified
+                            // via `use other-iface.{rn}` (e.g. runner's
+                            // `test:resource-floats/test [resource-drop]float`
+                            // when only `(3, "exports", "float")` ht exists).
+                            //
+                            // Self-owns check: this component owns a handle
+                            // table for the SPECIFIC (iface, rn) pair. We do
+                            // NOT block when the iface differs but the
+                            // resource name is the same — those are
+                            // `use`-aliased resources unified at canon-type
+                            // level, and they SHOULD route through the
+                            // re-exporter's ht.
+                            let self_owns_specific = merged.handle_tables.contains_key(&(
+                                comp_idx,
+                                iface.to_string(),
+                                rn.to_string(),
+                            ));
+                            if self_owns_specific {
                                 None
                             } else {
                                 merged
@@ -913,6 +933,13 @@ impl Merger {
                                     .iter()
                                     .find(|((_, i, r), _)| i == iface && r == rn)
                                     .map(|(_, ht)| ht)
+                                    .or_else(|| {
+                                        merged
+                                            .handle_tables
+                                            .iter()
+                                            .find(|((_, _, r), _)| r == rn)
+                                            .map(|(_, ht)| ht)
+                                    })
                             }
                         };
                         if let Some(ht) = key_target {

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -130,8 +130,13 @@ pub struct MergedModule {
     /// Maps (component_idx, resource_name) → merged function index for [resource-new].
     pub resource_new_by_component: HashMap<(usize, String), u32>,
 
-    /// Per-component handle table info for re-exporters.
-    pub handle_tables: HashMap<usize, HandleTableInfo>,
+    /// Per-resource handle table info for re-exporters.
+    /// Key is (owning_component_idx, interface, resource_name) — a single
+    /// re-exporter component may have multiple entries when it re-exports
+    /// multiple resources, and routing must discriminate per-resource so the
+    /// re-exporter's own export resource gets a handle table while imports
+    /// it passes through do not.
+    pub handle_tables: HashMap<(usize, String, String), HandleTableInfo>,
 
     /// Task.return shim info: maps merged import index of [task-return]N
     /// to the global indices where the shim stores result values.
@@ -277,6 +282,23 @@ struct ImportDedupInfo {
 /// Strip `@major.minor.patch` version suffix from a WASI module name.
 ///
 /// `"wasi:io/error@0.2.0"` → `"wasi:io/error"`; `"env"` → `"env"`
+/// Build a unique export-name suffix for a per-resource handle table.
+///
+/// Combines component index, sanitised interface, and resource name into
+/// one identifier. The interface sanitisation replaces ':', '/', '@', '.'
+/// (illegal in WASM export names? all are legal but conventionally avoided)
+/// with '_'.
+pub(crate) fn ht_export_suffix(comp_idx: usize, interface: &str, resource_name: &str) -> String {
+    let safe_iface: String = interface
+        .chars()
+        .map(|c| match c {
+            ':' | '/' | '@' | '.' | '-' => '_',
+            other => other,
+        })
+        .collect();
+    format!("{}_{}_{}", comp_idx, safe_iface, resource_name)
+}
+
 fn normalize_wasi_module_name(name: &str) -> &str {
     match name.rfind('@') {
         Some(pos) if name[..pos].contains(':') => &name[..pos],
@@ -477,14 +499,17 @@ impl Merger {
         const HT_CAPACITY: u32 = 256;
         const ENTRY_SIZE: u32 = 4; // i32
 
-        for &comp_idx in &graph.reexporter_components {
+        for (comp_idx, iface, rn) in &graph.reexporter_resources {
+            let comp_idx = *comp_idx;
             // Find merged memory index for this component's memory 0
             let memory_idx = match merged.memory_index_map.get(&(comp_idx, 0, 0)) {
                 Some(&idx) => idx,
                 None => continue, // No memory — skip (shouldn't happen for real components)
             };
 
-            // Determine table base: grow memory by 1 page, place table at start of new page
+            // Determine table base: grow memory by 1 page, place table at start
+            // of new page. Each (component, resource) gets its own page so the
+            // tables don't collide.
             let mem_slot = (memory_idx - merged.import_counts.memory) as usize;
             let current_pages = if mem_slot < merged.memories.len() {
                 merged.memories[mem_slot].minimum
@@ -579,7 +604,7 @@ impl Merger {
             }
 
             merged.handle_tables.insert(
-                comp_idx,
+                (comp_idx, iface.clone(), rn.clone()),
                 HandleTableInfo {
                     memory_idx,
                     next_ptr_global,
@@ -592,25 +617,30 @@ impl Merger {
             );
 
             // Export handle table functions so the P2 wrapper can alias them.
+            // Naming: $ht_new_{comp}_{iface_safe}_{rn} so multiple resources
+            // per component don't collide.
+            let suffix = ht_export_suffix(comp_idx, iface, rn);
             merged.exports.push(MergedExport {
-                name: format!("$ht_new_{}", comp_idx),
+                name: format!("$ht_new_{}", suffix),
                 kind: EncoderExportKind::Func,
                 index: new_func_idx,
             });
             merged.exports.push(MergedExport {
-                name: format!("$ht_rep_{}", comp_idx),
+                name: format!("$ht_rep_{}", suffix),
                 kind: EncoderExportKind::Func,
                 index: rep_func_idx,
             });
             merged.exports.push(MergedExport {
-                name: format!("$ht_drop_{}", comp_idx),
+                name: format!("$ht_drop_{}", suffix),
                 kind: EncoderExportKind::Func,
                 index: drop_func_idx,
             });
 
             log::info!(
-                "handle table for component {}: memory={}, base=0x{:x}, global={}, funcs=({},{},{})",
+                "handle table for component {} resource {}/{}: memory={}, base=0x{:x}, global={}, funcs=({},{},{})",
                 comp_idx,
+                iface,
+                rn,
                 memory_idx,
                 table_base_addr,
                 next_ptr_global,
@@ -720,14 +750,28 @@ impl Merger {
         // These are needed for 3-component resource chains where the
         // re-exporter's wit-bindgen code expects 4-byte-aligned memory
         // pointers as handles, not sequential canonical ABI handles.
-        if !graph.reexporter_components.is_empty() {
+        if !graph.reexporter_resources.is_empty() {
             Self::allocate_handle_tables(graph, &mut merged)?;
 
-            // Remap re-exporter's resource.rep/new/drop imports to handle table
-            // functions, then re-rewrite affected function bodies so call
-            // instructions pick up the corrected indices.
+            // Remap [resource-*] imports to handle-table functions, with
+            // per-resource discrimination. For each component that owns a
+            // handle table, walk its core modules' imports and redirect only
+            // those imports whose (interface, resource_name) matches a
+            // registered handle table for this component as owner.
+            //
+            // The owner of `[export]<iface>.[resource-*]<rn>` is the
+            // importing component itself (it's the component's own export
+            // resource). The owner of `<iface>.[resource-*]<rn>` (no
+            // [export] prefix) is whatever component DEFINES the resource —
+            // that's resource_graph.resource_definer(iface, rn). Imports
+            // routed at the leaf-definer's helpers should NOT be rewritten
+            // through any other component's handle table; they must call
+            // the natural canonical-ABI handler in their owning component.
             let mut affected_modules: Vec<(usize, usize)> = Vec::new();
-            for (&comp_idx, ht) in &merged.handle_tables {
+            // Index of which components have handle tables, for fast checks.
+            let comps_with_ht: HashSet<usize> =
+                merged.handle_tables.keys().map(|(c, _, _)| *c).collect();
+            for &comp_idx in &comps_with_ht {
                 let component = &components[comp_idx];
                 for (mod_idx, module) in component.core_modules.iter().enumerate() {
                     let mut import_func_idx = 0u32;
@@ -736,20 +780,54 @@ impl Merger {
                         if !matches!(imp.kind, crate::parser::ImportKind::Function(_)) {
                             continue;
                         }
-                        if imp.name.starts_with("[resource-rep]") {
+                        // Parse: which (iface, resource_name) and which op?
+                        let (op_kind, rn) =
+                            if let Some(rn) = imp.name.strip_prefix("[resource-rep]") {
+                                (Some("rep"), rn)
+                            } else if let Some(rn) = imp.name.strip_prefix("[resource-new]") {
+                                (Some("new"), rn)
+                            } else if let Some(rn) = imp.name.strip_prefix("[resource-drop]") {
+                                (Some("drop"), rn)
+                            } else {
+                                (None, "")
+                            };
+                        if op_kind.is_none() {
+                            import_func_idx += 1;
+                            continue;
+                        }
+                        // Strip [export] prefix from the import module name.
+                        // If present, the importer is the owner; else look up
+                        // the definer via the resource graph.
+                        let iface_with_prefix = imp.module.as_str();
+                        let iface = iface_with_prefix
+                            .strip_prefix("[export]")
+                            .unwrap_or(iface_with_prefix);
+                        let owner = if iface_with_prefix.starts_with("[export]") {
+                            // Component's own export — owner is self.
+                            comp_idx
+                        } else if let Some(rg) = graph.resource_graph.as_ref() {
+                            match rg.resource_definer(iface, rn) {
+                                Some(def) => def,
+                                None => {
+                                    import_func_idx += 1;
+                                    continue;
+                                }
+                            }
+                        } else {
+                            import_func_idx += 1;
+                            continue;
+                        };
+                        let key = (owner, iface.to_string(), rn.to_string());
+                        if let Some(ht) = merged.handle_tables.get(&key) {
+                            let target = match op_kind.unwrap() {
+                                "rep" => ht.rep_func,
+                                "new" => ht.new_func,
+                                "drop" => ht.drop_func,
+                                _ => unreachable!(),
+                            };
                             merged
                                 .function_index_map
-                                .insert((comp_idx, mod_idx, import_func_idx), ht.rep_func);
-                            changed = true;
-                        } else if imp.name.starts_with("[resource-new]") {
-                            merged
-                                .function_index_map
-                                .insert((comp_idx, mod_idx, import_func_idx), ht.new_func);
-                            changed = true;
-                        } else if imp.name.starts_with("[resource-drop]") {
-                            merged
-                                .function_index_map
-                                .insert((comp_idx, mod_idx, import_func_idx), ht.drop_func);
+                                .insert((comp_idx, mod_idx, import_func_idx), target);
                             changed = true;
                         }
                         import_func_idx += 1;
@@ -3257,6 +3335,7 @@ mod tests {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,
@@ -3378,6 +3457,7 @@ mod tests {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,
@@ -3429,6 +3509,7 @@ mod tests {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,
@@ -3488,6 +3569,7 @@ mod tests {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,
@@ -3538,6 +3620,7 @@ mod tests {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,
@@ -3592,6 +3675,7 @@ mod tests {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,
@@ -3723,6 +3807,7 @@ mod tests {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,
@@ -3880,6 +3965,7 @@ mod tests {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,
@@ -4030,6 +4116,7 @@ mod tests {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -288,6 +288,20 @@ struct ImportDedupInfo {
 /// one identifier. The interface sanitisation replaces ':', '/', '@', '.'
 /// (illegal in WASM export names? all are legal but conventionally avoided)
 /// with '_'.
+/// Strip a trailing `$N` dedup suffix from a resource name. Meld appends
+/// these when multiple components import the same `[resource-*]X` helper —
+/// the canonical resource name (used for handle-table lookup and the
+/// canonical-ABI) doesn't include the suffix.
+pub(crate) fn strip_dollar_suffix(s: &str) -> &str {
+    if let Some(dollar_pos) = s.rfind('$') {
+        let suffix = &s[dollar_pos + 1..];
+        if !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()) {
+            return &s[..dollar_pos];
+        }
+    }
+    s
+}
+
 pub(crate) fn ht_export_suffix(comp_idx: usize, interface: &str, resource_name: &str) -> String {
     let safe_iface: String = interface
         .chars()
@@ -768,10 +782,12 @@ impl Merger {
             // through any other component's handle table; they must call
             // the natural canonical-ABI handler in their owning component.
             let mut affected_modules: Vec<(usize, usize)> = Vec::new();
-            // Index of which components have handle tables, for fast checks.
-            let comps_with_ht: HashSet<usize> =
-                merged.handle_tables.keys().map(|(c, _, _)| *c).collect();
-            for &comp_idx in &comps_with_ht {
+            // Iterate ALL components, not just those with handle tables.
+            // A pure consumer (e.g. the runner in a 3-component chain) holds
+            // handles allocated by the re-exporter's ht_new and must drop
+            // them through the same handle table — its [resource-drop]
+            // imports also need redirection.
+            for (comp_idx, _component) in components.iter().enumerate() {
                 let component = &components[comp_idx];
                 for (mod_idx, module) in component.core_modules.iter().enumerate() {
                     let mut import_func_idx = 0u32;
@@ -781,7 +797,10 @@ impl Merger {
                             continue;
                         }
                         // Parse: which (iface, resource_name) and which op?
-                        let (op_kind, rn) =
+                        // Strip optional `$N` dedup suffix that meld appends
+                        // when multiple components import the same resource
+                        // helper — the canonical resource name is the same.
+                        let (op_kind, rn_raw) =
                             if let Some(rn) = imp.name.strip_prefix("[resource-rep]") {
                                 (Some("rep"), rn)
                             } else if let Some(rn) = imp.name.strip_prefix("[resource-new]") {
@@ -795,30 +814,36 @@ impl Merger {
                             import_func_idx += 1;
                             continue;
                         }
+                        let rn = strip_dollar_suffix(rn_raw);
                         // Strip [export] prefix from the import module name.
-                        // If present, the importer is the owner; else look up
-                        // the definer via the resource graph.
+                        // If present (importer's own export resource), the
+                        // owner is self. Otherwise the importer is consuming
+                        // a resource from elsewhere — find ANY component that
+                        // has a handle table for (iface, rn). That's the
+                        // re-exporter that allocated the handles being passed
+                        // around; consumers must route their [resource-*]
+                        // calls through that same table to stay consistent.
                         let iface_with_prefix = imp.module.as_str();
                         let iface = iface_with_prefix
                             .strip_prefix("[export]")
                             .unwrap_or(iface_with_prefix);
-                        let owner = if iface_with_prefix.starts_with("[export]") {
-                            // Component's own export — owner is self.
-                            comp_idx
-                        } else if let Some(rg) = graph.resource_graph.as_ref() {
-                            match rg.resource_definer(iface, rn) {
-                                Some(def) => def,
-                                None => {
-                                    import_func_idx += 1;
-                                    continue;
-                                }
-                            }
+                        let key_target = if iface_with_prefix.starts_with("[export]") {
+                            // Importer's own export — look up by self.
+                            let key = (comp_idx, iface.to_string(), rn.to_string());
+                            merged.handle_tables.get(&key)
                         } else {
-                            import_func_idx += 1;
-                            continue;
+                            // Consumer-side import — find any handle table for
+                            // this (iface, rn) regardless of which component
+                            // owns it. In well-formed compositions there's at
+                            // most one re-exporter per resource so this is
+                            // unambiguous.
+                            merged
+                                .handle_tables
+                                .iter()
+                                .find(|((_, i, r), _)| i == iface && r == rn)
+                                .map(|(_, ht)| ht)
                         };
-                        let key = (owner, iface.to_string(), rn.to_string());
-                        if let Some(ht) = merged.handle_tables.get(&key) {
+                        if let Some(ht) = key_target {
                             let target = match op_kind.unwrap() {
                                 "rep" => ht.rep_func,
                                 "new" => ht.new_func,

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -639,18 +639,24 @@ impl Merger {
             // Find the resource's dtor function (if any) so ht_drop can
             // invoke it before zeroing the slot. wit-bindgen-rust emits
             // `<iface>#[dtor]<rn>` as a core export for each component that
-            // owns a Box-backed rep. For the re-exporter that owns this
-            // handle table, the matching dtor is the one whose function
-            // origin component matches `comp_idx` (in the dedup-suffixed
-            // export list, multiple variants exist; we want the one
-            // belonging to comp_idx specifically).
-            let dtor_export_pattern = format!("#[dtor]{}", rn);
+            // owns a Box-backed rep.
+            //
+            // Match by EXACT `<iface>#[dtor]<rn>` (with optional `$N` dedup
+            // suffix tolerance). A previous version used `name.contains(...)`
+            // which collided when one component defines the same resource
+            // name across multiple interfaces (e.g. `resource_floats` has
+            // dtors for `exports#[dtor]float`, `imports#[dtor]float`, and
+            // `test:resource-floats/test#[dtor]float` — the contains-match
+            // picked the first regardless of iface). Exact match plus the
+            // origin-comp filter selects the right dtor unambiguously.
+            let exact_dtor_export = format!("{}#[dtor]{}", iface, rn);
+            let exact_dtor_dollar = format!("{}#[dtor]{}$", iface, rn);
             let dtor_func_idx: Option<u32> = merged
                 .exports
                 .iter()
                 .filter(|e| {
                     matches!(e.kind, EncoderExportKind::Func)
-                        && e.name.contains(&dtor_export_pattern)
+                        && (e.name == exact_dtor_export || e.name.starts_with(&exact_dtor_dollar))
                 })
                 .find_map(|e| {
                     let import_count = merged.import_counts.func;

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -35,6 +35,13 @@ pub struct DependencyGraph {
 
     /// Component indices that re-export resources (need per-component handle tables).
     pub reexporter_components: Vec<usize>,
+
+    /// Re-exporter (component, interface, resource_name) tuples that need their
+    /// own handle table. A single re-exporter component may appear multiple
+    /// times if it re-exports several distinct resources — one entry per
+    /// (component, resource) pair so handle table allocation and routing can
+    /// discriminate per-resource rather than per-component.
+    pub reexporter_resources: Vec<(usize, String, String)>,
 }
 
 /// An import that couldn't be resolved within the component set
@@ -1185,6 +1192,7 @@ impl Resolver {
             module_resolutions: Vec::new(),
             resource_graph: None,
             reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
         };
 
         // Build export index
@@ -1279,23 +1287,53 @@ impl Resolver {
             }
         }
 
-        // Identify re-exporter components: those targeted by adapter sites with
-        // callee_defines_resource=false (they re-export resources defined elsewhere).
+        // Identify re-exporter components and the specific resources each
+        // re-exports. A component is a re-exporter for resource R if it's
+        // targeted by an adapter site whose resource op for R has
+        // callee_defines_resource=false (i.e. the resource lives elsewhere
+        // and this component just re-exposes it).
+        //
+        // We track both the per-component set (used by older redirect logic
+        // and by tests) and the per-resource set (used by handle-table
+        // allocation and per-resource routing).
         {
             let mut reexporter_set: HashSet<usize> = HashSet::new();
+            let mut reexporter_resource_set: HashSet<(usize, String, String)> = HashSet::new();
+
+            let extract_iface_and_resource = |op: &ResolvedResourceOp| -> Option<(String, String)> {
+                let iface = op
+                    .import_module
+                    .strip_prefix("[export]")
+                    .unwrap_or(&op.import_module)
+                    .to_string();
+                let rn = op
+                    .import_field
+                    .strip_prefix("[resource-rep]")
+                    .or_else(|| op.import_field.strip_prefix("[resource-new]"))
+                    .or_else(|| op.import_field.strip_prefix("[resource-drop]"))?;
+                Some((iface, rn.to_string()))
+            };
+
             for site in &graph.adapter_sites {
                 for op in &site.requirements.resource_params {
                     if !op.callee_defines_resource {
                         reexporter_set.insert(site.to_component);
+                        if let Some((iface, rn)) = extract_iface_and_resource(op) {
+                            reexporter_resource_set.insert((site.to_component, iface, rn));
+                        }
                     }
                 }
                 for op in &site.requirements.resource_results {
                     if !op.callee_defines_resource {
                         reexporter_set.insert(site.to_component);
+                        if let Some((iface, rn)) = extract_iface_and_resource(op) {
+                            reexporter_resource_set.insert((site.to_component, iface, rn));
+                        }
                     }
                 }
             }
             graph.reexporter_components = reexporter_set.into_iter().collect();
+            graph.reexporter_resources = reexporter_resource_set.into_iter().collect();
         }
 
         // Note: the re-exporter caller_already_converted logic (from PR #81)

--- a/meld-core/tests/adapter_safety.rs
+++ b/meld-core/tests/adapter_safety.rs
@@ -428,6 +428,7 @@ fn test_sr12_adapter_generation_for_string_param() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);
@@ -813,6 +814,7 @@ fn test_sr13_cabi_realloc_targets_correct_memory() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);
@@ -1226,6 +1228,7 @@ fn test_sr15_list_copy_length() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);
@@ -1719,6 +1722,7 @@ fn test_sr16_inner_pointer_fixup_list_string() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);
@@ -2005,6 +2009,7 @@ fn test_sr17_utf8_to_utf16_string_transcoding() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);

--- a/meld-core/tests/file_ops_validate.rs
+++ b/meld-core/tests/file_ops_validate.rs
@@ -205,6 +205,7 @@ fn file_ops_fuses_and_validates() {
     let config = FuserConfig {
         memory_strategy: MemoryStrategy::MultiMemory,
         output_format: OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
         ..Default::default()
     };
     let mut fuser = Fuser::new(config);

--- a/meld-core/tests/multi_memory.rs
+++ b/meld-core/tests/multi_memory.rs
@@ -210,6 +210,7 @@ fn test_multi_memory_separate_memories() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Merge,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);
@@ -260,6 +261,7 @@ fn test_multi_memory_preserves_isolation() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Merge,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);

--- a/meld-core/tests/nested_component.rs
+++ b/meld-core/tests/nested_component.rs
@@ -68,6 +68,7 @@ fn test_fuse_composed_p2_component() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);

--- a/meld-core/tests/realloc_safety.rs
+++ b/meld-core/tests/realloc_safety.rs
@@ -508,6 +508,7 @@ fn ls_a_7_every_realloc_call_has_null_guard() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);

--- a/meld-core/tests/release_components.rs
+++ b/meld-core/tests/release_components.rs
@@ -73,6 +73,7 @@ fn try_fuse(path: &str, name: &str) -> (bool, usize, String) {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);
@@ -230,6 +231,7 @@ fn test_fused_output_validates() {
             preserve_names: false,
             custom_sections: meld_core::CustomSectionHandling::Drop,
             output_format: OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
         };
 
         let mut fuser = Fuser::new(config);
@@ -321,6 +323,7 @@ fn test_p1_adapter_detection_with_instances() {
             preserve_names: false,
             custom_sections: meld_core::CustomSectionHandling::Drop,
             output_format: OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
         };
         let mut fuser = Fuser::new(config);
         if fuser.add_component_named(&bytes, Some(file)).is_err() {
@@ -400,6 +403,7 @@ fn test_reasonable_memory_count() {
             preserve_names: false,
             custom_sections: meld_core::CustomSectionHandling::Drop,
             output_format: OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
         };
 
         let mut fuser = Fuser::new(config);
@@ -485,6 +489,7 @@ fn test_write_fused_output_for_runtime() {
             preserve_names: true,
             custom_sections: meld_core::CustomSectionHandling::Drop,
             output_format: OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
         };
 
         let mut fuser = Fuser::new(config);
@@ -549,6 +554,7 @@ fn test_no_duplicate_imports() {
             preserve_names: false,
             custom_sections: meld_core::CustomSectionHandling::Drop,
             output_format: OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
         };
 
         let mut fuser = Fuser::new(config);
@@ -632,6 +638,7 @@ fn test_adapter_generation_for_release_components() {
             preserve_names: false,
             custom_sections: meld_core::CustomSectionHandling::Drop,
             output_format: OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
         };
 
         let mut fuser = Fuser::new(config);
@@ -698,6 +705,7 @@ fn test_adapter_call_site_wiring() {
             preserve_names: false,
             custom_sections: meld_core::CustomSectionHandling::Drop,
             output_format: OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
         };
 
         let mut fuser = Fuser::new(config);
@@ -848,6 +856,7 @@ fn test_no_stale_resource_drop_versions() {
             preserve_names: false,
             custom_sections: meld_core::CustomSectionHandling::Drop,
             output_format: OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
         };
 
         let mut fuser = Fuser::new(config);
@@ -931,6 +940,7 @@ fn test_component_wrap_validates() {
             preserve_names: false,
             custom_sections: meld_core::CustomSectionHandling::Drop,
             output_format: OutputFormat::Component,
+            opaque_resources: Vec::new(),
         };
 
         let mut fuser = Fuser::new(config);

--- a/meld-core/tests/runtime_from_exports.rs
+++ b/meld-core/tests/runtime_from_exports.rs
@@ -132,6 +132,7 @@ fn test_from_exports_resolution_runtime() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);
@@ -181,6 +182,7 @@ fn test_from_exports_shared_memory_strategy() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);
@@ -230,6 +232,7 @@ fn test_from_exports_function_count() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);

--- a/meld-core/tests/runtime_intra_adapter.rs
+++ b/meld-core/tests/runtime_intra_adapter.rs
@@ -213,6 +213,7 @@ fn test_intra_component_three_module_fusion() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);
@@ -264,6 +265,7 @@ fn test_intra_component_memory_count() {
         preserve_names: false,
         custom_sections: meld_core::CustomSectionHandling::Drop,
         output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -62,6 +62,7 @@ fn fuse_fixture(name: &str, output_format: OutputFormat) -> anyhow::Result<Vec<u
         preserve_names: false,
         custom_sections: CustomSectionHandling::Drop,
         output_format,
+        opaque_resources: Vec::new(),
     };
 
     let mut fuser = Fuser::new(config);

--- a/safety/adr/ADR-0.md
+++ b/safety/adr/ADR-0.md
@@ -1,0 +1,173 @@
+---
+id: ADR-0
+type: design-question
+title: Static fusion of re-exporter resource chains
+status: open
+gating-fixtures:
+  - resource_floats
+  - resource_with_lists
+  - resource-import-and-export
+design-paths:
+  - D — Mini-shim for trivial wit-bindgen wrapper structs (meld-only)
+  - E — Elide trivial pass-through re-exporters (research)
+  - F — Layout inference from compiled re-exporter code (research)
+  - G — FACT-style trampoline as inner core module (meld-only, larger)
+  - H — Outsource the re-exporter boundary to wit-component (heavy dep)
+  - I — pulseengine/wit-bindgen opaque-rep pattern (upstream + downstream)
+  - J — Hybrid output: emit re-exporter as a sub-instance the host wires
+---
+
+# ADR-0 — Static fusion of re-exporter resource chains
+
+## Context
+
+Three wit-bindgen test fixtures (`resource_floats`, `resource_with_lists`,
+`resource-import-and-export`) fuse successfully through `meld fuse`
+but trap at runtime with a `wasm unreachable instruction executed`
+error. They are currently marked as `fuse_only_test!` in
+`meld-core/tests/wit_bindgen_runtime.rs` (epic #69 / issue #92).
+
+All three are 3-component re-exporter chains: `A` (caller) → `C`
+(re-exporter) → `B` (implementor). The re-exporter `C` is a
+wit-bindgen-generated component that wraps an inner type from `B`
+in a Rust struct (e.g., `pub struct FloatRep { inner: Float }`),
+boxes it, and uses the box pointer as the resource representation.
+
+## Why the runtime trap
+
+Per the investigation memo and the upstream rust-compiler trap on
+`& 7`: the re-exporter's user code dereferences the rep pointer it
+gets back from `_resource_rep(handle)` and the rust compiler's
+debug-mode `assume(ptr.is_aligned())` materializes as a wasm
+unreachable when the rep value is not 8-byte aligned (or not in
+the right memory).
+
+Meld's existing per-component handle table (commit `30cf088`,
+infrastructure on `feat/per-component-handle-tables`) stores whatever
+rep value is passed to `[resource-new]`. In a re-exporter chain
+that's the CALLER's rep — a pointer in `A`'s memory — but the
+re-exporter's user code expects to dereference it as a pointer
+in `C`'s memory, to a struct laid out per `C`'s compiler. Both
+the address space and the alignment can be wrong.
+
+In other words: the meld-side handle table is correct as a
+container, but the **value stored in it is the wrong thing**.
+The right value would be a pointer to a properly-constructed
+wrapper struct in `C`'s memory — and constructing that wrapper
+requires either calling `C`'s own internal helpers (not exposed
+as canon imports) or duplicating the layout knowledge in meld.
+
+## Why this needs an ADR
+
+There are at least seven plausible paths. Some are entirely within
+meld; some require an upstream change to wit-bindgen; some require
+ecosystem-level coordination. The right choice depends on:
+
+1. How many real-world (non-fixture) components exhibit this pattern
+2. Whether wit-bindgen will accept an opt-in opaque-rep convention
+3. How willing we are to take on `wit-component` as a dependency
+4. How much of the work is actually `meld`'s vs. someone else's
+
+This ADR enumerates the design space. Sibling ADRs (`ADR-1` …) under
+this parent will document each path's prototype, validation result,
+and verdict. The synthesis pass (one final agent reading all
+siblings) recommends one as `accepted`; others move to `rejected`
+or `superseded`.
+
+## Design space (not the verdict — see siblings)
+
+### D — Mini-shim for trivial wrapper structs
+
+Detect re-exporter resources whose wrapping struct is trivial
+(`{ inner: Handle }` with no extra fields). For those, emit a small
+function that calls `C`'s `cabi_realloc(0, 0, 4, 4)`, stores the
+inner handle, returns the new pointer. Routes `[resource-new]` to
+that function. Reuses existing handle-table infrastructure.
+
+Locus: `meld`. Viability ≈ 4. Generalization: medium (covers test
+fixtures; fragile for real components with non-trivial wrappers).
+
+### E — Elide trivial pass-through re-exporters
+
+Detect that `C` is a pure WIT-mediation layer and route `A → B`
+directly, skipping `C` entirely. Saves output size as a bonus.
+Requires "is C trivial?" detection — surprisingly tractable for
+wit-bindgen output but fragile against any user-added code.
+
+Locus: `meld`. Viability ≈ 3 (research-y). Risk: brittle detection.
+
+### F — Layout inference from compiled C
+
+Statically analyze `C`'s `[resource-new]` callers to discover the
+wrapper struct's layout and field initializations. Use that knowledge
+to construct the struct from the adapter side.
+
+Locus: `meld`. Viability ≈ 2 (high effort; reverse-engineering Rust
+struct layouts from wasm is brittle).
+
+### G — FACT-style trampoline as inner core module
+
+What wasmtime's FACT does at runtime, done at fuse-time: emit a
+separate adapter module that imports `C`'s exports and exports the
+canonical interface. The merged P2 wrapper instantiates it as a
+sibling core module. Architecturally converges meld with wasmtime's
+adapter generation.
+
+Locus: `meld` (with potential future convergence on the
+`canonical-abi-emit` crate proposed in
+`docs/wasmtime-fact-reusability.md`). Viability ≈ 3.
+
+### H — Outsource to wit-component
+
+`wit-component` is the reference implementation of component
+composition. Have meld delegate the re-exporter boundary to
+wit-component's logic. Heavy dependency.
+
+Locus: `hybrid` (meld + wit-component). Viability: needs
+feasibility report.
+
+### I — pulseengine/wit-bindgen opaque-rep pattern
+
+The rep-as-pointer convention is wit-bindgen's choice, not the
+spec's. Add an opt-in `#[wit_bindgen::resource(opaque_rep)]`
+attribute that treats the rep as opaque (never dereferenced; just
+round-tripped). Components that opt in are statically fusable.
+Implementation in `pulseengine/wit-bindgen` (our fork); meld branch
+consumes the new pattern; draft RFC for upstream.
+
+Locus: `wit-bindgen`. Viability ≈ 3 (multi-step but each step is
+small). Strongest long-term fix.
+
+### J — Hybrid output: re-exporter as sub-instance
+
+Acknowledge meld can't fully fuse re-exporter chains; emit them as
+separate component instances inside the output, requiring the host
+to do trivial resource-handle translation (which existing wasmtime
+/ jco hosts already do).
+
+Locus: `meld`. Viability ≈ 4 (small implementation). Trade-off:
+output is no longer a single core module for these cases.
+
+## Pipeline
+
+This ADR is the parent for an `explore` pipeline run (see
+`scripts/explore/HOWTO.md`):
+
+1. `rank.md` produces a JSON ranking of the seven paths.
+2. For each path with viability ≥ 3: `prototype.md` agent in parallel.
+3. For each prototype: `validate.md` fresh agent.
+4. For each confirmed: `emit.md` produces `safety/adr/ADR-N.md` as a
+   sibling to this parent.
+5. Synthesis: one agent reads all siblings, recommends one as
+   `accepted`.
+
+## References
+
+- Issue #92 (3-component re-exporter resource chains: implement shim
+  module approach)
+- Epic #69 (per-component resource handle tables for 3-component chains)
+- `feat/per-component-handle-tables` branch (initial infrastructure)
+- `docs/wasmtime-fact-reusability.md` (related: shareable canonical-ABI
+  emission core)
+- `docs/superpowers/plans/2026-03-29-per-component-handle-tables.md`
+  (original per-component-handle-table plan, partially landed in main)

--- a/safety/adr/schema.yaml
+++ b/safety/adr/schema.yaml
@@ -1,0 +1,135 @@
+# Schema for design ADRs (Architecture Decision Records).
+#
+# ADRs live in `safety/adr/ADR-N.md` as YAML front-matter + a markdown
+# body. They are emitted by the explore pipeline (see
+# `scripts/explore/emit.md`) and grouped under parent design questions
+# (`safety/adr/ADR-0.md` etc).
+#
+# This schema enforces structure so design decisions are comparable
+# across alternatives.
+
+schema-version: 1
+
+# An ADR is one of two shapes:
+#
+#   1. A PARENT design question — `type: design-question`. States the
+#      problem. Lists the gating fixtures. Identifies the design space.
+#      Children are `type: design-adr` siblings linked back via
+#      `parent`.
+#
+#   2. A DESIGN ADR — `type: design-adr`. Represents one alternative
+#      within the parent question's design space. Always emits as
+#      `status: draft`; humans promote.
+
+types:
+  - design-question
+  - design-adr
+
+# Required fields for `type: design-question`.
+design-question-required:
+  - id           # ADR-N
+  - type         # design-question
+  - title
+  - status       # open | resolved
+  - context      # markdown body of the file
+  - gating-fixtures  # list of test names
+  - design-paths     # list of brief path descriptions (D, E, F, G, H, I, J, ...)
+
+# Required fields for `type: design-adr`.
+design-adr-required:
+  - id              # ADR-N (different N from parent)
+  - parent          # ADR-N referencing the design-question
+  - type            # design-adr
+  - title           # one line; names the path, not the verdict
+  - status          # draft | accepted | rejected | superseded
+  - description     # markdown body
+  - fields          # see below
+  - links           # see below
+
+design-adr-fields:
+  locus-of-fix:
+    type: enum
+    values: [meld, wit-bindgen, spec, wasm-tools, hybrid]
+    description: >
+      Where the change properly belongs. `wit-bindgen` means the
+      pulseengine fork (or upstream Bytecode Alliance, if we choose
+      to send a PR). `hybrid` means meld must do part; an upstream
+      change makes the other part correct.
+
+  viability:
+    type: integer
+    range: [1, 5]
+    description: >
+      Inherited from the rank pass. 5 = prototype is straightforward;
+      1 = speculative, no concrete prototype possible today.
+
+  generalization:
+    type: enum
+    values: [low, medium, high]
+    description: >
+      Validator's read of how well this approach extends beyond the
+      gating fixture to the other failing cases under the parent.
+
+  maintenance-cost:
+    type: enum
+    values: [low, medium, high]
+    description: >
+      Ongoing cost of the new code: new abstractions, new invariants
+      the rest of the codebase must respect, ongoing upstream tracking.
+
+  fixture-coverage:
+    type: list-of-strings
+    description: >
+      Specific fixtures the prototype demonstrably handles. At least
+      the gating fixture; ideally siblings under the same parent.
+
+  upstream-dependency:
+    type: string
+    description: >
+      Free-form description of what the path requires from outside
+      this repo. `independent` if none.
+
+design-adr-links:
+  parent:
+    type: adr-id
+    required: true
+    description: ADR-N of the design-question this ADR resolves.
+
+  alternative-to:
+    type: list-of-adr-ids
+    required: true
+    description: Sibling ADRs under the same parent (may be empty).
+
+  prototype-branch:
+    type: git-ref
+    required: true
+    description: Full git branch name where the prototype lives.
+
+  oracle:
+    type: string
+    required: true
+    description: >
+      Fully-qualified test name that the prototype causes to pass.
+      e.g., meld-core::tests::wit_bindgen_runtime::test_runtime_wit_bindgen_resource_floats
+
+  references:
+    type: list-of-strings
+    required: false
+    description: >
+      Prior art, RFCs, upstream issues. Include the hypothesis-priors
+      paragraph from the prototype's invocation so future readers
+      know what the explorer was told to consider.
+
+# Promotion rules (enforced by humans, not by tooling today):
+#
+#   draft       — emitted by `explore/emit.md`. Awaiting human review.
+#   accepted    — humans chose this as the path forward. There should
+#                 be at most one `accepted` ADR per parent at a time.
+#                 Sibling ADRs typically move to `rejected` when one
+#                 is accepted.
+#   rejected    — humans considered this and chose another sibling.
+#                 The branch may be deleted; the ADR remains as a
+#                 record.
+#   superseded  — was accepted; later replaced by another ADR. Link
+#                 to the superseding ADR via `superseded-by` (added
+#                 to links when this transition happens).

--- a/scripts/explore/HOWTO.md
+++ b/scripts/explore/HOWTO.md
@@ -1,0 +1,92 @@
+# Explore — Mythos-style design exploration pipeline
+
+Sibling pattern to `scripts/mythos/` (bug hunting). Where mythos forces
+divergent bug hypotheses through a convergent oracle (failing test +
+Kani harness), explore forces divergent **design alternatives** through
+a convergent oracle (working prototype that flips a `fuse_only_test!`
+to `runtime_test!` PASSING).
+
+The pattern is: let agents reason about designs freely, but require a
+machine-checkable oracle for every recommended design so we don't ship
+hand-waved architecture.
+
+## When to use
+
+- A failing fixture or class of failures has more than one plausible
+  fix — typically because the right fix straddles meld, wit-bindgen,
+  the component-model spec, or wasm-tools. Examples: the re-exporter
+  resource chains in epic #69, future RFC #46 lowering, etc.
+- Decisions where "implementation as argumentation" matters. If you'll
+  defend a design choice in a discussion with someone outside meld
+  (Christof Petig, BA, kiln team), having a working branch beats prose.
+- Multiple agents can usefully work in parallel on independent paths.
+  If the design space is one-dimensional, just pick the obvious thing.
+
+## The four prompts
+
+| Prompt | Purpose | Output | Sigil analog |
+|---|---|---|---|
+| `rank.md` | Score design paths by **viability × locus-of-fix** | JSON list, sorted descending | `mythos/rank.md` |
+| `prototype.md` | Build smallest viable slice + memo for ONE path | Branch + structured report | `mythos/discover.md` |
+| `validate.md` | Fresh validator confirms prototype + assesses generalization | Verdict + reason | `mythos/validate.md` |
+| `emit.md` | Convert confirmed prototype to a draft ADR | YAML matching `safety/adr/schema.yaml` | `mythos/emit.md` |
+
+## The two-axis rank
+
+This is the key difference from mythos. Each design path gets two ratings:
+
+1. **Viability (1–5)**: how likely the prototype actually fixes the
+   gating fixture, given current knowledge.
+2. **Locus-of-fix (meld | wit-bindgen | spec | wasm-tools | hybrid)**:
+   where the change properly belongs.
+
+A path with viability 5 and locus = `wit-bindgen` is a strong signal
+to invest upstream rather than build a downstream workaround. A path
+with viability 5 and locus = `meld` is "do it now."
+
+## Pipeline run
+
+From a Claude Code session in the meld repo:
+
+1. `Read scripts/explore/rank.md` and substitute the parent question
+   from `safety/adr/ADR-N.md`. Produces ranked design paths.
+2. For each path with viability ≥ 3: new session (parallel), paste
+   `prototype.md` with `{{adr-id}}`, `{{path-name}}`, `{{gating-oracle}}`,
+   `{{hypothesis-priors}}`, `{{locus-of-fix}}`. Output = structured
+   prototype report.
+3. For each prototype: fresh session with `validate.md`. Both oracle
+   halves must hold (prototype actually flips the test, validator
+   confirms generalization claims). Reject anything that doesn't
+   confirm.
+4. For each confirmed: `emit.md` produces a draft `safety/adr/ADR-N.md`
+   entry under the parent ADR. Human promotes to `accepted` /
+   `rejected` / `superseded`.
+
+One agent per path, in parallel — the same trick mythos uses.
+
+## Per-project customization
+
+- **`rank.md`** rubric is meld-specific (the locus options, the
+  viability-criteria for fusion correctness)
+- **`prototype.md`** carries hypothesis priors per path — discovered
+  by the human running the pipeline. Examples: "look at wit-component's
+  re-exporter handling," "check if wasm-tools has prior art for X."
+- **`emit.md`** generates a YAML matching `safety/adr/schema.yaml`
+- **`validate.md`** rejects on top of the standard "prototype works"
+  oracle: maintenance cost too high, generalization too narrow,
+  upstream-only fix, etc.
+
+## Gotchas
+
+- **Approaches you haven't built a 100-line prototype for default to
+  viability rank 3.** Do not let abstract speculation inflate ranks.
+  Mirror of sigil's "Files you haven't seen default to rank 2."
+- **Validators must be fresh sessions.** Reusing prototype context lets
+  the agent defend its own design.
+- **One agent per path, not per epic.** Parallel agents on different
+  paths produce diverse approaches; a single agent converges on its
+  first plausible idea.
+- **Locus-of-fix is part of the verdict.** Honest "this isn't ours to
+  fix; here's the upstream issue we should file" is a valid output.
+  Hallucinating a downstream workaround is more expensive than that
+  silence.

--- a/scripts/explore/emit.md
+++ b/scripts/explore/emit.md
@@ -1,0 +1,124 @@
+You are emitting a new design ADR (Architecture Decision Record) under
+the parent question in `safety/adr/{{adr-id}}.md`. The schema for ADRs
+is `safety/adr/schema.yaml` — consult it for the exact field set and
+allowed values. Do not invent fields.
+
+Input:
+- Confirmed prototype report (from prototype.md, validated by validate.md)
+- Validator's locus-of-fix assignment
+- Validator's generalization assessment
+---
+{{confirmed_report}}
+LOCUS-OF-FIX: {{locus}}
+GENERALIZATION: {{generalization}}
+PARENT-ADR: {{adr-id}}
+---
+
+## Rules
+
+1. **Grouping invariant**: ADRs in this repository are grouped under
+   parent design questions. If `safety/adr/` already contains an ADR-N
+   linked to `{{adr-id}}` via `parent`, this new finding becomes a
+   SIBLING ADR-M with the same parent, NOT a new top-level ADR.
+   Each sibling expresses a distinct alternative to the same problem.
+
+2. **The new id** must be the next unused `ADR-N` by integer suffix
+   under the parent. Read existing files in `safety/adr/` to determine
+   it.
+
+3. **Required fields** (per `safety/adr/schema.yaml`):
+     - `id` (e.g., `ADR-3`)
+     - `parent` (e.g., `ADR-0`)
+     - `type: design-adr`
+     - `title` (one line, names the path NOT the verdict)
+     - `status: draft` (always; humans promote to `accepted` /
+       `rejected` / `superseded`)
+     - `description` — reference the prototype branch by full git ref
+       and the gating oracle by test name. Bug lives in code, not in
+       prose.
+     - `fields.locus-of-fix` — meld | wit-bindgen | spec | wasm-tools
+                              | hybrid
+     - `fields.viability` (1–5, from rank pass)
+     - `fields.generalization` — low | medium | high
+     - `fields.maintenance-cost` — low | medium | high
+     - `fields.fixture-coverage` — list of fixture names the
+       prototype demonstrably handles (gating + any others)
+     - `fields.upstream-dependency` — text describing what (if
+       anything) the path requires from outside this repo
+
+4. **Required links**:
+     - `alternative-to` — list of sibling ADR ids under the same
+       parent. Even if siblings don't exist YET, leave an empty list;
+       later emissions update.
+     - `prototype-branch` — full git ref, e.g.
+       `feat/explore-D-mini-shim`
+     - `oracle` — fully-qualified test name, e.g.
+       `meld-core::tests::wit_bindgen_runtime::test_runtime_wit_bindgen_resource_floats`
+     - `references` — prior art, RFCs, upstream issues. Include the
+       hypothesis-priors paragraph from the prototype's invocation
+       so future readers know what the explorer was told to consider.
+
+5. **Status MUST be `draft` on first emission.** The human running
+   the synthesis pass promotes one of the siblings to `accepted` and
+   the others to `rejected` / `superseded`.
+
+6. **Do not invent verdict text in `description`.** Cite the
+   validator's REASON paragraph verbatim. The ADR is not a place to
+   re-argue the case the validator already made.
+
+## Output
+
+Emit ONLY the YAML for the new ADR file at `safety/adr/ADR-N.md`,
+ready to write to disk. The file body is a YAML front-matter block
+followed by a markdown body that quotes the validator reason and
+links to the prototype branch.
+
+Example shape (do not copy verbatim — fill from the input):
+
+```yaml
+---
+id: ADR-3
+parent: ADR-0
+type: design-adr
+title: D — Mini-shim for trivial wit-bindgen wrapper structs
+status: draft
+fields:
+  locus-of-fix: meld
+  viability: 4
+  generalization: medium
+  maintenance-cost: low
+  fixture-coverage:
+    - resource_floats
+  upstream-dependency: independent
+links:
+  alternative-to:
+    - ADR-4
+    - ADR-5
+  prototype-branch: feat/explore-D-mini-shim
+  oracle: meld-core::tests::wit_bindgen_runtime::test_runtime_wit_bindgen_resource_floats
+  references:
+    - https://github.com/bytecodealliance/wit-bindgen/blob/main/crates/rust/src/interface.rs
+---
+
+# ADR-3 — D — Mini-shim for trivial wit-bindgen wrapper structs
+
+## Context
+
+(One paragraph: state the problem from the parent ADR and which
+alternative this represents.)
+
+## Decision (DRAFT)
+
+(Cite validator REASON verbatim.)
+
+## Consequences
+
+(From the prototype report's "WHAT THE PROTOTYPE DOES NOT HANDLE",
+"GENERALIZATION SCORE", and "MAINTENANCE COST".)
+
+## Prototype
+
+`feat/explore-D-mini-shim` flips the gating oracle. Diff stat: ...
+```
+
+Emit ONLY this YAML+markdown file content, nothing else.

--- a/scripts/explore/prototype.md
+++ b/scripts/explore/prototype.md
@@ -1,0 +1,92 @@
+Build the smallest possible working slice for ONE design path under
+the parent question in `safety/adr/{{adr-id}}.md`. You are exploring,
+not finishing — produce the minimum viable proof that this path can
+satisfy the gating oracle.
+
+Path you are exploring: `{{path-name}}`
+Locus-of-fix declared in rank: `{{locus-of-fix}}`
+Gating oracle: `{{gating-oracle}}` (a single test that, if it flips
+from `fuse_only_test!` to a passing `runtime_test!`, demonstrates the
+core mechanism works).
+
+## Context you must use
+
+- This is meld, a static fusion tool for WebAssembly components. It
+  takes composed P2/P3 components and fuses them into a single core
+  wasm module. The safety model is STPA-based; the parent ADR cites
+  the relevant losses/hazards.
+- Read the parent ADR FIRST (`safety/adr/{{adr-id}}.md`) — it states
+  the problem, lists the alternatives, and points to prior code
+  attempts.
+- Read the gating oracle test in `meld-core/tests/wit_bindgen_runtime.rs`
+  before writing code, so you know exactly what passing means.
+- The 19-site LS-A-7 audit (commits `fcad26a`, `1223555`) and the
+  P3 async stabilizing-shim work (commits `e5cd80f`, `6a63971`,
+  `1097f08`) introduced infrastructure (`emit_checked_realloc`,
+  `emit_overflow_guard`, `cabi_size_align`, `collect_indirections`,
+  `generate_stabilizing_shim`) you should reuse where applicable.
+
+## Hypothesis priors for this path
+
+{{hypothesis-priors}}
+
+(One paragraph the human running the pipeline supplies — known prior
+art, related upstream discussions, or particular code paths to
+consider before writing the prototype.)
+
+## Oracle requirement (non-negotiable)
+
+For this path to count as a viable design, you MUST produce ALL of
+the following:
+
+  (1) A branch `feat/explore-{{path-name}}` with a working prototype
+      that flips the gating fixture's `fuse_only_test!` to a passing
+      `runtime_test!`. The prototype may be ugly; it must be correct.
+  (2) `cargo test --package meld-core` MUST pass with the prototype
+      applied — no regressions.
+  (3) `cargo test --test wit_bindgen_runtime {{gating-oracle}}` MUST
+      pass — the oracle holds.
+  (4) A short report (under 600 words) summarizing what the prototype
+      does, where it falls down, and what the validator should look at.
+
+If you cannot produce all four — for example, because the prototype
+requires an upstream change that does not yet exist, or because the
+infrastructure you need isn't in meld — output exactly:
+
+  `NOT VIABLE TODAY: <one sentence on what's missing>`
+
+…and stop. Do NOT submit a prototype that doesn't actually flip the
+oracle. Hallucinations are more expensive than silence — a half-baked
+prototype that "looks like it might work" wastes the validator's time
+and degrades the convergent oracle that makes this pipeline useful.
+
+If your `locus-of-fix` is NOT `meld`, the oracle still applies:
+you may need to vendor / patch / submodule the upstream piece into
+this repo as a temporary mock, but the meld-side changes must
+interoperate with that mock and the meld-side test must pass.
+
+## Output format
+
+If viable, produce a single structured report:
+
+- PATH: `{{path-name}}`
+- BRANCH: `feat/explore-{{path-name}}` (must exist and pass tests)
+- ORACLE STATUS: PASSED (the gating fixture flipped and runs)
+- DESIGN ONE-LINER: one sentence describing the mechanism
+- WHAT CHANGED: bullet list of file paths + nature of edits
+- WHAT THE PROTOTYPE DOES NOT HANDLE: honest list of edge cases /
+  fixtures / scenarios this prototype skips. Be specific.
+- GENERALIZATION SCORE: low | medium | high — your honest take on
+  whether the approach extends to `resource_with_lists` and
+  `resource-import-and-export` (the other two failing fixtures).
+  "Low" is fine; the validator will assess.
+- MAINTENANCE COST: low | medium | high — your honest take on the
+  ongoing cost of the new code (new abstractions, new invariants
+  the rest of the codebase must respect, ongoing upstream tracking).
+- UPSTREAM DEPENDENCY: independent | requires-pulseengine-wit-bindgen-fork |
+  requires-spec-change | etc.
+- ONE QUESTION FOR THE VALIDATOR: the single most-load-bearing
+  judgment call you made; the thing the validator most needs to
+  assess.
+
+Do NOT include prose beyond what the format requires.

--- a/scripts/explore/rank.md
+++ b/scripts/explore/rank.md
@@ -1,0 +1,86 @@
+Rank candidate design paths for the parent question in
+`safety/adr/{{adr-id}}.md` by likelihood that a small prototype would
+satisfy the oracle (typically: a `fuse_only_test!` flips to a passing
+`runtime_test!`).
+
+Output JSON:
+`[{"path": "...", "viability": N, "locus": "...", "reason": "..."}]`,
+sorted by viability descending then by locus ergonomics (meld first).
+
+## Two-axis rubric
+
+### Axis 1 — viability (1–5)
+
+5 (you can sketch the prototype in 100 lines, no new infrastructure):
+  - Mechanism is well-understood; nothing in the code base prevents it
+  - Existing helpers cover the primitives (e.g., handle table, shim
+    generator, byte-scan tests)
+  - Failure modes are obvious and testable
+
+4 (prototype is medium-effort but well-scoped):
+  - One new abstraction needed; one or two new helpers
+  - Some risk of surfacing a deeper invariant the prototype must respect
+
+3 (real research; prototype is feasible but no one has built one
+   before in this repo):
+  - Path requires a feasibility report before code, OR
+  - Borrows heavily from external tooling (wit-component, wasm-tools)
+    we haven't integrated
+
+2 (path needs upstream change to even be built locally):
+  - Requires a fork of an external dep + a meld branch consuming the
+    fork
+  - The prototype isn't testable without the upstream side landing
+
+1 (speculative, no concrete prototype possible today):
+  - Spec change required; current tooling doesn't support the pattern
+
+### Axis 2 — locus-of-fix (categorical)
+
+`meld` — the fix is entirely within meld
+`wit-bindgen` — the fix belongs in wit-bindgen's resource lowering
+                convention; meld can consume the new pattern
+`spec` — the fix belongs in the component-model spec
+`wasm-tools` — the fix belongs in wasm-tools (validator, encoder, …)
+`hybrid` — meld must do part; an upstream change makes the other part
+           correct
+
+A path with `locus = wit-bindgen` and viability ≥ 4 should NOT be
+discounted just because the upstream change is hard. The honest
+verdict in many cases is "the right fix is upstream; meld should
+participate in the spec/impl conversation while shipping a workaround."
+
+## Constraints
+
+- Open the parent ADR first (`safety/adr/{{adr-id}}.md`) and the
+  fixtures it references. Do not rank from imagination.
+- For each candidate path, write at most one sentence in `reason` —
+  the ranker is not the prototype agent and should not propose
+  solutions, only judge how viable each is.
+- Approaches you haven't seen built (no PR / branch / discussion of
+  the same approach in this or upstream repos) default to viability 3.
+  Do not guess viability 5 from memorability or apparent simplicity.
+- The straddle rule: if a path sits between two viability tiers, pick
+  the LOWER (be skeptical of yourself).
+- Locus-of-fix is binary per path — pick the one that best matches
+  where the change PROPERLY belongs, not where it's easiest for us.
+
+## Output
+
+A JSON array sorted by viability descending. Example shape:
+
+```json
+[
+  {"path": "D-mini-shim",
+   "viability": 4,
+   "locus": "meld",
+   "reason": "Trivial wrapper struct is one i32; existing handle table infra covers most of it."},
+  {"path": "I-wit-bindgen-opaque-rep",
+   "viability": 3,
+   "locus": "wit-bindgen",
+   "reason": "Opt-in attribute pattern; downstream consumer needs only a flag, but prototype requires fork."},
+  ...
+]
+```
+
+Return only the JSON. No prose.

--- a/scripts/explore/validate.md
+++ b/scripts/explore/validate.md
@@ -1,0 +1,77 @@
+I have received the following design-prototype report. Can you please
+confirm if the prototype actually works and is worth promoting to a
+draft ADR?
+
+Report:
+---
+{{report}}
+---
+
+You are a fresh validator with no stake in the exploration. Your job
+is to reject hallucinations, half-baked prototypes, and approaches
+whose maintenance cost outweighs the fixture they unlock.
+
+A false positive here costs:
+- Human triage time during ADR review
+- Code-base architectural debt if the wrong path lands
+- Discussion bandwidth when defending the chosen path externally
+
+So be honest about rejection — "the prototype technically passes the
+test but introduces an invariant the rest of the code base will quietly
+violate" is a valid `not-confirmed` reason.
+
+## Procedure
+
+1. **Read the parent ADR FIRST** (`safety/adr/{{adr-id}}.md`). Form
+   your own view of what the design space looks like before reading
+   this prototype's hypothesis.
+2. **Check out the prototype's branch** locally:
+   `git fetch && git checkout feat/explore-{{path-name}}`.
+3. **Run the gating oracle**:
+   `cargo test --test wit_bindgen_runtime {{gating-oracle}}`.
+   If it does NOT pass on the prototype branch, the prototype is NOT
+   confirmed — reply `VERDICT: not-confirmed` and a short reason.
+   Stop.
+4. **Run the full test suite**:
+   `cargo test --package meld-core`. If anything regresses on the
+   prototype branch vs `main`, that's NOT confirmed. Stop.
+5. **Read the prototype's diff** and the report's "WHAT THE PROTOTYPE
+   DOES NOT HANDLE" section. Now ask: is this *interesting enough* to
+   promote to an ADR?
+
+   A prototype is NOT interesting (and should be rejected) if any of
+   the following hold:
+     - The prototype hard-codes the gating fixture's specific shape
+       so narrowly that it doesn't extend even to a sibling fixture
+       within the same parent question. (Mythos analog: "requires an
+       attacker who already has the capability the bug grants.")
+     - The prototype is a duplicate of an approach already documented
+       under another ADR sibling (check `safety/adr/`).
+     - The prototype's `MAINTENANCE COST` is `high` AND its
+       `GENERALIZATION SCORE` is `low`. Two `high` ratings is a
+       three-strikes-out for ADR promotion.
+     - The prototype assumes an upstream behavior the upstream has
+       not committed to and is unlikely to commit to.
+     - The prototype passes the oracle by SKIPPING semantics the
+       fixture is supposed to exercise (e.g., the resource gets
+       leaked instead of dropped, the wrapping struct gets memcpy'd
+       instead of constructed). Read the test BODY, not just the
+       pass/fail.
+6. If still confirmed and interesting, identify the **locus-of-fix**.
+   The prototype's report claims one; do you agree? If the prototype
+   builds in meld but the validator decides the right fix really
+   belongs in `wit-bindgen` or in the spec, override the locus and
+   note this in the verdict.
+
+## Output
+
+- `VERDICT: confirmed | not-confirmed | confirmed-with-caveats`
+- `LOCUS-OF-FIX: meld | wit-bindgen | spec | wasm-tools | hybrid`
+  (only on confirmed; may differ from the prototype's claim)
+- `GENERALIZATION ASSESSMENT: low | medium | high` (your independent
+  read of how well this extends to the other failing fixtures —
+  `resource_with_lists`, `resource-import-and-export`, future
+  re-exporters in real components)
+- `REASON:` one paragraph. If `not-confirmed`, state which step of
+  the procedure failed. If `confirmed-with-caveats`, list the caveats
+  the human must hold during ADR promotion.


### PR DESCRIPTION
## Summary

Architectural progression on issue #107 (under epic #106 / issue #92):

- **Per-resource handle table discrimination** (Path B): rekey `HandleTableInfo` from `HashMap<usize, _>` to `HashMap<(usize, String, String), _>` so multi-resource re-exporters route per-resource instead of per-component. (commits e027bb1, c104b1b, 254bfab)
- **`--opaque-rep` CLI flag** for resources built with `pulseengine/wit-bindgen feat/opaque-rep-attribute`. Plumbed end-to-end; conditional behavior is currently a no-op (architectural design pending). (commit e166cb4)
- **Alias-fallback** for `use`-aliased resources where wasmtime unifies multiple WIT interfaces into one canonical type. Both definer-side and consumer-side branches now route to the unique re-exporter handle table. (commits 0035441, 73f95e6)
- **`ht_drop` invokes `[dtor]`** before zeroing the slot — restores the canonical-ABI lifetime contract so wit-bindgen's Box-backed reps are properly dropped (and any `Option::take` on inner-handle fields fires at the right moment). (commit 9eb1229)

## Test status

| Test | Result |
|---|---|
| 73-test wit-bindgen runtime suite | 73/73 (0 regressions) |
| 8 two-component re-exporter fixtures | 8/8 |
| `resource_floats` runtime | PASSES (was `wasm unreachable`) |
| `resource_with_lists` runtime | FAILS Option::unwrap on None |
| `resource-import-and-export` runtime | FAILS Option::unwrap on None |
| `resource_floats_opaque` (fork driver) | Passes |
| `resource_floats_opaque` (meld) | FAILS Same architectural class as the 2 trio failures |

## What this DOES NOT fix yet

Two of the trio fixtures still trap with `Option::unwrap() on None`. Diagnosis (issue #107): cross-component handle namespace conflation. Multiple components share a single handle table when their resources unify via `use` or shared interface — handles from different components address different memory layouts, and wit-bindgen's `_ResourceRep<T>::val.as_ref().unwrap()` reads garbage when handed a rep from the wrong component.

The principled fix is per-component handle tables with bridging trampolines at cross-component hand-offs (Option A in #107). That's a separate branch (`feat/per-component-ht-bridging`).

## Why open this as a draft now

- 73/73 standard suite + 1/3 trio is meaningful progress
- The alias-fallback + dtor wiring are architecturally correct and should land regardless of how the remaining 2 trio failures are fixed
- Soliciting review on the design surface before further iteration

## Test plan

- [x] `cargo test --release --test wit_bindgen_runtime` — 73/73
- [x] `cargo run --release --bin meld -- fuse tests/wit_bindgen/fixtures/resource_floats.wasm -o /tmp/f.wasm --component && wasmtime --invoke='run()' /tmp/f.wasm` — outputs `()`
- [x] `cargo run --release --bin meld -- fuse tests/wit_bindgen/fixtures/resource_with_lists.wasm -o /tmp/r.wasm --component && wasmtime --invoke='run()' /tmp/r.wasm` — traps (documented)
- [ ] PR review

## Related issues

- Closes part of #107 (full fix tracked there)
- Progress on #69 (Epic: per-component resource handle tables)
- Progress on #92 (3-component re-exporter resource chains)
- Will enable #75 (promote resource_floats to runtime test) once landed
- Documented in #106 (Epic ADR-0)

## Branch state

Worktree: `/Users/r/git/pulseengine/meld-conditional-typing` on `feat/conditional-resource-typing` head `9eb1229`. Pushed to origin.