### PR TITLE
feat: P3 async error / backpressure conventions for pulseengine:async ABI (closes #121)

### DIFF
--- a/meld-core/src/p3_async.rs
+++ b/meld-core/src/p3_async.rs
@@ -67,6 +67,33 @@
 //!   (`component_wrap.rs::generate_callback_driving_adapter`). This module
 //!   only provides the *data-plane* (stream/future) intrinsics.
 //!
+//! ## Error and backpressure conventions (issue #121, ADR-2)
+//!
+//! Every `stream_*` / `future_*` intrinsic that returns `i32` follows the
+//! convention: **non-negative = success-with-payload, negative = error
+//! drawn from the closed enum [`AbiError`]**.
+//!
+//! * Stream EOF is `0` from `stream_read` and is **distinguishable** from
+//!   "no bytes available right now" — the latter returns
+//!   [`AbiError::Pending`]. EOF is sticky once observed.
+//! * `stream_write` exposes backpressure as a partial count
+//!   (`written < requested`). The **producer** is the retry authority;
+//!   the runtime does not queue the un-accepted tail. A write of `0`
+//!   bytes is still backpressure, NOT EOF.
+//! * `future_read` returns `1` (resolved), `0` (pending), or negative
+//!   (error). `0` is **not** EOF — `Closed` is.
+//! * Pending operations register the relevant handle in a waitable-set
+//!   and re-invoke the intrinsic after `[waitable-set-wait]` fires.
+//!   Byte counts / resolved flags are read from the *next intrinsic
+//!   call*, not from the waitable's payload.
+//!
+//! Helper decoders [`StreamWriteResult`], [`StreamReadResult`], and
+//! [`FutureReadResult`] turn raw `i32` returns into typed variants for
+//! use in tests and adapter glue.
+//!
+//! See [ADR-2](../../safety/adr/ADR-2-p3-async-error-conventions.md) for
+//! the formal rationale.
+//!
 //! ## Detection
 //!
 //! [`P3AsyncFeatures`] summarises what P3 async constructs a parsed component
@@ -126,21 +153,199 @@ pub mod future {
 
 /// A specific P3 async canonical built-in, mapped to the host intrinsic
 /// it lowers to.
+///
+/// # Return-value conventions
+///
+/// All `stream_*` / `future_*` intrinsics that return `i32` follow the
+/// **non-negative = success, negative = error** convention, where the error
+/// codes are drawn from the closed enum [`AbiError`]. Helper decoders
+/// [`StreamReadResult`], [`StreamWriteResult`], and [`FutureReadResult`]
+/// turn raw return values into these typed variants for testing and for
+/// generated adapter glue.
+///
+/// See the per-variant rustdoc below for partial-write semantics, EOF
+/// distinguishability, and how each intrinsic interacts with the
+/// `[waitable-set-wait]` built-in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HostIntrinsic {
+    /// `() -> i64` — allocate a new stream handle pair. Low 32 bits =
+    /// readable end, high 32 bits = writable end.
+    ///
+    /// Errors are reported by encoding [`AbiError::Oom`] (or other
+    /// negative codes) **in the low 32 bits** with the high 32 bits set to
+    /// zero. Callers MUST inspect the low 32 bits as `i32` before using
+    /// either half. (`i64::from_ne_bytes`-style decoding never produces a
+    /// negative low half from a valid handle pair, since handles are
+    /// non-negative.)
     StreamNew,
+    /// `(handle: i32, buf_ptr: i32, buf_len: i32, mem_idx: i32) -> i32`
+    /// — read up to `buf_len` bytes into `buf_ptr` of memory `mem_idx`.
+    ///
+    /// Return value (decode with [`StreamReadResult::decode`]):
+    ///
+    /// * `n > 0` — exactly `n` bytes were copied into `buf_ptr`. `n` may
+    ///   be less than `buf_len`; that simply means the runtime had fewer
+    ///   bytes available *right now*. The reader is free to retry — the
+    ///   stream is **not** at EOF.
+    /// * `n == 0` — **EOF, distinguishable from "0 bytes available"**:
+    ///   the writable end has been dropped AND no buffered bytes remain.
+    ///   The runtime MUST NOT return 0 to indicate "nothing available
+    ///   right now"; in that case the reader receives [`AbiError::Pending`]
+    ///   so the reader can register a waitable instead of busy-looping.
+    ///   Once a reader has observed `0`, every subsequent call on the
+    ///   same handle MUST also return `0` (EOF is sticky).
+    /// * `n < 0` — error from [`AbiError`]. Notable codes:
+    ///   * [`AbiError::Pending`] — no bytes available right now and the
+    ///     stream is still open. The reader SHOULD register the handle
+    ///     in a waitable-set (see *Interaction with `[waitable-set-wait]`*
+    ///     below) and re-invoke `stream_read` after the set fires.
+    ///   * [`AbiError::Closed`] — the writable end was dropped *before*
+    ///     the read started AND no buffered bytes were available. This
+    ///     is the same observable state as EOF; the runtime MAY return
+    ///     `0` instead and most do.
+    ///   * [`AbiError::InvalidHandle`] — `handle` is not a live readable
+    ///     end of a stream owned by this caller.
+    ///   * [`AbiError::Cancelled`] — the read was cancelled by a
+    ///     concurrent `stream_cancel_read`.
+    ///
+    /// ### Interaction with `[waitable-set-wait]`
+    ///
+    /// `stream_read` is a *non-blocking* primitive. When it returns
+    /// [`AbiError::Pending`], the caller registers the **readable handle**
+    /// in a waitable-set (created via `[waitable-set-new]`, populated via
+    /// `[waitable-join]`). The runtime fires the waitable when bytes
+    /// become available OR the writable end is dropped (whichever comes
+    /// first). The caller drains the readiness via `[waitable-set-wait]`
+    /// and re-invokes `stream_read` to retrieve the actual bytes (or `0`
+    /// for EOF). The waitable's payload identifies *which* handle is
+    /// ready; the byte count is **not** delivered through the waitable —
+    /// it is read out of the next `stream_read` call.
     StreamRead,
+    /// `(handle: i32, data_ptr: i32, data_len: i32, mem_idx: i32) -> i32`
+    /// — write `data_len` bytes from `data_ptr`.
+    ///
+    /// Return value (decode with [`StreamWriteResult::decode`]):
+    ///
+    /// * `n == data_len` — full success.
+    /// * `0 <= n < data_len` — **partial write / backpressure**: the
+    ///   reader is slow. The producer is the *retry authority*: meld and
+    ///   the runtime do **not** queue the un-accepted tail. The producer
+    ///   MUST resubmit the slice `[data_ptr + n .. data_ptr + data_len)`
+    ///   (typically after a `[waitable-set-wait]` round; see below). A
+    ///   compliant runtime may return `0` to mean "no progress right now";
+    ///   producers SHOULD treat `n == 0` identically to a positive
+    ///   partial write — backpressure, retry. Returning `0` is **not**
+    ///   EOF on the write side; readable EOF is signalled only on the
+    ///   read side.
+    /// * `n < 0` — error from [`AbiError`]:
+    ///   * [`AbiError::Closed`] — the readable end was dropped. The
+    ///     producer should drop the writable end; further writes will
+    ///     fail with the same code.
+    ///   * [`AbiError::InvalidHandle`] — `handle` is not a live writable
+    ///     end of a stream owned by this caller.
+    ///   * [`AbiError::Cancelled`] — the write was cancelled by a
+    ///     concurrent `stream_cancel_write`.
+    ///   * [`AbiError::Oom`] — the runtime could not allocate buffer
+    ///     space for any progress. Distinct from backpressure: producers
+    ///     SHOULD propagate this as a hard error rather than retry.
+    ///
+    /// ### Interaction with `[waitable-set-wait]`
+    ///
+    /// On a partial write or `AbiError::Pending` (some runtimes prefer
+    /// the latter when 0 bytes were accepted), the producer registers
+    /// the **writable handle** in a waitable-set. The runtime fires the
+    /// waitable when buffer space frees up OR the readable end is
+    /// dropped. The producer re-invokes `stream_write` with the
+    /// remaining slice; the actual byte count is read out of that call,
+    /// not the waitable payload.
     StreamWrite,
+    /// `(handle: i32) -> i32` — cancel a pending read on the given handle.
+    ///
+    /// Return value:
+    ///
+    /// * `1` — a pending read was cancelled. The cancelled `stream_read`
+    ///   call (on whichever task issued it) returns
+    ///   [`AbiError::Cancelled`].
+    /// * `0` — no read was pending; this is a no-op success.
+    /// * `n < 0` — error from [`AbiError`], typically
+    ///   [`AbiError::InvalidHandle`].
     StreamCancelRead,
+    /// `(handle: i32) -> i32` — cancel a pending write on the given
+    /// handle. Return convention matches [`HostIntrinsic::StreamCancelRead`].
     StreamCancelWrite,
+    /// `(handle: i32)` — drop the readable end. Closing both ends destroys
+    /// the stream and any buffered bytes. After dropping the readable end:
+    ///
+    /// * Pending writes complete with [`AbiError::Closed`] (if no bytes
+    ///   were already accepted) or with the partial count.
+    /// * Subsequent writes return [`AbiError::Closed`].
     StreamDropReadable,
+    /// `(handle: i32)` — drop the writable end. After dropping:
+    ///
+    /// * Pending reads drain any buffered bytes, then return `0` (EOF).
+    /// * Subsequent reads return `0` (EOF is sticky).
     StreamDropWritable,
+    /// `() -> i64` — allocate a new future handle pair. Low 32 bits =
+    /// read end, high 32 bits = write end. Error encoding matches
+    /// [`HostIntrinsic::StreamNew`].
     FutureNew,
+    /// `(handle: i32, buf_ptr: i32, mem_idx: i32) -> i32` — read the
+    /// resolved value into `buf_ptr` (size = canonical layout of `T`).
+    ///
+    /// Return value (decode with [`FutureReadResult::decode`]):
+    ///
+    /// * `1` — resolved; the canonical-ABI layout of `T` has been written
+    ///   to `buf_ptr`. Subsequent calls on the same handle MUST also
+    ///   return `1` (the resolved value is sticky until the read end is
+    ///   dropped); runtimes MAY instead return [`AbiError::Closed`] after
+    ///   the value has been consumed once.
+    /// * `0` — **not yet resolved AND the write end is still alive.**
+    ///   The reader registers the handle in a waitable-set (see
+    ///   `[waitable-set-wait]` interaction below) and retries on
+    ///   readiness.
+    /// * `n < 0` — error from [`AbiError`]:
+    ///   * [`AbiError::Closed`] — the write end was dropped without
+    ///     resolving. Distinguishable from "not yet resolved": EOF on a
+    ///     future means *no value will ever arrive*.
+    ///   * [`AbiError::InvalidHandle`], [`AbiError::Cancelled`].
+    ///
+    /// ### Interaction with `[waitable-set-wait]`
+    ///
+    /// Identical to `stream_read`: the reader joins the readable end
+    /// into a waitable-set, waits, then re-invokes `future_read` to
+    /// retrieve the resolved value (`1`) or observe drop (`Closed`).
     FutureRead,
+    /// `(handle: i32, data_ptr: i32, mem_idx: i32) -> i32` — resolve the
+    /// future by writing `T`'s canonical layout from `data_ptr`.
+    ///
+    /// Return value:
+    ///
+    /// * `1` — resolved successfully.
+    /// * `n < 0` — error from [`AbiError`]:
+    ///   * [`AbiError::Closed`] — the read end was dropped before
+    ///     resolution. The value is discarded.
+    ///   * [`AbiError::InvalidHandle`], [`AbiError::Cancelled`],
+    ///     [`AbiError::Oom`].
+    ///
+    /// Unlike `stream_write`, `future_write` is **all-or-nothing**:
+    /// there is no partial-write / backpressure case. Either the runtime
+    /// accepts the resolution or it errors.
     FutureWrite,
+    /// `(handle: i32) -> i32` — cancel a pending read on the given
+    /// future. Return convention matches
+    /// [`HostIntrinsic::StreamCancelRead`].
     FutureCancelRead,
+    /// `(handle: i32) -> i32` — cancel a pending write on the given
+    /// future. Return convention matches
+    /// [`HostIntrinsic::StreamCancelRead`].
     FutureCancelWrite,
+    /// `(handle: i32)` — drop the readable end. After dropping, a
+    /// pending or subsequent `future_write` returns [`AbiError::Closed`].
     FutureDropReadable,
+    /// `(handle: i32)` — drop the writable end without resolving.
+    /// Pending `future_read` calls return [`AbiError::Closed`] (no
+    /// value will arrive). Subsequent reads also return
+    /// [`AbiError::Closed`].
     FutureDropWritable,
 }
 
@@ -189,6 +394,214 @@ impl HostIntrinsic {
             CanonicalEntry::FutureDropReadable { .. } => Some(Self::FutureDropReadable),
             CanonicalEntry::FutureDropWritable { .. } => Some(Self::FutureDropWritable),
             _ => None,
+        }
+    }
+}
+
+/// Closed enum of error codes returned by `pulseengine:async` intrinsics.
+///
+/// This is the **canonical, stable** set of negative `i32` values that any
+/// `stream_*` or `future_*` intrinsic may return. Runtimes (kiln,
+/// wasmtime reference impl, …) MUST NOT invent additional negative codes
+/// outside this enum without a matching addition here and a version bump.
+///
+/// # Numeric stability
+///
+/// The discriminants are pinned by [`AbiError::as_i32`] / [`AbiError::from_i32`]
+/// and by the unit tests in `meld-core/tests/p3_async_abi.rs`. Changing
+/// these is a **breaking ABI change** — bump the meld minor version and
+/// document in the next ADR.
+///
+/// All codes are negative `i32` so that on the wire (`i32` return) the
+/// sign bit cleanly distinguishes error from success.
+///
+/// # Code rationale (mapping to WASI 0.3 stream semantics)
+///
+/// * [`AbiError::Closed`] — the *peer end* of the stream/future was
+///   dropped. Distinct from EOF on a stream-read (returned as `0`
+///   bytes), but the runtime MAY conflate the two on `stream_read` if
+///   no buffered bytes remain (see [`HostIntrinsic::StreamRead`] doc).
+/// * [`AbiError::InvalidHandle`] — the handle is not live, not owned by
+///   this caller, or is the wrong end (e.g., calling `stream_read` on a
+///   writable handle).
+/// * [`AbiError::Oom`] — the runtime could not allocate the buffer space
+///   needed to make any progress. NOT used for backpressure (which is
+///   signalled by partial-write / `Pending`).
+/// * [`AbiError::Cancelled`] — a concurrent `*_cancel_read` /
+///   `*_cancel_write` aborted this operation.
+/// * [`AbiError::Pending`] — operation would block. The caller is
+///   expected to register the handle in a waitable-set (see
+///   `[waitable-set-wait]` interaction in [`HostIntrinsic`] doc) and
+///   retry. Runtimes MAY instead return a positive partial count for
+///   `stream_write` / `stream_read`; producers and consumers must
+///   handle both forms.
+/// * [`AbiError::Runtime`] — catch-all for runtime-internal failures
+///   (e.g., trap during a multi-memory copy in the data-plane). Hosts
+///   SHOULD prefer a more specific code; this is a forward-compatible
+///   escape hatch so that runtimes can surface a non-fatal failure
+///   without trapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(i32)]
+pub enum AbiError {
+    /// The peer end of the stream/future has been dropped.
+    Closed = -1,
+    /// The provided handle is not live, not owned, or is the wrong end.
+    InvalidHandle = -2,
+    /// The runtime could not allocate buffer space to make any progress.
+    Oom = -3,
+    /// The operation was aborted by a concurrent `*_cancel_*` call.
+    Cancelled = -4,
+    /// The operation would block. Register the handle in a waitable-set
+    /// and retry once `[waitable-set-wait]` reports readiness.
+    Pending = -5,
+    /// Catch-all for runtime-internal failures. Forward-compatible
+    /// escape hatch; specific codes SHOULD be preferred.
+    Runtime = -6,
+}
+
+impl AbiError {
+    /// All defined error codes, in stable order. Useful for exhaustive
+    /// tests and for runtime implementers that want to assert coverage.
+    pub const ALL: [Self; 6] = [
+        Self::Closed,
+        Self::InvalidHandle,
+        Self::Oom,
+        Self::Cancelled,
+        Self::Pending,
+        Self::Runtime,
+    ];
+
+    /// The numeric `i32` value of this error code.
+    ///
+    /// Note: `repr(i32)` allows direct casting (`code as i32`); this
+    /// helper is provided for clarity at call sites.
+    pub const fn as_i32(self) -> i32 {
+        self as i32
+    }
+
+    /// Decode a raw `i32` return value into `Some(AbiError)` if it
+    /// matches a known code, or `None` otherwise.
+    ///
+    /// Non-negative values are always `None` (they are success codes,
+    /// not errors). Negative values that don't match a known
+    /// discriminant are also `None` — callers that receive such a value
+    /// SHOULD treat it as `AbiError::Runtime` per the forward-compat
+    /// rule, but this decoder does not synthesise that mapping.
+    pub const fn from_i32(v: i32) -> Option<Self> {
+        match v {
+            -1 => Some(Self::Closed),
+            -2 => Some(Self::InvalidHandle),
+            -3 => Some(Self::Oom),
+            -4 => Some(Self::Cancelled),
+            -5 => Some(Self::Pending),
+            -6 => Some(Self::Runtime),
+            _ => None,
+        }
+    }
+}
+
+/// Decoded return value of [`HostIntrinsic::StreamWrite`].
+///
+/// See the variant docs on [`HostIntrinsic::StreamWrite`] for the full
+/// partial-write / backpressure contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamWriteResult {
+    /// All `requested` bytes were accepted.
+    Complete { written: u32 },
+    /// `written < requested`. The producer is the retry authority; meld
+    /// and the runtime do NOT queue the un-accepted tail. `written` may
+    /// be `0`, which is still backpressure (not EOF, not error).
+    Partial { written: u32, requested: u32 },
+    /// The runtime returned an error code.
+    Error(AbiError),
+    /// The runtime returned an unrecognised negative code. Callers
+    /// SHOULD treat this as `AbiError::Runtime`. Surfacing the raw value
+    /// helps debugging and test assertions.
+    Unknown(i32),
+}
+
+impl StreamWriteResult {
+    /// Decode the raw `i32` return value of `stream_write` against the
+    /// `requested` byte count the producer passed in.
+    pub const fn decode(ret: i32, requested: u32) -> Self {
+        if ret < 0 {
+            match AbiError::from_i32(ret) {
+                Some(e) => Self::Error(e),
+                None => Self::Unknown(ret),
+            }
+        } else {
+            let written = ret as u32;
+            if written >= requested {
+                Self::Complete { written }
+            } else {
+                Self::Partial { written, requested }
+            }
+        }
+    }
+}
+
+/// Decoded return value of [`HostIntrinsic::StreamRead`].
+///
+/// See [`HostIntrinsic::StreamRead`] for the full EOF-vs-pending
+/// distinguishability contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamReadResult {
+    /// `n > 0` bytes were copied into the caller's buffer. `n` may be
+    /// less than the requested length; the stream is **not** at EOF.
+    Bytes { read: u32 },
+    /// `0` — EOF. The writable end has been dropped AND no buffered
+    /// bytes remain. EOF is sticky.
+    Eof,
+    /// The runtime returned a known error code (typically
+    /// [`AbiError::Pending`] for "no bytes available right now").
+    Error(AbiError),
+    /// The runtime returned an unrecognised negative code.
+    Unknown(i32),
+}
+
+impl StreamReadResult {
+    /// Decode the raw `i32` return value of `stream_read`.
+    pub const fn decode(ret: i32) -> Self {
+        if ret > 0 {
+            Self::Bytes { read: ret as u32 }
+        } else if ret == 0 {
+            Self::Eof
+        } else {
+            match AbiError::from_i32(ret) {
+                Some(e) => Self::Error(e),
+                None => Self::Unknown(ret),
+            }
+        }
+    }
+}
+
+/// Decoded return value of [`HostIntrinsic::FutureRead`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FutureReadResult {
+    /// `1` — the future is resolved; `T`'s canonical layout has been
+    /// written to the caller's buffer.
+    Resolved,
+    /// `0` — the future is not yet resolved AND the write end is still
+    /// alive. Register in a waitable-set and retry.
+    Pending,
+    /// The runtime returned a known error code.
+    Error(AbiError),
+    /// The runtime returned an unrecognised negative code.
+    Unknown(i32),
+}
+
+impl FutureReadResult {
+    /// Decode the raw `i32` return value of `future_read`.
+    pub const fn decode(ret: i32) -> Self {
+        match ret {
+            1 => Self::Resolved,
+            0 => Self::Pending,
+            n if n < 0 => match AbiError::from_i32(n) {
+                Some(e) => Self::Error(e),
+                None => Self::Unknown(n),
+            },
+            // Positive non-1 values are reserved; treat as Unknown.
+            n => Self::Unknown(n),
         }
     }
 }

