### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,83 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] — Unreleased
+
+### Added
+
+- **P3 async lowering pass — full data plane** (#120 / #129).
+  Canonical built-ins `(canon stream.{new,read,write,cancel-read,
+  cancel-write,drop-readable,drop-writable})` and the same seven verbs
+  for `future` are now rewritten into core-module imports against the
+  `pulseengine:async` ABI documented in `meld_core::p3_async`. The
+  rewrite reuses every existing function-index reference so already-
+  encoded `call N` instructions pick up the new defined-function
+  positions. End-to-end tests for `stream<u8>` and `future<i32>`
+  symmetric cases pass; the 73-test suite stays green when no P3
+  async features are present (the pass is a no-op).
+- **Closed `AbiError` enum + typed result decoders for `pulseengine:async`**
+  (#121 / #127). Stable numeric error codes (`Closed=-1`,
+  `InvalidHandle=-2`, `Oom=-3`, `Cancelled=-4`, `Pending=-5`,
+  `Runtime=-6`) plus `StreamWriteResult` / `StreamReadResult` /
+  `FutureReadResult` decoders. Per-variant rustdoc on every
+  `HostIntrinsic::Stream*` / `Future*` documents partial-write
+  semantics (producer is retry authority — runtime does NOT queue),
+  EOF vs Pending distinguishability, and the `[waitable-set-wait]`
+  interaction. ADR-2 documents the conventions.
+- **Async-export callback trampoline alignment** (#122 / #128). Stable
+  numeric event-type codes (`event::NONE`, `SUBTASK`, `STREAM_READ`,
+  `STREAM_WRITE`, `FUTURE_READ`, `FUTURE_WRITE`, `CANCELLED`) and
+  callback-return-code constants (`callback::EXIT`, `YIELD`, `WAIT`,
+  `POLL` + `CODE_MASK` / `PAYLOAD_SHIFT`) exposed in
+  `meld_core::p3_async`. ADR-1 addendum pins the canonical trampoline
+  shape (`generate_async_callback_adapter` emits one shape regardless
+  of which P3 built-ins the guest happens to use). Tests
+  `async_callback_trampoline_shape_canonical`,
+  `async_callback_event_codes_pinned`,
+  `async_callback_return_codes_pinned` pin the contract.
+
+### Fixed
+
+- **`callback::POLL` dispatched as YIELD (LS-A-9 / pre-release Mythos
+  finding).** The trampoline's
+  `if code == WAIT { dispatch [waitable-set-poll] } else { send EVENT_NONE }`
+  silently treated POLL (3) as YIELD (1), dropping any event the host
+  had ready. Discovered by the v0.6 pre-release Mythos pass on
+  `adapter/fact.rs`. Fix: branch on `code == WAIT || code == POLL`.
+  Approved as **LS-A-9**.
+
+### Safety / STPA
+
+- New approved loss scenario: **LS-A-9** (UCA-F-3): async callback
+  POLL fall-through; fixed in `adapter/fact.rs`.
+- New ADR: **ADR-2** (`safety/adr/ADR-2-p3-async-error-conventions.md`)
+  — `pulseengine:async` error / backpressure conventions.
+- Updated ADR-1 — P3 async lowering pass marked shipped; trampoline
+  addendum from #122 included; ADR-2 cross-reference added.
+
+### Internal
+
+- `meld-core/src/p3_async.rs` — +1019 LOC: lowering pass
+  (`lower_p3_async_intrinsics`, `LoweringPlan`), `AbiError` enum,
+  result decoders, event/callback constant tables, partial-write +
+  EOF + waitable-set-wait rustdoc.
+- `meld-core/src/adapter/fact.rs` — async-callback trampoline now
+  references named `event::*` / `callback::*` constants (no more
+  magic numbers); POLL dispatch fix.
+- `meld-core/tests/p3_async_lowering.rs` — +399 LOC: lowering
+  end-to-end tests for stream/future, callback shape pins.
+- `meld-core/tests/p3_async_abi.rs` (new) — 22 encoding-pin tests for
+  the `AbiError` numeric values and result decoders.
+- `safety/adr/ADR-2-p3-async-error-conventions.md` (new).
+
+### Pre-release Mythos pass
+
+Tier-5 + tier-4 files changed since v0.5.0: `adapter/fact.rs` only
+(+62 LOC, async-callback constant references). Scanned per
+`scripts/mythos/discover.md`; **1 confirmed finding** (LS-A-9 above).
+Fix shipped in this release; the discovery → fix → approved-LS pattern
+parallels v0.3.0 and v0.4.0's Mythos cycle.
+
 ## [0.5.0] — Unreleased
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -4063,14 +4063,23 @@ impl FactStyleGenerator {
         body.instruction(&Instruction::I32Eqz);
         body.instruction(&Instruction::BrIf(1)); // break to $exit block
 
-        // if code == WAIT (2): call waitable-set-poll(payload, event_ptr)
+        // if code == WAIT (2) OR code == POLL (3): call
+        // waitable-set-poll(payload, event_ptr).
         // Use scratch space at address 0 in callee memory for the 3xi32 event tuple
         // (This is safe because the callee isn't running — we're driving it).
-        // Note: POLL (3) goes through the same path; the runtime treats
-        // poll as a non-blocking variant of wait against the same call.
+        // POLL is the non-blocking variant of WAIT against the same call;
+        // both must dispatch to the host. LS-A-9: a previous version
+        // matched only WAIT, silently treating POLL as YIELD which sent
+        // (EVENT_NONE, 0, 0) to [callback] and dropped the event the host
+        // had ready, producing semantic drift between fused and composed
+        // modules.
         body.instruction(&Instruction::LocalGet(l_code));
         body.instruction(&Instruction::I32Const(crate::p3_async::callback::WAIT));
         body.instruction(&Instruction::I32Eq);
+        body.instruction(&Instruction::LocalGet(l_code));
+        body.instruction(&Instruction::I32Const(crate::p3_async::callback::POLL));
+        body.instruction(&Instruction::I32Eq);
+        body.instruction(&Instruction::I32Or);
         body.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
         {
             // waitable-set-poll(set_handle, event_ptr) → i32

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -647,6 +647,43 @@ loss-scenarios:
     status: approved
     priority: high
 
+  - id: LS-A-9
+    title: Async callback POLL falls through to YIELD path
+    uca: UCA-F-3
+    hazards: [H-3]
+    type: inadequate-control-algorithm
+    scenario: >
+      `FactStyleGenerator::generate_async_callback_adapter` in
+      meld-core/src/adapter/fact.rs (~lines 4071-4119) dispatched
+      `[waitable-set-poll]` only when the guest's callback return code
+      equalled `callback::WAIT (2)`. The spec rustdoc on
+      `meld_core::p3_async::callback::POLL (3)` requires POLL to also
+      dispatch the host poll (POLL is the non-blocking variant of WAIT
+      against the same call). The pre-fix `if code == WAIT` branch
+      treated POLL as falling through to the else arm, which sent
+      `(EVENT_NONE, 0, 0)` to `[callback]` and dropped any event the
+      host had ready. Effect: a guest legitimately returning POLL never
+      sees the event it is polling for, even when the host has it
+      ready — the fused module diverges from the composed module on
+      P3 async export call paths [UCA-F-3]. Hazards: H-3
+      (semantic-preservation violation). Detected by Kani harness
+      `kani_trampoline_dispatches_poll_like_wait` and PoC
+      `async_callback_trampoline_dispatches_poll`. Fix: branch on
+      `code == WAIT || code == POLL` (an `I32Eq + I32Eq + I32Or` pair
+      replaces the single `I32Eq`). Existing
+      `async_callback_return_codes_pinned` /
+      `async_callback_trampoline_shape_canonical` tests pin the
+      *constants* / *bit layout* but not the *dispatch decision*, so
+      they did not catch this.
+    causal-factors:
+      - Single-arm `I32Eq` against `callback::WAIT` instead of
+        `WAIT || POLL`
+      - Comment at L4069-4070 claimed POLL goes through the same path,
+        but the code did not implement it
+      - Pin tests covered constants and bit layout, not dispatch
+    status: approved
+    priority: high
+
   # ==========================================================================
   # Merger scenario (discovered during gap analysis)
   # ==========================================================================


### PR DESCRIPTION
## Summary

Bumps `0.5.0` → `0.6.0`. Closes the P3 async deferred-work trio (#120, #121, #122) and ships a Mythos-discovered fix (LS-A-9).

## What's in 0.6.0

3 issues closed plus 1 pre-release fix.

### Added
- **P3 async lowering pass** (#120 / #129): `(canon stream.*)` / `(canon future.*)` → `pulseengine:async/*` imports.
- **`AbiError` + typed result decoders** (#121 / #127): closed enum, partial-write semantics doc, `[waitable-set-wait]` interaction. ADR-2 lands.
- **Async-export callback trampoline alignment** (#122 / #128): event-code and callback-code constants exposed; canonical trampoline shape pinned.

### Fixed
- **LS-A-9** (pre-release Mythos finding, fixed in this PR): `callback::POLL` was dispatched as YIELD, silently dropping host-ready events. Trampoline now branches on `WAIT || POLL`.

### Safety / STPA
- LS-A-9 (UCA-F-3) approved.
- ADR-2 added; ADR-1 updated with lowering-pass-shipped + trampoline addendum + ADR-2 cross-ref.

## Pre-release Mythos pass

Tier-5 + tier-4 files changed since v0.5.0: `adapter/fact.rs` only (+62 LOC). Scanned; **1 confirmed finding** (LS-A-9, fixed here). Pattern parallels v0.3.0 and v0.4.0.

## Test plan

- [x] `cargo test --release` — green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI green on this PR
- [ ] Tag `v0.6.0` after merge

## Branch

`release/v0.6.0` head `f477998` — 1 commit on top of `main`.
