### PR TITLE
feat: criterion benchmarks for fusion pipeline (closes #103)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,53 @@
+name: Bench Smoke
+
+# Compile-only sanity check for the criterion fusion benches. Catches the
+# common regression where someone refactors a public API and the benches
+# silently rot. Does NOT run the actual benchmarks — running them on shared
+# CI runners produces noisy, untrustworthy numbers and slows PR feedback.
+#
+# Full benchmark runs are intended to live on a dedicated host (or be
+# reproduced locally with `cargo bench -p meld-core`).
+#
+# Security note: every `run:` step below uses values that come exclusively
+# from the workflow file itself. No untrusted event payloads (issue/PR
+# titles, commit messages, branch refs from forks, etc.) are interpolated
+# into shell commands. If you add steps that consume `github.event.*` data,
+# route it through `env:` first.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  bench-smoke:
+    name: Bench compile-only
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-bench-
+
+      - name: Compile benches (no run)
+        run: cargo bench -p meld-core --no-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +297,33 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -514,6 +553,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +612,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -880,6 +961,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +997,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1094,10 +1192,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1271,6 +1389,7 @@ version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitflags",
+ "criterion",
  "hex",
  "log",
  "petgraph 0.8.3",
@@ -1348,6 +1467,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1511,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1744,6 +1897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2337,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2497,7 +2679,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object",
  "pulley-interpreter",
@@ -2692,6 +2874,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
 dependencies = [
  "wast 246.0.2",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ env_logger = "0.11"
 
 # Testing
 proptest = "1.5"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 # Required for wit-bindgen component bindings (WASI filesystem interfaces)
 bitflags = "2.6"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 &nbsp;
 
 [![CI](https://github.com/pulseengine/meld/actions/workflows/ci.yml/badge.svg)](https://github.com/pulseengine/meld/actions/workflows/ci.yml)
+[![Bench](https://github.com/pulseengine/meld/actions/workflows/bench.yml/badge.svg)](https://github.com/pulseengine/meld/actions/workflows/bench.yml)
 [![codecov](https://codecov.io/gh/pulseengine/meld/graph/badge.svg)](https://codecov.io/gh/pulseengine/meld)
 ![Rust](https://img.shields.io/badge/Rust-CE422B?style=flat-square&logo=rust&logoColor=white&labelColor=1a1b27)
 ![WebAssembly](https://img.shields.io/badge/WebAssembly-654FF0?style=flat-square&logo=webassembly&logoColor=white&labelColor=1a1b27)
@@ -151,6 +152,27 @@ cargo test                 # Test
 bazel build //...          # Bazel build
 RUST_LOG=debug cargo run -- fuse a.wasm b.wasm -o out.wasm
 ```
+
+### Benchmarks
+
+Criterion benchmarks for the fusion pipeline live in
+`meld-core/benches/fusion_benchmarks.rs` and exercise four groups:
+
+- `parser` — `ComponentParser::parse` throughput per input byte.
+- `merger` — `Merger::merge` throughput per component count.
+- `resolver` — `Resolver::resolve_with_hints` throughput per resolved-symbol count.
+- `end_to_end` — `Fuser::fuse_with_stats` over small / medium / large
+  graphs.
+
+```bash
+cargo bench -p meld-core                          # full run
+cargo bench -p meld-core --bench fusion_benchmarks -- parser   # one group
+cargo bench -p meld-core --no-run                 # compile-only sanity (CI smoke)
+```
+
+CI runs `cargo bench --no-run` on every PR (`.github/workflows/bench.yml`)
+to prevent the bench harness from rotting. Full benches are not run in CI
+to keep PRs fast and avoid noisy regressions on shared runners.
 
 ## License
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -218,7 +218,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "meld-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/meld-core/Cargo.toml
+++ b/meld-core/Cargo.toml
@@ -44,8 +44,13 @@ wat = "1.219"
 wasmtime = "41.0.1"
 wasmtime-wasi = "41.0.4"
 bitflags.workspace = true  # Required for wit-bindgen component bindings
+criterion.workspace = true
 
 [features]
 default = []
 # Enable wsc-attestation integration for supply chain tracking
 attestation = ["wsc-attestation"]
+
+[[bench]]
+name = "fusion_benchmarks"
+harness = false

--- a/meld-core/benches/fusion_benchmarks.rs
+++ b/meld-core/benches/fusion_benchmarks.rs
@@ -1,0 +1,269 @@
+//! Criterion benchmarks for the meld fusion pipeline.
+//!
+//! meld is on the hot path of every pulseengine toolchain build (fuse runs
+//! before loom/kiln/synth), so a silent slowdown in the parser, merger, or
+//! resolver translates directly into longer build times across the estate.
+//!
+//! These benchmarks exercise the four observable stages of the pipeline so
+//! regressions are pinpoint-able rather than only visible at the end-to-end
+//! level:
+//!
+//! 1. [`bench_parser`] — `ComponentParser::parse` on real wit-bindgen
+//!    fixtures, with throughput reported per input byte.
+//! 2. [`bench_merger`] — `Merger::merge` against pre-parsed components and
+//!    a pre-built dependency graph, throughput per component count.
+//! 3. [`bench_resolver`] — `Resolver::resolve_with_hints` against pre-parsed
+//!    components, throughput per resolved-import (symbol) count.
+//! 4. [`bench_end_to_end`] — `Fuser::fuse_with_stats` for small (1 fixture),
+//!    medium (5 fixtures), and large (12 fixtures) component graphs.
+//!
+//! Run with:
+//!     cargo bench -p meld-core
+//! Or compile-only sanity (used in CI):
+//!     cargo bench -p meld-core --no-run
+//!
+//! Fixtures live at `meld/tests/wit_bindgen/fixtures/`. If the fixture
+//! directory is unavailable the bench gracefully skips groups instead of
+//! panicking.
+
+use std::path::Path;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use meld_core::{
+    ComponentParser, CustomSectionHandling, Fuser, FuserConfig, MemoryStrategy, OutputFormat,
+    ParsedComponent, WiringHints, merger::Merger, resolver::Resolver,
+};
+
+const FIXTURES_DIR: &str = "../tests/wit_bindgen/fixtures";
+
+/// Fixtures known to fuse cleanly; chosen to span small / medium / large
+/// payload sizes without exceeding what is checked into the repo.
+const FIXTURES: &[&str] = &[
+    "numbers",
+    "strings",
+    "strings-simple",
+    "lists",
+    "lists-alias",
+    "records",
+    "variants",
+    "options",
+    "results",
+    "many-arguments",
+    "fixed-length-lists",
+    "flavorful",
+];
+
+/// Read a fixture file, returning `None` if it is missing so callers can
+/// skip rather than panic. The tracked corpus is small (~7-12 MB per file)
+/// but absence is tolerated for partial checkouts.
+fn read_fixture(name: &str) -> Option<Vec<u8>> {
+    let path = format!("{FIXTURES_DIR}/{name}.wasm");
+    if !Path::new(&path).is_file() {
+        eprintln!("skipping {name}: fixture not found at {path}");
+        return None;
+    }
+    std::fs::read(&path).ok()
+}
+
+/// Default fuser config for benches: deterministic, no attestation overhead,
+/// drop custom sections so we measure pipeline cost (not section copy cost).
+fn bench_config() -> FuserConfig {
+    FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        address_rebasing: false,
+        preserve_names: false,
+        custom_sections: CustomSectionHandling::Drop,
+        output_format: OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
+    }
+}
+
+/// Drive `Fuser::add_component_named` so we get the same flattened slice the
+/// fusion pipeline uses internally, then surface `(components, wiring_hints)`
+/// for the merger/resolver benches.
+fn flatten_fixture(name: &str, bytes: &[u8]) -> Option<(Vec<ParsedComponent>, WiringHints)> {
+    let mut fuser = Fuser::new(bench_config());
+    fuser.add_component_named(bytes, Some(name)).ok()?;
+    Some((fuser.components().to_vec(), fuser.wiring_hints().clone()))
+}
+
+// ---------------------------------------------------------------------------
+// Group 1: Parser throughput (per input byte)
+// ---------------------------------------------------------------------------
+
+fn bench_parser(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parser");
+    group.measurement_time(Duration::from_secs(5));
+
+    for &name in FIXTURES {
+        let Some(bytes) = read_fixture(name) else {
+            continue;
+        };
+        group.throughput(Throughput::Bytes(bytes.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(name), &bytes, |b, bytes| {
+            b.iter(|| {
+                let parser = ComponentParser::new();
+                let parsed = parser.parse(black_box(bytes)).unwrap();
+                black_box(parsed);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Group 2: Merger throughput (per component count)
+// ---------------------------------------------------------------------------
+
+fn bench_merger(c: &mut Criterion) {
+    let mut group = c.benchmark_group("merger");
+    group.measurement_time(Duration::from_secs(5));
+
+    for &name in FIXTURES {
+        let Some(bytes) = read_fixture(name) else {
+            continue;
+        };
+        let Some((components, hints)) = flatten_fixture(name, &bytes) else {
+            continue;
+        };
+
+        // Pre-build the dependency graph once; we only want to measure
+        // merge() cost in this group.
+        let resolver = Resolver::with_strategy(MemoryStrategy::MultiMemory);
+        let Ok(graph) = resolver.resolve_with_hints(&components, &hints) else {
+            eprintln!("skipping {name}: resolver failed");
+            continue;
+        };
+
+        group.throughput(Throughput::Elements(components.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &(components, graph),
+            |b, (components, graph)| {
+                b.iter(|| {
+                    let merger = Merger::new(MemoryStrategy::MultiMemory, false);
+                    let merged = merger
+                        .merge(black_box(components), black_box(graph))
+                        .unwrap();
+                    black_box(merged);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Group 3: Resolver throughput (per resolved-symbol count)
+// ---------------------------------------------------------------------------
+
+fn bench_resolver(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resolver");
+    group.measurement_time(Duration::from_secs(5));
+
+    for &name in FIXTURES {
+        let Some(bytes) = read_fixture(name) else {
+            continue;
+        };
+        let Some((components, hints)) = flatten_fixture(name, &bytes) else {
+            continue;
+        };
+
+        // Run once to learn the symbol (resolved-import) count for the
+        // throughput axis. Resolution is deterministic so this is stable.
+        let resolver = Resolver::with_strategy(MemoryStrategy::MultiMemory);
+        let symbol_count = match resolver.resolve_with_hints(&components, &hints) {
+            Ok(graph) => graph.resolved_imports.len().max(1) as u64,
+            Err(_) => {
+                eprintln!("skipping {name}: resolver failed during probe");
+                continue;
+            }
+        };
+
+        group.throughput(Throughput::Elements(symbol_count));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &(components, hints),
+            |b, (components, hints)| {
+                b.iter(|| {
+                    let resolver = Resolver::with_strategy(MemoryStrategy::MultiMemory);
+                    let graph = resolver
+                        .resolve_with_hints(black_box(components), black_box(hints))
+                        .unwrap();
+                    black_box(graph);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Group 4: End-to-end fusion throughput
+// ---------------------------------------------------------------------------
+
+/// Build a `Fuser` populated with the requested fixtures. Each fixture is a
+/// self-contained P2 component (host + guest); adding several into one fuser
+/// exercises the parse/resolve/merge passes on a multi-fixture graph even
+/// though the fixtures don't share imports.
+fn build_fuser(names: &[&str]) -> Option<Fuser> {
+    let mut fuser = Fuser::new(bench_config());
+    for &name in names {
+        let bytes = read_fixture(name)?;
+        fuser.add_component_named(&bytes, Some(name)).ok()?;
+    }
+    Some(fuser)
+}
+
+fn bench_end_to_end(c: &mut Criterion) {
+    let mut group = c.benchmark_group("end_to_end");
+    // Full pipeline runs are slower; allow more time per iteration.
+    group.measurement_time(Duration::from_secs(8));
+    group.sample_size(20);
+
+    // Small graph: one fixture (still flattens to several sub-components).
+    let small: &[&str] = &["numbers"];
+    // Medium graph: 5 fixtures.
+    let medium: &[&str] = &["numbers", "strings", "lists", "records", "variants"];
+    // Large graph: 12 fixtures (the whole curated corpus).
+    let large: &[&str] = FIXTURES;
+
+    for (label, fixtures) in [("small", small), ("medium", medium), ("large", large)] {
+        let Some(fuser) = build_fuser(fixtures) else {
+            eprintln!("skipping end_to_end/{label}: missing fixtures");
+            continue;
+        };
+        let component_count = fuser.component_count() as u64;
+        group.throughput(Throughput::Elements(component_count));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(label),
+            fixtures,
+            |b, fixtures| {
+                b.iter_batched(
+                    || build_fuser(fixtures).expect("fixtures present"),
+                    |fuser| {
+                        let (bytes, stats) = fuser.fuse_with_stats().unwrap();
+                        black_box((bytes, stats));
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    fusion_benches,
+    bench_parser,
+    bench_merger,
+    bench_resolver,
+    bench_end_to_end,
+);
+criterion_main!(fusion_benches);

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -251,6 +251,23 @@ impl Fuser {
             .collect()
     }
 
+    /// Borrow the flattened parsed components.
+    ///
+    /// Useful for benchmarks and tools that want to drive `Resolver` /
+    /// `Merger` directly with the same flattened slice the fusion pipeline
+    /// uses internally, without having to re-implement
+    /// `flatten_nested_components`.
+    pub fn components(&self) -> &[ParsedComponent] {
+        &self.components
+    }
+
+    /// Borrow the wiring hints derived from composition graphs (component
+    /// instance / alias wiring). Pair with `components()` when calling
+    /// `Resolver::resolve_with_hints` for parity with the in-pipeline call.
+    pub fn wiring_hints(&self) -> &WiringHints {
+        &self.wiring_hints
+    }
+
     /// Perform the fusion and return the fused module bytes
     pub fn fuse(&self) -> Result<Vec<u8>> {
         let (bytes, _stats) = self.fuse_with_stats()?;
@@ -1615,7 +1632,7 @@ fn flatten_nested_components(
 /// propagated to whichever sub-component consumes them.
 /// Directed resolution hints from the composition graph.
 /// Maps (importer_flat_idx, interface_name) → exporter_flat_idx.
-type WiringHints = std::collections::HashMap<(usize, String), usize>;
+pub type WiringHints = std::collections::HashMap<(usize, String), usize>;
 
 #[allow(clippy::collapsible_if)]
 fn propagate_outer_wiring(

--- a/safety/requirements/benchmarks.yaml
+++ b/safety/requirements/benchmarks.yaml
@@ -1,0 +1,114 @@
+# Performance Benchmarks
+#
+# Criterion benchmark groups for the meld fusion pipeline. These artifacts
+# document the regression gate evidence required by ISO 26262-6 Table 10
+# row 1e ("performance test", HR at ASIL D) and DO-178C Table A-6 Obj 3
+# ("compliance with performance requirements").
+#
+# Each TEST-BENCH-* entry corresponds to one criterion group in
+# `meld-core/benches/fusion_benchmarks.rs`. The CI smoke job
+# (.github/workflows/bench.yml) runs `cargo bench --no-run` on every PR to
+# guarantee the harness keeps compiling. Full benchmark execution and
+# baseline persistence are intended for a dedicated host outside the PR
+# fast-feedback loop.
+#
+# Format: rivet generic-yaml
+
+artifacts:
+
+  - id: TEST-BENCH-PARSER
+    type: requirement
+    title: Parser throughput benchmark
+    description: >
+      Criterion group `parser` measures `ComponentParser::parse` throughput
+      per input byte across a curated set of wit-bindgen P2 fixtures.
+      Detects regressions in the parser hot path (validation, depth-aware
+      core-module extraction, canonical ABI section walking).
+    status: implemented
+    tags: [bench, performance, regression-gate]
+    links:
+      - type: derives-from
+        target: SR-1
+      - type: derives-from
+        target: SR-2
+    fields:
+      implementation:
+        - meld-core/benches/fusion_benchmarks.rs
+        - meld-core/src/parser.rs
+      verification-method: test
+      verification-description: >
+        cargo bench -p meld-core --bench fusion_benchmarks -- parser
+      ci-smoke: .github/workflows/bench.yml
+
+  - id: TEST-BENCH-MERGER
+    type: requirement
+    title: Merger throughput benchmark
+    description: >
+      Criterion group `merger` measures `Merger::merge` throughput per
+      flattened component count, with the dependency graph pre-built so
+      only merge cost is observed. Detects regressions in index-space
+      merging, function-table assembly, and shared-memory plan computation.
+    status: implemented
+    tags: [bench, performance, regression-gate]
+    links:
+      - type: derives-from
+        target: SR-23
+      - type: derives-from
+        target: SR-31
+    fields:
+      implementation:
+        - meld-core/benches/fusion_benchmarks.rs
+        - meld-core/src/merger.rs
+      verification-method: test
+      verification-description: >
+        cargo bench -p meld-core --bench fusion_benchmarks -- merger
+      ci-smoke: .github/workflows/bench.yml
+
+  - id: TEST-BENCH-RESOLVER
+    type: requirement
+    title: Resolver throughput benchmark
+    description: >
+      Criterion group `resolver` measures `Resolver::resolve_with_hints`
+      throughput per resolved-symbol count. Detects regressions in
+      cross-component import matching, instance-graph resolution, and the
+      resource-ownership graph build.
+    status: implemented
+    tags: [bench, performance, regression-gate]
+    links:
+      - type: derives-from
+        target: SR-25
+    fields:
+      implementation:
+        - meld-core/benches/fusion_benchmarks.rs
+        - meld-core/src/resolver.rs
+      verification-method: test
+      verification-description: >
+        cargo bench -p meld-core --bench fusion_benchmarks -- resolver
+      ci-smoke: .github/workflows/bench.yml
+
+  - id: TEST-BENCH-FUSION-E2E
+    type: requirement
+    title: End-to-end fusion throughput benchmark
+    description: >
+      Criterion group `end_to_end` measures `Fuser::fuse_with_stats` over
+      small (1 fixture), medium (5 fixtures), and large (12 fixtures)
+      component graphs. Catches whole-pipeline regressions (parse +
+      resolve + merge + adapter + encode) that aren't visible from any
+      single-stage benchmark.
+    status: implemented
+    tags: [bench, performance, regression-gate]
+    links:
+      - type: derives-from
+        target: SR-1
+      - type: derives-from
+        target: SR-23
+      - type: derives-from
+        target: SR-31
+    fields:
+      implementation:
+        - meld-core/benches/fusion_benchmarks.rs
+        - meld-core/src/lib.rs
+      verification-method: test
+      verification-description: >
+        cargo bench -p meld-core --bench fusion_benchmarks -- end_to_end
+      ci-smoke: .github/workflows/bench.yml


### PR DESCRIPTION
## Summary

Adds a regression gate for meld's fusion performance. meld is on the hot path of every pulseengine toolchain build (fuse before loom/kiln/synth), so a silent slowdown in the parser, merger, or resolver translates directly into longer build times across the estate.

`meld-core/benches/fusion_benchmarks.rs` defines four criterion groups:

- `parser` — `ComponentParser::parse` throughput per input byte across 12 wit-bindgen fixtures.
- `merger` — `Merger::merge` throughput per flattened component count, with the dependency graph pre-built so only merge cost is observed.
- `resolver` — `Resolver::resolve_with_hints` throughput per resolved-symbol count.
- `end_to_end` — `Fuser::fuse_with_stats` over small (1 fixture), medium (5 fixtures), and large (12 fixtures) component graphs.

Closes #103.

## Implementation notes

- Adds `criterion = "0.5"` (with `html_reports`) as a workspace dev-dependency.
- The merger/resolver benches need the same flattened slice that the fusion pipeline uses internally. To expose that without leaking pipeline internals, this PR adds two small accessors on `Fuser` (`components()`, `wiring_hints()`) and re-exports the `WiringHints` type alias as `pub`.
- A dedicated `.github/workflows/bench.yml` runs `cargo bench --no-run` on every PR to keep the harness from rotting. Full benchmark execution is left for a dedicated host (not in CI) to keep PR feedback fast and avoid noisy regressions on shared runners.
- `safety/requirements/benchmarks.yaml` registers `TEST-BENCH-PARSER`, `TEST-BENCH-MERGER`, `TEST-BENCH-RESOLVER`, and `TEST-BENCH-FUSION-E2E` rivet artifacts so the regression-gate evidence required by ISO 26262-6 Table 10 row 1e and DO-178C Table A-6 Obj 3 is traceable.

## Local sanity numbers

Single-iteration spot checks on the dev machine (release profile):

```
parser/numbers          time: ~23 ms     thrpt: ~310 MiB/s
merger/numbers          time: ~3.3 ms    thrpt: ~910 elem/s
resolver/numbers        time: ~140 µs    thrpt: ~7.2 Kelem/s
end_to_end/small        time: ~5.4 ms    thrpt: ~558 elem/s
```

Numbers are illustrative — the regression gate is the bench *existing* and compiling on every PR, not the absolute throughput.

## Acceptance checklist (from issue body)

- [x] `meld-core/benches/fusion_benchmarks.rs` with criterion groups for parser / merger / resolver / end-to-end.
- [x] CI job running `cargo bench --no-run` on every PR (`.github/workflows/bench.yml`).
- [ ] Nightly job running full benches with baseline persisted — left as follow-up; the PR description for #103 explicitly marks this optional.
- [x] Benchmarks referenced from `rivet.yaml` as TEST-BENCH-* artifacts (via `safety/requirements/benchmarks.yaml`, picked up by the existing `safety/requirements` source in `rivet.yaml`).
- [x] README badge for the new bench workflow.

## Test plan

- [x] `cargo bench --no-run -p meld-core` — compile-only sanity.
- [x] `cargo bench -p meld-core --bench fusion_benchmarks -- parser/numbers --quick` — single-group smoke.
- [x] `cargo bench -p meld-core --bench fusion_benchmarks -- merger/numbers --quick`
- [x] `cargo bench -p meld-core --bench fusion_benchmarks -- resolver/numbers --quick`
- [x] `cargo bench -p meld-core --bench fusion_benchmarks -- end_to_end/small --quick`
- [x] `cargo test --test wit_bindgen_runtime` — 73/73 pass.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [ ] Bench-smoke workflow executes successfully on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)