--- a/meld-core/tests/p3_async_abi.rs
+++ b/meld-core/tests/p3_async_abi.rs
@@ -1,0 +1,311 @@
+//! Pin tests for the `pulseengine:async` error-and-backpressure ABI
+//! (issue #121, ADR-2).
+//!
+//! These tests are **encoding-only**. Meld is a build-time tool and does
+//! not run a P3 runtime; nothing here exercises real stream / future
+//! intrinsics. What they DO exercise is the wire-level convention any
+//! conforming runtime (kiln, the wasmtime reference impl, …) MUST
+//! reproduce:
+//!
+//! 1. Closed enum `AbiError` has stable, non-overlapping `i32`
+//!    discriminants in the negative half-plane.
+//! 2. `StreamWriteResult::decode` distinguishes complete writes,
+//!    partial-write backpressure (including the `written == 0` corner),
+//!    and errors. The producer is the retry authority — the runtime does
+//!    NOT queue the tail; the decoder simply surfaces the count.
+//! 3. `StreamReadResult::decode` distinguishes `Bytes`, `Eof` (`0`), and
+//!    `Pending` (`-5`). EOF and "no bytes available right now" map to
+//!    different variants — this is what issue #121 asks us to pin.
+//! 4. `FutureReadResult::decode` separates `Resolved` (`1`), `Pending`
+//!    (`0`), and `Closed` (`-1`).
+//!
+//! Changing any numeric value in `AbiError` is a **breaking ABI change**
+//! and must update both this test and ADR-2.
+
+use meld_core::p3_async::{AbiError, FutureReadResult, StreamReadResult, StreamWriteResult};
+
+// ---------------------------------------------------------------------------
+// AbiError — closed enum with pinned numeric values
+// ---------------------------------------------------------------------------
+
+/// Pin the numeric value of every `AbiError` variant. Any change here is
+/// a breaking ABI change and must be coordinated with ADR-2 and runtime
+/// implementers.
+#[test]
+fn abi_error_numeric_values_are_pinned() {
+    assert_eq!(AbiError::Closed.as_i32(), -1);
+    assert_eq!(AbiError::InvalidHandle.as_i32(), -2);
+    assert_eq!(AbiError::Oom.as_i32(), -3);
+    assert_eq!(AbiError::Cancelled.as_i32(), -4);
+    assert_eq!(AbiError::Pending.as_i32(), -5);
+    assert_eq!(AbiError::Runtime.as_i32(), -6);
+}
+
+/// `AbiError` discriminants must all be negative (the sign bit is the
+/// success/error discriminator on the wire).
+#[test]
+fn all_abi_errors_are_negative() {
+    for e in AbiError::ALL {
+        assert!(
+            e.as_i32() < 0,
+            "AbiError variant {e:?} has non-negative wire value {}",
+            e.as_i32()
+        );
+    }
+}
+
+/// `AbiError::ALL` is in stable order (matches numeric order, descending
+/// magnitude / ascending negativity).
+#[test]
+fn abi_error_all_is_in_stable_order() {
+    let codes: Vec<i32> = AbiError::ALL.iter().map(|e| e.as_i32()).collect();
+    assert_eq!(codes, vec![-1, -2, -3, -4, -5, -6]);
+}
+
+/// All variants in `AbiError::ALL` must have distinct numeric values.
+/// Belt-and-braces guard against accidental discriminant collisions if
+/// someone reorders the enum.
+#[test]
+fn abi_error_values_are_distinct() {
+    let mut codes: Vec<i32> = AbiError::ALL.iter().map(|e| e.as_i32()).collect();
+    codes.sort();
+    let len_before = codes.len();
+    codes.dedup();
+    assert_eq!(
+        codes.len(),
+        len_before,
+        "AbiError discriminants must be distinct"
+    );
+}
+
+/// `from_i32` is the inverse of `as_i32` for every defined variant, and
+/// returns `None` for non-negative values and unknown negative codes.
+#[test]
+fn abi_error_from_i32_round_trips() {
+    for e in AbiError::ALL {
+        assert_eq!(AbiError::from_i32(e.as_i32()), Some(e));
+    }
+    // Success codes are not errors.
+    assert_eq!(AbiError::from_i32(0), None);
+    assert_eq!(AbiError::from_i32(1), None);
+    assert_eq!(AbiError::from_i32(i32::MAX), None);
+    // Unknown negative codes return None — caller is expected to map to
+    // AbiError::Runtime per the forward-compat rule (documented).
+    assert_eq!(AbiError::from_i32(-7), None);
+    assert_eq!(AbiError::from_i32(i32::MIN), None);
+}
+
+// ---------------------------------------------------------------------------
+// StreamWriteResult — partial-write / backpressure semantics
+// ---------------------------------------------------------------------------
+
+/// A write that accepts every byte requested is `Complete`.
+#[test]
+fn stream_write_complete_when_all_bytes_accepted() {
+    match StreamWriteResult::decode(64, 64) {
+        StreamWriteResult::Complete { written } => assert_eq!(written, 64),
+        other => panic!("expected Complete, got {other:?}"),
+    }
+}
+
+/// `written < requested` is **partial / backpressure** — NOT EOF, NOT
+/// error. The producer is responsible for retrying with the un-accepted
+/// tail.
+#[test]
+fn stream_write_partial_is_backpressure_not_eof() {
+    match StreamWriteResult::decode(20, 64) {
+        StreamWriteResult::Partial { written, requested } => {
+            assert_eq!(written, 20);
+            assert_eq!(requested, 64);
+        }
+        other => panic!("expected Partial, got {other:?}"),
+    }
+}
+
+/// `written == 0` with a positive `requested` is **still backpressure**,
+/// not EOF or error. This is the corner case issue #121 calls out:
+/// `stream_write` returning `0` bytes accepted means "no progress right
+/// now"; producers retry like any other partial.
+#[test]
+fn stream_write_zero_accepted_is_partial_not_error() {
+    match StreamWriteResult::decode(0, 64) {
+        StreamWriteResult::Partial { written, requested } => {
+            assert_eq!(written, 0);
+            assert_eq!(requested, 64);
+        }
+        other => panic!("expected Partial(0, 64), got {other:?}"),
+    }
+}
+
+/// A `requested == 0` empty write that returns `0` is `Complete` —
+/// vacuously, all zero requested bytes were accepted.
+#[test]
+fn stream_write_zero_requested_zero_written_is_complete() {
+    match StreamWriteResult::decode(0, 0) {
+        StreamWriteResult::Complete { written } => assert_eq!(written, 0),
+        other => panic!("expected Complete, got {other:?}"),
+    }
+}
+
+/// Negative return values decode to the matching `AbiError`.
+#[test]
+fn stream_write_error_codes_decode_to_abi_error() {
+    let cases = [
+        (-1, AbiError::Closed),
+        (-2, AbiError::InvalidHandle),
+        (-3, AbiError::Oom),
+        (-4, AbiError::Cancelled),
+        (-5, AbiError::Pending),
+        (-6, AbiError::Runtime),
+    ];
+    for (raw, expected) in cases {
+        match StreamWriteResult::decode(raw, 32) {
+            StreamWriteResult::Error(e) => assert_eq!(e, expected, "raw {raw}"),
+            other => panic!("raw {raw}: expected Error({expected:?}), got {other:?}"),
+        }
+    }
+}
+
+/// Unknown negative codes surface as `Unknown`, preserving the raw value
+/// for diagnostics. Forward-compat: callers SHOULD map these to
+/// `AbiError::Runtime`, but the decoder doesn't synthesise the mapping.
+#[test]
+fn stream_write_unknown_negative_is_preserved() {
+    match StreamWriteResult::decode(-99, 32) {
+        StreamWriteResult::Unknown(v) => assert_eq!(v, -99),
+        other => panic!("expected Unknown(-99), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StreamReadResult — EOF distinguishability from "0 bytes available"
+// ---------------------------------------------------------------------------
+
+/// Positive return is `Bytes` (read N bytes, may be < buffer length).
+#[test]
+fn stream_read_positive_is_bytes() {
+    match StreamReadResult::decode(7) {
+        StreamReadResult::Bytes { read } => assert_eq!(read, 7),
+        other => panic!("expected Bytes, got {other:?}"),
+    }
+}
+
+/// `0` from `stream_read` is **EOF**, not "no bytes right now". Issue
+/// #121 explicitly calls for this distinguishability.
+#[test]
+fn stream_read_zero_is_eof() {
+    assert_eq!(StreamReadResult::decode(0), StreamReadResult::Eof);
+}
+
+/// "No bytes right now (still open)" is `AbiError::Pending`, distinct
+/// from EOF. This is the core issue-#121 contract.
+#[test]
+fn stream_read_pending_is_distinct_from_eof() {
+    let pending = StreamReadResult::decode(AbiError::Pending.as_i32());
+    let eof = StreamReadResult::decode(0);
+    assert_ne!(pending, eof);
+    assert_eq!(pending, StreamReadResult::Error(AbiError::Pending));
+    assert_eq!(eof, StreamReadResult::Eof);
+}
+
+/// All `AbiError` codes round-trip through `StreamReadResult::decode`.
+#[test]
+fn stream_read_error_codes_decode_to_abi_error() {
+    for e in AbiError::ALL {
+        match StreamReadResult::decode(e.as_i32()) {
+            StreamReadResult::Error(decoded) => assert_eq!(decoded, e),
+            other => panic!("decoding {e:?} produced {other:?}"),
+        }
+    }
+}
+
+/// Unknown negative codes surface as `Unknown`.
+#[test]
+fn stream_read_unknown_negative_is_preserved() {
+    match StreamReadResult::decode(-42) {
+        StreamReadResult::Unknown(v) => assert_eq!(v, -42),
+        other => panic!("expected Unknown(-42), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FutureReadResult — Resolved (1) vs Pending (0) vs Closed (-1)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn future_read_one_is_resolved() {
+    assert_eq!(FutureReadResult::decode(1), FutureReadResult::Resolved);
+}
+
+/// `0` from `future_read` is **Pending**, not "future EOF". A future
+/// with a dropped write end returns `Closed` instead.
+#[test]
+fn future_read_zero_is_pending_not_closed() {
+    let pending = FutureReadResult::decode(0);
+    let closed = FutureReadResult::decode(AbiError::Closed.as_i32());
+    assert_ne!(pending, closed);
+    assert_eq!(pending, FutureReadResult::Pending);
+    assert_eq!(closed, FutureReadResult::Error(AbiError::Closed));
+}
+
+#[test]
+fn future_read_error_codes_decode_to_abi_error() {
+    for e in AbiError::ALL {
+        match FutureReadResult::decode(e.as_i32()) {
+            FutureReadResult::Error(decoded) => assert_eq!(decoded, e),
+            other => panic!("decoding {e:?} produced {other:?}"),
+        }
+    }
+}
+
+/// Positive non-1 values are reserved; treated as `Unknown` so future
+/// extensions (e.g., `2 = "resolved with multi-value"`) can be added
+/// without retagging the existing variants.
+#[test]
+fn future_read_positive_non_one_is_unknown() {
+    match FutureReadResult::decode(2) {
+        FutureReadResult::Unknown(v) => assert_eq!(v, 2),
+        other => panic!("expected Unknown(2), got {other:?}"),
+    }
+}
+
+#[test]
+fn future_read_unknown_negative_is_preserved() {
+    match FutureReadResult::decode(-77) {
+        FutureReadResult::Unknown(v) => assert_eq!(v, -77),
+        other => panic!("expected Unknown(-77), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: AbiError numeric values must agree across decoders
+// ---------------------------------------------------------------------------
+
+/// The same negative `i32` must decode to the same `AbiError` across
+/// `StreamReadResult`, `StreamWriteResult`, and `FutureReadResult`.
+/// Catches divergent decoding tables if the convention drifts.
+#[test]
+fn error_codes_are_consistent_across_decoders() {
+    for e in AbiError::ALL {
+        let raw = e.as_i32();
+
+        let r = StreamReadResult::decode(raw);
+        let w = StreamWriteResult::decode(raw, 16);
+        let f = FutureReadResult::decode(raw);
+
+        match (r, w, f) {
+            (
+                StreamReadResult::Error(a),
+                StreamWriteResult::Error(b),
+                FutureReadResult::Error(c),
+            ) => {
+                assert_eq!(a, e);
+                assert_eq!(b, e);
+                assert_eq!(c, e);
+            }
+            other => {
+                panic!("code {raw} ({e:?}) decoded inconsistently across result types: {other:?}")
+            }
+        }
+    }
+}

--- a/safety/adr/ADR-1-p3-async-lowering.md
+++ b/safety/adr/ADR-1-p3-async-lowering.md
@@ -104,6 +104,11 @@ Out of scope (deferred to follow-up sub-issues under #94):
   (`stream_write` returns bytes accepted < requested = backpressure;
   negative = error) is fixed in rustdoc, but the runtime contract
   needs companion docs in kiln + a wasmtime reference impl.
+  *Update (issue #121):* the closed-enum convention is now formalised
+  in [`ADR-2`](ADR-2-p3-async-error-conventions.md) and pinned by
+  `meld-core/tests/p3_async_abi.rs`. Companion docs in kiln and the
+  wasmtime reference impl remain out of scope (separable tracking
+  issues).
 - **Static validation** — type-compat and circular-dependency checks
   for cross-component streams (issue #94 §4).
 
@@ -137,8 +142,12 @@ since they share only this contract.
 ## References
 
 * GitHub issue #94 — original proposal.
+* GitHub issue #121 — error/backpressure conventions follow-up
+  (resolved by ADR-2).
 * RFC #46 — meld toolchain architecture.
 * WASM Component Model P3 spec —
   https://github.com/WebAssembly/component-model
 * WASI 0.3 roadmap — https://wasi.dev/roadmap
 * `meld-core/src/p3_async.rs` — canonical ABI documentation.
+* [ADR-2](ADR-2-p3-async-error-conventions.md) — error/backpressure
+  conventions for the same `pulseengine:async` ABI.

--- a/safety/adr/ADR-2-p3-async-error-conventions.md
+++ b/safety/adr/ADR-2-p3-async-error-conventions.md
@@ -1,0 +1,207 @@
+---
+id: ADR-2
+type: design-question
+title: P3 async error and backpressure conventions for the `pulseengine:async` ABI
+status: open
+gating-fixtures:
+  - p3_async_abi::abi_error_numeric_values_are_pinned
+  - p3_async_abi::stream_read_pending_is_distinct_from_eof
+  - p3_async_abi::stream_write_zero_accepted_is_partial_not_error
+  - p3_async_abi::error_codes_are_consistent_across_decoders
+design-paths:
+  - K — Closed `AbiError` enum with stable negative-i32 codes (chosen, this PR)
+  - L — Per-intrinsic ad-hoc error codes (rejected — diverges across runtimes)
+  - M — Component-model `result<T, E>` lift around every intrinsic (rejected — too heavyweight for the data plane)
+---
+
+# ADR-2 — P3 async error and backpressure conventions
+
+## Context
+
+ADR-1 fixed the **shape** of the host-intrinsic ABI under module
+`pulseengine:async` (14 imports, signatures, element-width hidden in the
+handle). It deferred the **semantic conventions** the intrinsics' return
+values follow:
+
+> *Out of scope (deferred to follow-up sub-issues under #94):*
+> *— Error and backpressure conventions — the ABI doc spec
+> (`stream_write` returns bytes accepted < requested = backpressure;
+> negative = error) is fixed in rustdoc, but the runtime contract
+> needs companion docs in kiln + a wasmtime reference impl.*
+
+Issue #121 tracks the formalisation. Without a closed enum of error
+codes, runtimes (kiln, wasmtime reference impl, ad-hoc embedders) would
+each invent their own negative-`i32` mapping and fused components would
+behave subtly differently across hosts. Worse, two of the intrinsic
+return contracts have ambiguous corners that issue #121 explicitly
+calls out:
+
+1. **`stream_write` partial-write semantics.** "Accepted fewer bytes
+   than requested" is documented as backpressure. Two questions: (a) is
+   `0 bytes accepted` *also* backpressure or a special "no progress"
+   error? (b) does the runtime queue the un-accepted tail, or must the
+   producer always retry?
+
+2. **`stream_read` EOF distinguishability.** "Returns 0 = EOF" leaves
+   no way to express "the stream is still open but no bytes are
+   available right now" — the reader cannot tell whether to drop the
+   handle or register a waitable. The same ambiguity affects
+   `future_read` (`0` = pending vs `0` = closed?).
+
+This ADR formalises the conventions and pins them with unit tests so
+runtimes can be conformance-checked against meld's expectations.
+
+## Decision
+
+**Path K — closed `AbiError` enum, negative-`i32` codes, partial-count
+backpressure with the producer as retry authority, EOF distinguishable
+from pending via a dedicated `Pending` code.**
+
+### The closed `AbiError` enum
+
+`meld_core::p3_async::AbiError` is `#[repr(i32)]` with these stable
+discriminants:
+
+| Variant | Value | Meaning |
+|---------|-------|---------|
+| `Closed` | `-1` | Peer end of the stream/future was dropped. |
+| `InvalidHandle` | `-2` | Handle is not live, not owned by this caller, or is the wrong end. |
+| `Oom` | `-3` | Runtime could not allocate buffer space to make any progress. |
+| `Cancelled` | `-4` | Concurrent `*_cancel_*` aborted the operation. |
+| `Pending` | `-5` | Operation would block; register in waitable-set and retry. |
+| `Runtime` | `-6` | Catch-all runtime-internal failure. Forward-compat escape hatch; specific codes preferred. |
+
+The numeric values are pinned by `meld-core/tests/p3_async_abi.rs` and
+referenced in `AbiError::ALL` for exhaustive coverage. Adding a new
+variant is non-breaking only if it takes the next free negative
+discriminant (`-7`); removing or renumbering a variant is a breaking
+ABI change.
+
+### Partial-write semantics (`stream_write`)
+
+* `written == requested` — full success.
+* `0 <= written < requested` — **partial write / backpressure**. The
+  reader cannot keep up. The runtime DOES NOT queue the un-accepted
+  tail; the **producer is the retry authority**. `written == 0` is
+  treated identically to a positive partial — it is **not** an error,
+  not EOF, just "no progress this round".
+* `written < 0` — error from `AbiError`. Notably, `Closed` means the
+  readable end was dropped (further writes will fail the same way) and
+  `Oom` is distinct from backpressure (hard error, propagate).
+
+The "producer retries" rule is what allows the runtime to remain a
+*reactive* implementation — no internal buffer beyond what's pending in
+flight. Hosts that want to absorb more data can wrap the intrinsic in
+component-model glue, but the ABI-level contract is no buffering.
+
+### EOF vs Pending (`stream_read`)
+
+* `n > 0` — `n` bytes copied. May be less than requested; stream is
+  **not** at EOF.
+* `n == 0` — **EOF, sticky.** The writable end was dropped AND no
+  buffered bytes remain. Subsequent reads also return `0`.
+* `n == AbiError::Pending` (`-5`) — stream is still open, no bytes
+  available *right now*. Reader registers in a waitable-set and retries
+  after `[waitable-set-wait]` fires.
+* Other negative — `AbiError` per the table above.
+
+Runtimes MAY conflate `Closed` with `0`-EOF on `stream_read`: if the
+writable end was dropped *before* the read started AND no bytes were
+buffered, returning `0` is observably equivalent to returning `Closed`.
+Most runtimes return `0` (the simpler case) but `Closed` is permitted
+for runtimes that distinguish "drained the buffer naturally" from
+"drained it because the writer disappeared".
+
+### Resolved vs Pending vs Closed (`future_read`)
+
+* `1` — resolved; `T`'s canonical layout has been written to the
+  buffer.
+* `0` — **pending**. The future is unresolved AND the write end is
+  still alive. Reader registers in waitable-set and retries.
+* `AbiError::Closed` (`-1`) — write end was dropped without resolving;
+  no value will ever arrive. **Distinguishable** from pending.
+* Other negative — `AbiError` per the table above.
+
+Unlike `stream_write`, `future_write` is all-or-nothing: there is no
+partial-write case for futures.
+
+### Interaction with `[waitable-set-wait]`
+
+The data-plane intrinsics are non-blocking. Each `stream_read`,
+`stream_write`, and `future_read` may report a "would block" condition
+(`AbiError::Pending`, partial count, or `0` for `future_read`). The
+caller's recovery is uniform:
+
+1. The handle (readable for read, writable for write) is **the
+   waitable**. No separate waitable object.
+2. Caller obtains a waitable-set via `[waitable-set-new]`.
+3. Caller joins the handle into the set via `[waitable-join]`.
+4. Caller blocks (or spins, depending on the lift mode) on
+   `[waitable-set-wait]`. The set fires when:
+   * `stream_read` waitable: bytes become available OR the writable
+     end is dropped.
+   * `stream_write` waitable: buffer space frees up OR the readable
+     end is dropped.
+   * `future_read` waitable: the future resolves OR the write end is
+     dropped.
+5. The waitable's payload identifies *which* handle is ready. The
+   actual byte count / resolved flag / error code is delivered by
+   re-invoking the relevant data-plane intrinsic — **not** by the
+   `[waitable-set-wait]` return value.
+
+This decoupling is intentional: it means waitable-sets only carry
+identity-of-readiness, while the data-plane intrinsics retain full
+control over their return contract. A runtime that wants to deliver
+bulk readiness without blocking can poll via `[waitable-set-poll]`
+identically.
+
+## What this PR ships
+
+* `meld_core::p3_async::AbiError` enum with `repr(i32)`, `as_i32`,
+  `from_i32`, `ALL` array.
+* `StreamWriteResult`, `StreamReadResult`, `FutureReadResult` decoder
+  enums for typed handling of return values in tests and in adapter
+  glue meld emits in the deferred lowering pass.
+* Per-variant rustdoc on `HostIntrinsic::Stream*` and
+  `HostIntrinsic::Future*` documenting partial-write semantics, EOF
+  distinguishability, and the waitable-set interaction.
+* `meld-core/tests/p3_async_abi.rs` pinning the numeric values and the
+  decoder behaviour (encoding-only — no runtime interaction).
+
+## Out of scope
+
+* **Companion docs in kiln** — referenced from this ADR; tracked as a
+  follow-up issue in `pulseengine/kiln`.
+* **Reference implementation in wasmtime** — referenced; tracked as a
+  separable follow-up.
+* **Lowering pass that uses these decoders in adapter glue** — the
+  decoders are public API in this PR, but the rewrite phase that
+  emits adapter code calling them is deferred per ADR-1.
+* **Component-model `result<T, E>` lift around every intrinsic
+  (path L)** — rejected because every data-plane call would pay the
+  canonical-ABI lift/lower cost of a `result`, and the
+  zero-copy contract for `stream_read` / `stream_write` would be lost.
+  The closed-enum-on-`i32` convention is the lowest-overhead option
+  that still gives runtimes a stable wire format.
+* **Per-intrinsic ad-hoc error codes (path M)** — rejected because it
+  fragments the conformance surface. With the closed enum, kiln and
+  the wasmtime reference can share a single error-mapping table.
+
+## Backward compatibility
+
+This PR adds new public API (`AbiError`, the three decoder enums) and
+does not modify the existing `HostIntrinsic` enum variants (per the
+v0.5.0 stability contract). Components fused before this PR continue
+to validate; the decoders are opt-in for new adapter glue and tests.
+
+## References
+
+* GitHub issue #121 — original task list.
+* GitHub issue #94 — parent epic.
+* ADR-1 (`safety/adr/ADR-1-p3-async-lowering.md`) — host-intrinsic ABI
+  shape, declared error/backpressure conventions out of scope for #94.
+* WASI 0.3 stream semantics — https://wasi.dev/roadmap
+* WASM Component Model P3 spec —
+  https://github.com/WebAssembly/component-model
+* `meld-core/src/p3_async.rs` — canonical ABI documentation.
+* `meld-core/tests/p3_async_abi.rs` — pin tests for the conventions.


### PR DESCRIPTION
## Summary

Formalises the wire-level error and backpressure conventions for the
`pulseengine:async` host-intrinsic ABI defined in ADR-1. Closes #121.

- **Closed `AbiError` enum** (`#[repr(i32)]`) with stable negative codes:
  `Closed=-1`, `InvalidHandle=-2`, `Oom=-3`, `Cancelled=-4`,
  `Pending=-5`, `Runtime=-6`.
- **Typed decoders** `StreamWriteResult`, `StreamReadResult`,
  `FutureReadResult` that turn raw `i32` returns into match-friendly
  variants for tests and the deferred adapter-glue lowering pass.
- **Per-variant rustdoc** on every `HostIntrinsic::Stream*` /
  `HostIntrinsic::Future*` documenting partial-write semantics
  (producer is retry authority; runtime does NOT queue the un-accepted
  tail), EOF distinguishability from "0 bytes available right now"
  (`0` is sticky EOF; `AbiError::Pending` is the open-but-empty case),
  and the `[waitable-set-wait]` interaction.
- **Sibling ADR-2** (`safety/adr/ADR-2-p3-async-error-conventions.md`)
  formalises the conventions and rationalises the design choice
  vs. ad-hoc per-intrinsic codes (rejected) and `result<T,E>` lift
  (rejected — too heavyweight for the data plane). ADR-1 is updated
  with a forward reference.
- **22 pin tests** in `meld-core/tests/p3_async_abi.rs` (encoding-only —
  meld doesn't run the P3 runtime; the tests assert the wire encoding
  any conforming runtime must reproduce).

## Constraints respected

- `HostIntrinsic` enum variants are unchanged (v0.5.0 stability
  contract). All new types — `AbiError`, `StreamWriteResult`,
  `StreamReadResult`, `FutureReadResult` — live alongside.
- No new runtime dependencies.
- 73-test `wit_bindgen_runtime` suite stays green.
- Pre-commit hooks (cargo-fmt + cargo-clippy + cargo-test) all green.

## Out of scope (separable tracking issues)

Per the issue body and ADR-2, these are *not* in this PR:

- Companion docs in kiln (the runtime reference impl).
- Reference implementation in wasmtime.
- The lowering pass that uses these decoders inside the adapter glue
  meld emits — deferred per ADR-1, foundation work tracked under #94.

## Test plan

- [x] `cargo test --package meld-core --test p3_async_abi` (22 new pin tests)
- [x] `cargo test --package meld-core --test p3_async_lowering` (5 existing — unchanged)
- [x] `cargo test --package meld-core --test wit_bindgen_runtime` (73/73 green)
- [x] `cargo test` (full workspace — green)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo doc --no-deps` (no new warnings; pre-existing HTML-tag warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)