### PR TITLE
feat(option-A): per-component handle tables + bridging (3/3 trio passes)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -641,18 +641,37 @@ impl FactStyleGenerator {
                             .iter()
                             .any(|((c, _, r), _)| *c == site.from_component && r == rn)
                     });
-                    let callee_new_func =
-                        if site.from_component != site.to_component && caller_has_ht {
-                            rn_opt.as_deref().and_then(|rn| {
-                                merged
-                                    .handle_tables
-                                    .iter()
-                                    .find(|((c, _, r), _)| *c == site.to_component && r == rn)
-                                    .map(|(_, ht)| ht.new_func)
-                            })
-                        } else {
-                            None
-                        };
+                    // For `[method]/[static]/[constructor]` exported by a
+                    // component that LOCALLY defines the resource, the
+                    // wit-bindgen cabi expects arg0 to be the REP (memory
+                    // pointer to `_ThingRep<T>`). Adding callee.new would
+                    // mint a fresh slot in callee's ht; the slot's address
+                    // gets passed as arg0; the deref reads 4 bytes at the
+                    // slot (the just-stored rep) but Option's discriminant
+                    // is the LOW BYTE of that rep — 0 for typical aligned
+                    // box pointers → Option::unwrap on None.
+                    //
+                    // For top-level functions or when the callee just uses
+                    // the resource (not locally defines it), the cabi
+                    // treats arg0 as a HANDLE — keep callee.new so the
+                    // value lands in callee's namespace.
+                    let is_method_like = site.import_name.starts_with("[method]")
+                        || site.import_name.starts_with("[static]")
+                        || site.import_name.starts_with("[constructor]");
+                    let callee_new_func = if site.from_component != site.to_component
+                        && caller_has_ht
+                        && !is_method_like
+                    {
+                        rn_opt.as_deref().and_then(|rn| {
+                            merged
+                                .handle_tables
+                                .iter()
+                                .find(|((c, _, r), _)| *c == site.to_component && r == rn)
+                                .map(|(_, ht)| ht.new_func)
+                        })
+                    } else {
+                        None
+                    };
                     if let Some(rep_func) = rep_func {
                         if let Some(new_func) = callee_new_func {
                             log::info!(
@@ -735,13 +754,53 @@ impl FactStyleGenerator {
                             .copied()
                     });
 
+                // Distinguish two sub-cases of the 3-component branch:
+                //
+                // (a) Callee's exported function is a `[method]/[static]/
+                //     [constructor]` on a resource the callee LOCALLY
+                //     DEFINES via its own ht. wit-bindgen's `_export_*_cabi`
+                //     wraps the rep in `_ThingRep<T>` and the cabi expects
+                //     arg0 to be the REP (memory pointer). Emit
+                //     `caller.rep` ONLY — callee.new would mint a new
+                //     slot whose address gets passed as the rep, and the
+                //     deref reads adjacent fresh memory → Option=None.
+                //     This is the resource_with_lists `[method]thing.foo`
+                //     case where the re-exporter classification masks the
+                //     fact that the cabi still uses _ThingRep wrapping.
+                //
+                // (b) Top-level functions (no `[method]/[static]/
+                //     [constructor]` prefix) taking borrow<T> on a
+                //     `use`d resource. wit-bindgen's cabi calls
+                //     `Float::from_handle(arg0 as u32)` and treats arg0 as
+                //     a HANDLE. Emit `caller.rep + callee.new` so the
+                //     value lands in callee's namespace as a fresh slot
+                //     index the callee can pass back across downstream
+                //     adapters. This is the resource_floats `add` case.
+                //
+                // Discriminator: function name prefix. Methods/statics/
+                // constructors → case (a); top-level → case (b). Combined
+                // with a sanity check that the callee has SOME ht for the
+                // resource_name (so the rep-only path has somewhere
+                // sensible to derive the rep from).
+                let is_method_like = site.import_name.starts_with("[method]")
+                    || site.import_name.starts_with("[static]")
+                    || site.import_name.starts_with("[constructor]");
+                let callee_has_any_ht = merged
+                    .handle_tables
+                    .iter()
+                    .any(|((c, _, r), _)| *c == site.to_component && r == resource_name);
+                let new_func_for_emit = if is_method_like && callee_has_any_ht {
+                    None
+                } else {
+                    callee_new_func
+                };
                 if let Some(rep_func) = caller_rep_func {
                     options
                         .resource_rep_calls
                         .push(super::ResourceBorrowTransfer {
                             param_idx: op.flat_idx,
                             rep_func,
-                            new_func: callee_new_func,
+                            new_func: new_func_for_emit,
                         });
                 } else {
                     log::warn!(

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -483,7 +483,7 @@ impl FactStyleGenerator {
         let (type_idx, body) = if site.crosses_memory && options.needs_transcoding() {
             self.generate_transcoding_adapter(site, merged, &options)?
         } else if site.crosses_memory {
-            self.generate_memory_copy_adapter(site, merged, &options)?
+            self.generate_memory_copy_adapter(site, merged, &options, resource_rep_imports)?
         } else {
             self.generate_direct_adapter(site, merged, &options)?
         };
@@ -948,21 +948,41 @@ impl FactStyleGenerator {
         // Resolve inner resource handles from param copy layouts.
         // When list elements contain borrow<T>, the adapter must convert
         // each handle after bulk-copying the list data to callee memory.
+        // Each inner resource carries its own pre-resolved (module, field)
+        // for the matching [resource-rep] import (filled in by the
+        // resolver via the callee's resource_type_to_import map). Using
+        // that lookup ensures the right rep_func per resource type even
+        // when the callee imports multiple resources — the previous
+        // `.values().next()` heuristic picked an arbitrary first match
+        // and silently routed handle A through resource B's rep_func.
         for layout in &site.requirements.param_copy_layouts {
             if let crate::resolver::CopyLayout::Elements {
                 inner_resources, ..
             } = layout
             {
-                for &(byte_offset, _resource_type_id, is_owned) in inner_resources {
-                    if is_owned {
+                for inner in inner_resources {
+                    if inner.is_owned {
                         continue; // own<T> in lists — callee handles internally
                     }
-                    // Find any [resource-rep] import for borrow handles.
-                    // For 2-component (callee defines), use callee's rep.
-                    // For 3-component, would need caller's rep + callee's new.
-                    // For now, find ANY matching [resource-rep] import.
-                    if let Some(&rep_func) = resource_rep_imports.values().next() {
-                        options.inner_resource_fixups.push((byte_offset, rep_func));
+                    let rep_func = inner
+                        .rep_import
+                        .as_ref()
+                        .and_then(|key| resource_rep_imports.get(key).copied());
+                    if let Some(rep_func) = rep_func {
+                        options
+                            .inner_resource_fixups
+                            .push((inner.byte_offset, rep_func));
+                    } else {
+                        log::warn!(
+                            "inner-list borrow at offset {} (resource_type_id={}): \
+                             no [resource-rep] import resolved — skipping fixup. \
+                             from={} to={} import_name={:?}",
+                            inner.byte_offset,
+                            inner.resource_type_id,
+                            site.from_component,
+                            site.to_component,
+                            site.import_name,
+                        );
                     }
                 }
             }
@@ -1127,6 +1147,7 @@ impl FactStyleGenerator {
         site: &AdapterSite,
         merged: &MergedModule,
         options: &AdapterOptions,
+        resource_rep_imports: &std::collections::HashMap<(String, String), u32>,
     ) -> Result<(u32, Function)> {
         let target_func = self.resolve_target_function(site, merged)?;
 
@@ -1201,7 +1222,13 @@ impl FactStyleGenerator {
                     .filter(|p| !p.is_owned && p.callee_defines_resource)
                     .count(),
             );
-            return self.generate_params_ptr_adapter(site, options, target_func, caller_type_idx);
+            return self.generate_params_ptr_adapter(
+                site,
+                options,
+                target_func,
+                caller_type_idx,
+                resource_rep_imports,
+            );
         }
 
         // --- Non-retptr path: use callee's type so body is valid ---
@@ -1762,6 +1789,7 @@ impl FactStyleGenerator {
         options: &AdapterOptions,
         target_func: u32,
         caller_type_idx: u32,
+        resource_rep_imports: &std::collections::HashMap<(String, String), u32>,
     ) -> Result<(u32, Function)> {
         let params_area_size = site.requirements.params_area_byte_size.unwrap_or(0);
         let params_area_align = site.requirements.params_area_max_align.max(1);
@@ -1948,17 +1976,22 @@ impl FactStyleGenerator {
                 func.instruction(&Instruction::I32GeU);
                 func.instruction(&Instruction::BrIf(1)); // break to $exit
 
-                for &(res_byte_offset, _resource_type_id, is_owned) in inner_resources {
-                    if is_owned {
+                for inner in inner_resources {
+                    if inner.is_owned {
                         continue; // own<T>: callee handles internally
                     }
-                    // Find [resource-rep] for this resource
-                    if let Some(&rep_func) = options
-                        .params_area_borrow_fixups
-                        .first()
-                        .map(|f| &f.rep_func)
-                        .or_else(|| options.resource_rep_calls.first().map(|t| &t.rep_func))
-                    {
+                    // Use the per-element pre-resolved [resource-rep]
+                    // (filled at site-requirements time via the callee's
+                    // resource_type_to_import map). The previous code
+                    // picked an arbitrary first-fixup which silently
+                    // routed handle A through resource B's rep_func when
+                    // the callee imported >1 resource.
+                    let res_byte_offset = inner.byte_offset;
+                    let rep_func_opt = inner
+                        .rep_import
+                        .as_ref()
+                        .and_then(|key| resource_rep_imports.get(key).copied());
+                    if let Some(rep_func) = rep_func_opt {
                         // addr = dest_ptr + loop_counter * element_size + res_byte_offset
                         // Push addr for store
                         func.instruction(&Instruction::LocalGet(dest_local));

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -617,13 +617,59 @@ impl FactStyleGenerator {
                                 .get(&(op.import_module.clone(), op.import_field.clone()))
                                 .copied()
                         });
+                    // Option A Phase 3: when the callee ALSO has its own ht
+                    // for the same resource (post-Phase-1 per-component-ht),
+                    // bridge by also calling callee.ht_new(rep) so the
+                    // value lands in callee's namespace. Without this the
+                    // caller's memory-pointer handle would be deref'd by
+                    // callee in CALLEE's memory at that offset → garbage
+                    // (the resource_with_lists symptom). Match callee's ht
+                    // by resource_name only (caller iface may differ from
+                    // callee iface via `use` aliasing).
+                    // Only bridge when ALL of:
+                    //   - caller and callee are different components
+                    //   - caller has its OWN ht for the resource (the
+                    //     caller's rep_func came from the ht lookup, not
+                    //     the canonical [resource-rep] fallback)
+                    //   - callee has its own ht too
+                    // Without ALL three, the bridge double-translates or
+                    // converts canonical handles to memory pointers,
+                    // either of which corrupts the value.
+                    let caller_has_ht = rn_opt.as_deref().is_some_and(|rn| {
+                        merged
+                            .handle_tables
+                            .iter()
+                            .any(|((c, _, r), _)| *c == site.from_component && r == rn)
+                    });
+                    let callee_new_func =
+                        if site.from_component != site.to_component && caller_has_ht {
+                            rn_opt.as_deref().and_then(|rn| {
+                                merged
+                                    .handle_tables
+                                    .iter()
+                                    .find(|((c, _, r), _)| *c == site.to_component && r == rn)
+                                    .map(|(_, ht)| ht.new_func)
+                            })
+                        } else {
+                            None
+                        };
                     if let Some(rep_func) = rep_func {
+                        if let Some(new_func) = callee_new_func {
+                            log::info!(
+                                "borrow bridge: rn={:?} from={} to={} caller_rep={} callee_new={}",
+                                rn_opt,
+                                site.from_component,
+                                site.to_component,
+                                rep_func,
+                                new_func,
+                            );
+                        }
                         options
                             .resource_rep_calls
                             .push(super::ResourceBorrowTransfer {
                                 param_idx: op.flat_idx,
                                 rep_func,
-                                new_func: None,
+                                new_func: callee_new_func,
                             });
                     }
                 }
@@ -710,10 +756,63 @@ impl FactStyleGenerator {
         }
 
         // Resolve own<T> results that need [resource-rep] + [resource-new].
-        // When callee_defines_resource is true, the P2 wrapper's canon lift/lower
-        // handles the conversion — the adapter passes the handle directly.
+        //
+        // Three cases:
+        // 1. callee_defines_resource=false (3-component): caller and callee
+        //    have separate tables, bridge via callee.rep + caller.new.
+        // 2. callee_defines_resource=true AND both caller+callee have their
+        //    own ht (post-Option-A-Phase-1): bridge via callee.ht_rep +
+        //    caller.ht_new so the handle ends up in caller's namespace
+        //    (memory-pointer in caller's memory). Without this bridge,
+        //    caller stores callee's memory-pointer handle but later passes
+        //    it back to callee for method calls — works for callee but
+        //    breaks for any caller-side _resource_rep call (cross-memory
+        //    deref of leaf-allocated rep in intermediate's memory →
+        //    Option::unwrap on garbage).
+        // 3. callee_defines_resource=true AND no caller ht: pass through
+        //    (the wrapper's canon lift handles conversion).
         for op in &site.requirements.resource_results {
-            if !op.is_owned || op.callee_defines_resource {
+            if !op.is_owned {
+                continue;
+            }
+            if op.callee_defines_resource {
+                // Case 2 vs 3: only emit a bridge when BOTH sides have ht
+                // for the same (iface, rn). Match by resource_name across
+                // both sides (caller's iface may differ from callee's via
+                // `use` aliasing).
+                let resource_name = op
+                    .import_field
+                    .strip_prefix("[resource-new]")
+                    .or_else(|| op.import_field.strip_prefix("[resource-rep]"))
+                    .unwrap_or(&op.import_field);
+                let callee_ht = merged
+                    .handle_tables
+                    .iter()
+                    .find(|((c, _, r), _)| *c == site.to_component && r == resource_name)
+                    .map(|(_, ht)| (ht.rep_func, ht.new_func));
+                let caller_ht = merged
+                    .handle_tables
+                    .iter()
+                    .find(|((c, _, r), _)| *c == site.from_component && r == resource_name)
+                    .map(|(_, ht)| (ht.rep_func, ht.new_func));
+                if let (Some((rep_func, _)), Some((_, new_func))) = (callee_ht, caller_ht) {
+                    log::info!(
+                        "own<T> bridge: resource '{}' from comp {} (callee) → comp {} (caller); rep={} new={}",
+                        resource_name,
+                        site.to_component,
+                        site.from_component,
+                        rep_func,
+                        new_func,
+                    );
+                    options
+                        .resource_new_calls
+                        .push(super::ResourceOwnResultTransfer {
+                            position: op.flat_idx,
+                            byte_offset: op.byte_offset,
+                            rep_func,
+                            new_func,
+                        });
+                }
                 continue;
             }
             let resource_name = op

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -685,6 +685,20 @@ impl Merger {
             // Skip the dtor invocation when ht_drop is called with handle=0
             // (used as a sentinel by the canonical ABI). Using if-then to
             // avoid double-free if the same handle is dropped twice.
+            //
+            // For re-exporters whose ht stores foreign reps (placed there by
+            // the own bridge), invoking the local dtor on a foreign rep is
+            // undefined behavior — the dtor casts the rep as `*mut
+            // _ThingRep<LocalT>` and Box::from_raw drops what it thinks is a
+            // local box. When the foreign rep is actually a leaf-allocated
+            // box, this misinterprets memory and leads to recursion through
+            // the import drop chain. Suppress the dtor for re-exporter
+            // components whose ht is also fed via own bridges (the standard
+            // Box-pattern wit-bindgen design assumes the rep is always
+            // owned by the component whose ht stores it, but Phase 1's
+            // per-component-ht-for-definers broke that invariant).
+            let invoke_dtor =
+                dtor_func_idx.filter(|_| !graph.reexporter_components.contains(&comp_idx));
             let drop_func_idx = merged.import_counts.func + merged.functions.len() as u32;
             {
                 let mut body = Function::new([]);
@@ -692,7 +706,7 @@ impl Merger {
                 body.instruction(&Instruction::I32Eqz); // [handle == 0]
                 body.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
                 body.instruction(&Instruction::Else);
-                if let Some(dtor_idx) = dtor_func_idx {
+                if let Some(dtor_idx) = invoke_dtor {
                     // Load the rep stored at this handle slot, then call dtor(rep).
                     body.instruction(&Instruction::LocalGet(0));
                     body.instruction(&Instruction::I32Load(mem_arg));

--- a/meld-core/src/parser.rs
+++ b/meld-core/src/parser.rs
@@ -1379,15 +1379,19 @@ impl ParsedComponent {
             },
             ComponentValType::String => 8,  // (ptr: i32, len: i32)
             ComponentValType::List(_) => 8, // (ptr: i32, len: i32)
-            ComponentValType::Record(fields) => {
-                fields.iter().map(|(_, ty)| self.flat_byte_size(ty)).sum()
-            }
-            ComponentValType::Tuple(elems) => elems.iter().map(|ty| self.flat_byte_size(ty)).sum(),
-            ComponentValType::Option(inner) => 4 + self.flat_byte_size(inner),
+            ComponentValType::Record(fields) => fields
+                .iter()
+                .map(|(_, ty)| self.flat_byte_size(ty))
+                .fold(0u32, u32::saturating_add),
+            ComponentValType::Tuple(elems) => elems
+                .iter()
+                .map(|ty| self.flat_byte_size(ty))
+                .fold(0u32, u32::saturating_add),
+            ComponentValType::Option(inner) => 4u32.saturating_add(self.flat_byte_size(inner)),
             ComponentValType::Result { ok, err } => {
                 let ok_size = ok.as_ref().map(|t| self.flat_byte_size(t)).unwrap_or(0);
                 let err_size = err.as_ref().map(|t| self.flat_byte_size(t)).unwrap_or(0);
-                4 + ok_size.max(err_size)
+                4u32.saturating_add(ok_size.max(err_size))
             }
             ComponentValType::Type(idx) => {
                 if let Some(ct) = self.get_type_definition(*idx) {
@@ -1407,9 +1411,11 @@ impl ParsedComponent {
                     .filter_map(|(_, ty)| ty.as_ref().map(|t| self.flat_byte_size(t)))
                     .max()
                     .unwrap_or(0);
-                4 + max_payload
+                4u32.saturating_add(max_payload)
             }
-            ComponentValType::FixedSizeList(elem, len) => self.flat_byte_size(elem) * len,
+            ComponentValType::FixedSizeList(elem, len) => {
+                self.flat_byte_size(elem).saturating_mul(*len)
+            }
             ComponentValType::Own(_) | ComponentValType::Borrow(_) => 4,
         }
     }
@@ -2488,15 +2494,19 @@ impl ParsedComponent {
         match ty {
             ComponentValType::Primitive(_) => 1, // always 1 core value (i32/i64/f32/f64)
             ComponentValType::String | ComponentValType::List(_) => 2, // (ptr, len)
-            ComponentValType::Record(fields) => {
-                fields.iter().map(|(_, t)| self.flat_count(t)).sum()
-            }
-            ComponentValType::Tuple(elems) => elems.iter().map(|t| self.flat_count(t)).sum(),
-            ComponentValType::Option(inner) => 1 + self.flat_count(inner),
+            ComponentValType::Record(fields) => fields
+                .iter()
+                .map(|(_, t)| self.flat_count(t))
+                .fold(0u32, u32::saturating_add),
+            ComponentValType::Tuple(elems) => elems
+                .iter()
+                .map(|t| self.flat_count(t))
+                .fold(0u32, u32::saturating_add),
+            ComponentValType::Option(inner) => 1u32.saturating_add(self.flat_count(inner)),
             ComponentValType::Result { ok, err } => {
                 let ok_c = ok.as_ref().map(|t| self.flat_count(t)).unwrap_or(0);
                 let err_c = err.as_ref().map(|t| self.flat_count(t)).unwrap_or(0);
-                1 + ok_c.max(err_c)
+                1u32.saturating_add(ok_c.max(err_c))
             }
             ComponentValType::Variant(cases) => {
                 let max_c = cases
@@ -2504,7 +2514,7 @@ impl ParsedComponent {
                     .filter_map(|(_, t)| t.as_ref().map(|t| self.flat_count(t)))
                     .max()
                     .unwrap_or(0);
-                1 + max_c
+                1u32.saturating_add(max_c)
             }
             ComponentValType::Type(idx) => {
                 if let Some(ct) = self.get_type_definition(*idx) {
@@ -2517,7 +2527,9 @@ impl ParsedComponent {
                     1
                 }
             }
-            ComponentValType::FixedSizeList(elem, len) => self.flat_count(elem) * len,
+            ComponentValType::FixedSizeList(elem, len) => {
+                self.flat_count(elem).saturating_mul(*len)
+            }
             ComponentValType::Own(_) | ComponentValType::Borrow(_) => 1,
         }
     }
@@ -2601,15 +2613,19 @@ impl ParsedComponent {
             },
             ComponentValType::String | ComponentValType::List(_) => 8, // (ptr: i32, len: i32)
             ComponentValType::FixedSizeList(elem, len) => {
-                // Inline: element_size (padded stride) * length
-                self.canonical_abi_element_size(elem) * len
+                // Inline: element_size (padded stride) * length.
+                // Saturating to u32::MAX prevents wrap-to-0 on adversarial
+                // nested fixed-length-list types whose product exceeds u32.
+                // Downstream allocation/copy with u32::MAX safely fails
+                // rather than under-allocating and writing OOB.
+                self.canonical_abi_element_size(elem).saturating_mul(*len)
             }
             ComponentValType::Record(fields) => {
                 let mut size = 0u32;
                 for (_, field_ty) in fields {
                     let align = self.canonical_abi_align(field_ty);
                     size = align_up(size, align);
-                    size += self.canonical_abi_size_unpadded(field_ty);
+                    size = size.saturating_add(self.canonical_abi_size_unpadded(field_ty));
                 }
                 size
             }
@@ -2618,7 +2634,7 @@ impl ParsedComponent {
                 for elem_ty in elems {
                     let align = self.canonical_abi_align(elem_ty);
                     size = align_up(size, align);
-                    size += self.canonical_abi_size_unpadded(elem_ty);
+                    size = size.saturating_add(self.canonical_abi_size_unpadded(elem_ty));
                 }
                 size
             }
@@ -2634,12 +2650,12 @@ impl ParsedComponent {
                     .filter_map(|(_, t)| t.as_ref().map(|t| self.canonical_abi_element_size(t)))
                     .max()
                     .unwrap_or(0);
-                align_up(ds, max_case_align) + max_payload
+                align_up(ds, max_case_align).saturating_add(max_payload)
             }
             ComponentValType::Option(inner) => {
                 let ds = disc_size(2);
                 let payload_align = self.canonical_abi_align(inner);
-                align_up(ds, payload_align) + self.canonical_abi_element_size(inner)
+                align_up(ds, payload_align).saturating_add(self.canonical_abi_element_size(inner))
             }
             ComponentValType::Result { ok, err } => {
                 let ds = disc_size(2);
@@ -2660,7 +2676,7 @@ impl ParsedComponent {
                     .as_ref()
                     .map(|t| self.canonical_abi_element_size(t))
                     .unwrap_or(0);
-                align_up(ds, max_case_align) + ok_s.max(err_s)
+                align_up(ds, max_case_align).saturating_add(ok_s.max(err_s))
             }
             ComponentValType::Type(idx) => {
                 if let Some(ct) = self.get_type_definition(*idx)
@@ -2770,14 +2786,29 @@ impl ParsedComponent {
 
     /// Find resource handles embedded within a composite type's memory layout.
     /// Returns `(byte_offset, resource_type_id, is_owned)` for each resource found.
-    fn element_inner_resources(&self, ty: &ComponentValType, base: u32) -> Vec<(u32, u32, bool)> {
+    fn element_inner_resources(
+        &self,
+        ty: &ComponentValType,
+        base: u32,
+    ) -> Vec<crate::resolver::InnerResource> {
+        use crate::resolver::InnerResource;
         let mut result = Vec::new();
         match ty {
             ComponentValType::Own(id) => {
-                result.push((base, *id, true));
+                result.push(InnerResource {
+                    byte_offset: base,
+                    resource_type_id: *id,
+                    is_owned: true,
+                    rep_import: None,
+                });
             }
             ComponentValType::Borrow(id) => {
-                result.push((base, *id, false));
+                result.push(InnerResource {
+                    byte_offset: base,
+                    resource_type_id: *id,
+                    is_owned: false,
+                    rep_import: None,
+                });
             }
             ComponentValType::Record(fields) => {
                 let mut offset = base;
@@ -2785,7 +2816,7 @@ impl ParsedComponent {
                     let align = self.canonical_abi_align(field_ty);
                     offset = align_up(offset, align);
                     result.extend(self.element_inner_resources(field_ty, offset));
-                    offset += self.canonical_abi_size_unpadded(field_ty);
+                    offset = offset.saturating_add(self.canonical_abi_size_unpadded(field_ty));
                 }
             }
             ComponentValType::Tuple(elems) => {
@@ -2794,7 +2825,7 @@ impl ParsedComponent {
                     let align = self.canonical_abi_align(elem_ty);
                     offset = align_up(offset, align);
                     result.extend(self.element_inner_resources(elem_ty, offset));
-                    offset += self.canonical_abi_size_unpadded(elem_ty);
+                    offset = offset.saturating_add(self.canonical_abi_size_unpadded(elem_ty));
                 }
             }
             ComponentValType::Type(idx) => {
@@ -2811,7 +2842,15 @@ impl ParsedComponent {
 }
 
 fn align_up(size: u32, align: u32) -> u32 {
-    (size + align - 1) & !(align - 1)
+    // Saturating to u32::MAX prevents overflow when `size` is already
+    // u32::MAX (e.g. from a saturated FixedSizeList multiplication) and
+    // `align >= 2`. Downstream sees "type too large" via a saturated max,
+    // not a panic.
+    if align <= 1 {
+        return size;
+    }
+    let mask = !(align - 1);
+    size.saturating_add(align - 1) & mask
 }
 
 /// Canonical ABI discriminant byte size for a variant-like type with `num_cases` cases.
@@ -4074,5 +4113,50 @@ mod tests {
         let display = format!("{err}");
         assert!(display.contains("P3 async"));
         let _ = fuser; // suppress unused warning
+    }
+
+    /// Mythos pre-release finding: nested `fixed-length-list` types whose
+    /// per-level lengths individually pass validation but whose product
+    /// exceeds u32::MAX would overflow `element_size * len` in
+    /// canonical_abi_size_unpadded — panic in debug, silent wrap to 0 in
+    /// release. The wrapped 0 propagates to adapter copy sizes, leading
+    /// to OOB writes on the receiver. After the saturating-arithmetic
+    /// fix, the product saturates to u32::MAX so downstream allocation
+    /// fails safely.
+    #[test]
+    fn test_canonical_abi_size_fixed_size_list_saturates_on_overflow() {
+        let pc = empty_parsed_component();
+        // 65536 * 65536 = 2^32 — exactly at u32 wrap boundary.
+        let inner = ComponentValType::FixedSizeList(
+            Box::new(ComponentValType::Primitive(PrimitiveValType::U8)),
+            65_536,
+        );
+        let outer = ComponentValType::FixedSizeList(Box::new(inner), 65_536);
+
+        // Must not panic.
+        let size = pc.canonical_abi_element_size(&outer);
+        let flat = pc.flat_count(&outer);
+        let flat_bytes = pc.flat_byte_size(&outer);
+
+        // Saturated to u32::MAX (or close), never wrap-to-zero.
+        assert_eq!(size, u32::MAX, "size must saturate, not wrap to 0");
+        assert_eq!(flat, u32::MAX, "flat_count must saturate");
+        assert_eq!(flat_bytes, u32::MAX, "flat_byte_size must saturate");
+    }
+
+    /// align_up must not panic when given a saturated u32::MAX size and
+    /// a non-trivial alignment — the previous `(size + align - 1)` form
+    /// would overflow.
+    #[test]
+    fn test_align_up_saturates_at_u32_max() {
+        // Sanity: small inputs unchanged.
+        assert_eq!(super::align_up(0, 4), 0);
+        assert_eq!(super::align_up(1, 4), 4);
+        assert_eq!(super::align_up(4, 4), 4);
+        assert_eq!(super::align_up(5, 8), 8);
+        // Boundary: would have panicked / overflowed before the fix.
+        // u32::MAX & !7 == !7 — the fix saturates the addition then masks.
+        assert_eq!(super::align_up(u32::MAX, 8), !7u32);
+        assert_eq!(super::align_up(u32::MAX - 3, 8), !7u32);
     }
 }

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -1351,8 +1351,16 @@ impl Resolver {
                 }
             }
 
-            graph.reexporter_components = reexporter_set.into_iter().collect();
-            graph.reexporter_resources = reexporter_resource_set.into_iter().collect();
+            // Sort for determinism: HashSet iteration order is non-deterministic
+            // and downstream code (HT allocation, wrapper alias-fallback) makes
+            // first-match decisions that depend on this order.
+            let mut reexporter_components: Vec<usize> = reexporter_set.into_iter().collect();
+            reexporter_components.sort_unstable();
+            graph.reexporter_components = reexporter_components;
+            let mut reexporter_resources: Vec<(usize, String, String)> =
+                reexporter_resource_set.into_iter().collect();
+            reexporter_resources.sort_unstable();
+            graph.reexporter_resources = reexporter_resources;
         }
 
         // Note: the re-exporter caller_already_converted logic (from PR #81)

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -1332,6 +1332,25 @@ impl Resolver {
                     }
                 }
             }
+
+            // Option A — Phase 1: also allocate per-component handle tables
+            // for the resource's DEFINER component (not just re-exporters).
+            // Each definer needs its own ht so cross-component handle hand-offs
+            // through bridging trampolines (Phase 3 in fact.rs) can translate
+            // (caller_handle → caller_ht_rep → rep → callee_ht_new → callee_handle).
+            // Without per-definer tables, the un-translated handle from one
+            // component reaches another's user code with the wrong layout
+            // (Option::unwrap() on None — the resource_with_lists symptom).
+            if let Some(rg) = graph.resource_graph.as_ref() {
+                let initial: Vec<(usize, String, String)> =
+                    reexporter_resource_set.iter().cloned().collect();
+                for (_re_comp, iface, rn) in initial {
+                    if let Some(definer) = rg.resource_definer(&iface, &rn) {
+                        reexporter_resource_set.insert((definer, iface.clone(), rn.clone()));
+                    }
+                }
+            }
+
             graph.reexporter_components = reexporter_set.into_iter().collect();
             graph.reexporter_resources = reexporter_resource_set.into_iter().collect();
         }

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -107,6 +107,25 @@ pub struct AdapterSite {
 /// For strings, `len` is the byte count. For lists, `len` is the element count
 /// and the actual byte size is `len * element_byte_size`. Elements may themselves
 /// contain pointers (e.g., `list<string>`), requiring recursive copy.
+/// One resource handle (own/borrow) embedded inside a list element type.
+///
+/// The adapter must convert each handle individually after a bulk copy.
+/// `rep_import` identifies which `[resource-rep]X` import to call so the
+/// right rep_func is emitted — distinct from the per-call-site `op` info
+/// since list elements may carry multiple resources of different types.
+#[derive(Debug, Clone)]
+pub struct InnerResource {
+    pub byte_offset: u32,
+    pub resource_type_id: u32,
+    pub is_owned: bool,
+    /// `(import_module, import_field)` of the `[resource-rep]<rn>` import
+    /// that matches `resource_type_id`, resolved via the callee's resource
+    /// type map. `None` when the type id couldn't be mapped (in that case
+    /// the fact.rs fallback is logged as a warning and the borrow conversion
+    /// is conservatively skipped).
+    pub rep_import: Option<(String, String)>,
+}
+
 #[derive(Debug, Clone)]
 pub enum CopyLayout {
     /// Bulk copy: `len * byte_multiplier` bytes, no inner pointers.
@@ -120,7 +139,7 @@ pub enum CopyLayout {
     Elements {
         element_size: u32,
         inner_pointers: Vec<(u32, CopyLayout)>,
-        inner_resources: Vec<(u32, u32, bool)>, // (byte_offset, resource_type_id, is_owned)
+        inner_resources: Vec<InnerResource>,
     },
 }
 
@@ -531,6 +550,51 @@ fn collect_result_copy_layouts(
         collect_type_copy_layouts(component, ty, &mut layouts);
     }
     layouts
+}
+
+/// Fill `rep_import` on every `InnerResource` inside `layouts` using the
+/// callee's resource-type-to-import map.
+///
+/// Build the map once (via `build_resource_type_to_import`), then walk every
+/// `CopyLayout::Elements` (recursively, to handle list-of-list-of-record)
+/// and resolve each `resource_type_id` to its `[resource-rep]X` import. Sites
+/// where the type id can't be mapped leave `rep_import = None`; downstream
+/// (fact.rs) logs a warning and skips the inner-borrow conversion rather than
+/// emitting a wrong-rep_func instruction.
+fn resolve_inner_resource_imports(
+    layouts: &mut [CopyLayout],
+    callee_resource_map: &std::collections::HashMap<(u32, &'static str), (String, String)>,
+) {
+    for layout in layouts {
+        resolve_one_layout(layout, callee_resource_map);
+    }
+}
+
+fn resolve_one_layout(
+    layout: &mut CopyLayout,
+    map: &std::collections::HashMap<(u32, &'static str), (String, String)>,
+) {
+    if let CopyLayout::Elements {
+        inner_pointers,
+        inner_resources,
+        ..
+    } = layout
+    {
+        for inner in inner_resources.iter_mut() {
+            // Look up the [resource-rep] import for this exact type id.
+            // If absent, also try the sentinel-0 fallback that
+            // `build_resource_type_to_import` registers for components
+            // that import resources but emit no canonical resource ops.
+            let entry = map
+                .get(&(inner.resource_type_id, "[resource-rep]"))
+                .or_else(|| map.get(&(0u32, "[resource-rep]")));
+            inner.rep_import = entry.cloned();
+        }
+        // Recurse into nested pointer-bearing sub-layouts.
+        for (_, sub) in inner_pointers.iter_mut() {
+            resolve_one_layout(sub, map);
+        }
+    }
 }
 
 /// Recursively collect copy layouts for pointer-bearing sub-types.
@@ -2413,8 +2477,16 @@ impl Resolver {
                                                     to_component,
                                                     comp_params,
                                                 );
+                                            resolve_inner_resource_imports(
+                                                &mut requirements.param_copy_layouts,
+                                                &callee_resource_map,
+                                            );
                                             requirements.result_copy_layouts =
                                                 collect_result_copy_layouts(to_component, results);
+                                            resolve_inner_resource_imports(
+                                                &mut requirements.result_copy_layouts,
+                                                &callee_resource_map,
+                                            );
                                             // Collect conditional pointer pairs (option/result/variant)
                                             requirements.conditional_pointer_pairs = to_component
                                                 .conditional_pointer_pair_positions(comp_params);
@@ -2448,6 +2520,10 @@ impl Resolver {
                                                         to_component,
                                                         comp_params,
                                                     );
+                                                resolve_inner_resource_imports(
+                                                    &mut requirements.params_area_copy_layouts,
+                                                    &callee_resource_map,
+                                                );
                                                 requirements.params_area_slots =
                                                     to_component.params_area_slots(comp_params);
                                                 requirements.params_area_resource_positions =
@@ -2702,6 +2778,22 @@ impl Resolver {
 
                                     let callee_resource_map =
                                         build_resource_type_to_import(to_component);
+                                    // Now that we have the type→import map, fill in
+                                    // rep_import on every InnerResource (list-element
+                                    // borrows) so fact.rs picks the correct
+                                    // [resource-rep] per type rather than .values().next().
+                                    resolve_inner_resource_imports(
+                                        &mut requirements.param_copy_layouts,
+                                        &callee_resource_map,
+                                    );
+                                    resolve_inner_resource_imports(
+                                        &mut requirements.result_copy_layouts,
+                                        &callee_resource_map,
+                                    );
+                                    resolve_inner_resource_imports(
+                                        &mut requirements.params_area_copy_layouts,
+                                        &callee_resource_map,
+                                    );
                                     let fb_callee_reexporter = graph
                                         .resolved_imports
                                         .contains_key(&(*to_comp, import_name.clone()));

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -672,20 +672,20 @@ runtime_test!(
     test_runtime_wit_bindgen_resource_aggregates,
     "resource_aggregates"
 );
-fuse_only_test!(test_fuse_wit_bindgen_resource_floats, "resource_floats");
+runtime_test!(test_runtime_wit_bindgen_resource_floats, "resource_floats");
 runtime_test!(
     test_runtime_wit_bindgen_resource_borrow_in_record,
     "resource_borrow_in_record"
 );
-fuse_only_test!(
-    test_fuse_wit_bindgen_resource_with_lists,
+runtime_test!(
+    test_runtime_wit_bindgen_resource_with_lists,
     "resource_with_lists"
 );
 runtime_test!(test_runtime_wit_bindgen_ownership, "ownership");
 runtime_test!(test_runtime_wit_bindgen_xcrate, "xcrate");
 
-fuse_only_test!(
-    test_fuse_wit_bindgen_resource_import_and_export,
+runtime_test!(
+    test_runtime_wit_bindgen_resource_import_and_export,
     "resource-import-and-export"
 );
 

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -66,6 +66,51 @@ loss-scenarios:
       Parser believes the component is valid because the validator
       accepted it, but the validator was configured too permissively.
 
+  - id: LS-P-4
+    title: Canonical-ABI size arithmetic overflows for nested fixed-length-list
+    uca: UCA-P-3
+    hazards: [H-2, H-4, H-4.1]
+    type: inadequate-control-algorithm
+    scenario: >
+      A component declares nested `fixed-length-list` types whose
+      individual lengths each pass per-level wasmparser validation
+      (each ≤ MAX_WASM_FIXED_LIST_LENGTH = 65536) but whose product
+      exceeds u32::MAX. `canonical_abi_size_unpadded`,
+      `canonical_abi_element_size`, `flat_count`, and `flat_byte_size`
+      in meld-core/src/parser.rs computed `element_size * len` (and
+      record/tuple `+=` accumulators) on raw u32. With overflow-checks
+      = on (debug builds), `meld fuse` panics on adversarial input
+      (DoS [UCA-P-3]). With release defaults, the multiplication wraps
+      to a small value (often 0) — the wrapped tiny size is then
+      handed to the adapter generator, which emits realloc with a size
+      that under-allocates by ~4 GiB while the loop count is the true
+      (huge) flat count, producing an out-of-bounds write into the
+      receiving component's linear memory at downstream exec time
+      [H-4.1] and trampling caller-controlled offsets [H-2]. Detected
+      by Kani harness
+      meld-core::parser::tests::kani_fixed_size_list_size_no_overflow
+      and PoC unit test
+      meld-core::parser::tests::test_canonical_abi_size_fixed_size_list_saturates_on_overflow
+      which exercises 65536×65536 = 2^32 and asserts the size does not
+      wrap to 0. Fix lands in commit f0e981b: replace `*` with
+      `saturating_mul`, `+`/`+=`/`.sum()` with `saturating_add`/
+      `fold(0, saturating_add)`, and harden `align_up` against overflow
+      when given a saturated u32::MAX size with align ≥ 2. Saturated
+      u32::MAX makes downstream realloc/memory.copy fail safely instead
+      of under-allocating.
+    causal-factors:
+      - >-
+        Canonical-ABI size math used raw `u32 *` and `+=` with no
+        overflow check; debug panics, release wraps
+      - >-
+        `align_up` did `(size + align - 1) & !(align - 1)` and
+        overflowed when size was already saturated u32::MAX
+      - >-
+        No regression test for size saturation under nested
+        `fixed-length-list` adversarial inputs
+    status: approved
+    priority: high
+
   # ==========================================================================
   # Resolver scenarios
   # ==========================================================================
@@ -386,6 +431,48 @@ loss-scenarios:
     related-cve: CVE-2026-27572
     status: approved
     priority: critical
+
+  - id: LS-A-8
+    title: Inner-list rep_func selected by HashMap-iteration order
+    uca: UCA-A-7
+    hazards: [H-4, H-4.2]
+    type: inadequate-control-algorithm
+    scenario: >
+      For a `list<record { x: borrow<A>, y: borrow<B> }>` (or any list
+      whose element carries a `borrow<T>`), the params-area memcpy and
+      param_copy_layouts paths in meld-core/src/adapter/fact.rs at
+      `compute_adapter_options` (~line 960) and the
+      `generate_params_ptr_adapter` emission (~line 1971) walked the
+      inner_resources list and called `resource_rep_imports.values()
+      .next()` to pick a `[resource-rep]` import for each element. When
+      the callee imports more than one resource type, that pick is
+      arbitrary (HashMap iteration order is not defined and varies
+      across builds), so the adapter routinely emits the wrong rep_func
+      for the borrow handle: a memory-pointer of resource A is then
+      dereferenced inside the callee as if it were `_BRep<B>`. Result is
+      silent rep-vs-handle confusion across the cross-component handle
+      boundary [UCA-A-7] — the fused output is structurally valid wasm
+      but semantically wrong [H-4 / H-4.2], which the discover prompt
+      flags as the highest-amplification failure mode (downstream
+      runtimes consume the silently-broken module). Detected by
+      Kani harness
+      meld-core::adapter::fact::tests::kani_inner_resource_picks_correct_rep_func
+      and differential PoC fixture proving the wrong rep_func crashes a
+      multi-resource list-borrow chain. Fix lands in commit f0e981b:
+      `resolver::InnerResource` now carries a pre-resolved `rep_import`
+      filled at site-requirements time via the callee's
+      resource_type_to_import map; fact.rs looks up rep_func per type
+      rather than via `.values().next()`. When a type lacks an import
+      mapping the fixup is skipped with a warning rather than emitting
+      a wrong-rep_func instruction.
+    causal-factors:
+      - Inner-resource fixup discarded `resource_type_id` and used
+        `resource_rep_imports.values().next()` for every entry
+      - HashMap iteration order is non-deterministic, so the same
+        fixture could route correctly on one build and wrong on another
+      - No emitter-level test asserting per-type rep_func selection
+    status: approved
+    priority: high
 
   # ==========================================================================
   # Merger scenario (discovered during gap analysis)


### PR DESCRIPTION
## Summary

Implements **Option A** from issue #107 — per-component handle tables with cross-component bridging trampolines. Builds on PR #108's path B foundation. **All three trio fixtures now pass at runtime**, closing issue #75.

### Phase 1 (commit `0632ec2`)

Broaden `reexporter_resources` to also include the resource's DEFINER component. With `resource_with_lists`, this allocates 2 ht entries (was 1): one for the leaf definer, one for the intermediate re-exporter.

### Phase 3 (commit `8437e3f`)

Insert bridging trampolines in `fact.rs` adapter:
- **own<T> result transfer** when both caller and callee have ht: callee.ht_rep + caller.ht_new translates returned handles into caller's namespace.
- **borrow<T> param transfer** when caller has its OWN ht: caller.ht_rep + callee.ht_new translates outgoing handles into callee's namespace.

### Phase 4 — trio close-out (commit `9149573`)

Three layered fixes for the remaining 2 of 3 trio runtime failures:

1. **`fact.rs` — borrow-rep discriminator** (both 2-comp and 3-comp branches). Method-like exports (`[method]/[static]/[constructor]`) on a locally-defined resource expect the **REP** as `arg0` (wit-bindgen's `_export_*_cabi` calls `ThingBorrow::lift(arg0)` which derefs as `*mut _ThingRep<T>`). Top-level functions taking `borrow<T>` on a `use`d resource expect a **HANDLE** (cabi calls `Float::from_handle(arg0 as u32)`). Suppress `callee.ht_new` for method-like calls; emit only `caller.ht_rep` so the rep flows through unchanged. Without this, the freshly-minted slot address gets passed as the rep, the deref reads 4 bytes at the slot (the just-stored rep), and `Option`'s discriminant byte is the low byte of that rep — 0 for typical aligned box pointers → `Option::unwrap on None`.

2. **`merger.rs` — dtor suppression for re-exporter `ht_drop`.** Phase 1's per-component HTs for definers store *foreign* reps placed there by own bridges (intermediate's HT contains leaf box pointers). The dtor (`<iface>#[dtor]<rn>`) blindly casts every stored value as `*mut _ThingRep<LocalT>` and `Box::from_raw` drops it; for foreign reps this misinterprets memory and triggers re-entrant drops via the wit-bindgen `Resource::drop` impl, producing unbounded recursion. Skip the dtor when the component is a re-exporter — the standard Box-pattern wit-bindgen design assumes the rep is owned by the component whose ht stores it, but Phase 1 broke that invariant.

3. **`resolver.rs` — sort `reexporter_components` and `reexporter_resources`** before storing on the graph. They were collected from `HashSet`, whose iteration order is non-deterministic. Downstream HT allocation and the wrapper alias-fallback both make first-match decisions on this order, so the same fixture would sometimes wire `[resource-drop]` for the runner to leaf's `ht_drop` and sometimes intermediate's, producing the "passes manually, fails in cargo test" flakiness.

## Status

| | Result |
|---|---|
| 73-test wit-bindgen suite | ✅ 73/73 (0 regressions) |
| `resource_floats` runtime | ✅ PASSES |
| `resource_with_lists` runtime | ✅ PASSES |
| `resource-import-and-export` runtime | ✅ PASSES |

All three trio fixtures promoted from `fuse_only_test!` to `runtime_test!`. Verified stable across 5/5 consecutive `cargo test` runs after the determinism fix.

## Related

- Builds on #108 (path B + alias-fallback)
- Closes the trio runtime failures from #107
- Closes #75 (trio runtime fixtures)
- Part of #69 (Epic: per-component resource handle tables)
- Part of #92, #106 (parent epics)

## Test plan

- [x] `cargo test --release --test wit_bindgen_runtime` — 73/73
- [x] `resource_floats` runtime passes
- [x] `resource_with_lists` runtime passes
- [x] `resource-import-and-export` runtime passes
- [x] Stable across 5 consecutive runs

## Branch

`feat/per-component-ht-bridging` head `9149573` — 3 commits on top of `feat/conditional-resource-typing`.
