### PR TITLE
chore(ci): add concurrency control to all workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,6 +14,10 @@ name: Bench Smoke
 # into shell commands. If you add steps that consume `github.event.*` data,
 # route it through `env:` first.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -1,5 +1,9 @@
 name: Update wit-bindgen Fixtures
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.run_id }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,6 +16,10 @@ name: Fuzz Smoke
 # forks, etc.) are interpolated into shell commands. If you add steps
 # that consume `github.event.*` data, route it through `env:` first.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     tags: ['v*']


### PR DESCRIPTION
## Summary

Adds a top-level `concurrency:` block to every `.github/workflows/*.yml`, per the org-wide **CI Concurrency Hardening** brief. Cancels superseded PR runs; never cancels runs on `main`, tags, releases, or scheduled events.

## Classification

| File | Variant | Notes |
|---|---|---|
| `ci.yml` | default | cancel-in-progress conditional on `pull_request` |
| `bench.yml` | default | same as ci.yml |
| `fuzz.yml` | default | same as ci.yml |
| `fixtures.yml` | scheduled | unique group per `run_id`; never cancel (each weekly run is independent data) |
| `release.yml` | release | group by `ref`; never cancel (mid-publish cancellation would leave registry / tag / attestation state inconsistent) |

## Note on the brief's `head_ref` pattern

The brief's canonical default pattern is `${{ github.workflow }}-${{ github.head_ref || github.ref }}`. The repo's pre-commit hook flags any expression referencing `github.head_ref` as a workflow-injection risk (it's in the documented risky-inputs list).

This PR uses `github.ref` alone, which:
- Is **NOT** in the hook's risky-inputs list.
- Is unique per branch (`refs/heads/<name>`) and per PR (`refs/pull/<N>/merge`).
- Produces equivalent grouping for both `push` and `pull_request` events.
- Combined with the conditional `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`, still delivers the brief's stated behavior: cancel superseded PR runs, preserve main / tag / schedule / dispatch runs.

## Verification plan (per brief §"Verification")

- [x] `yamllint` (via `python -c yaml.safe_load`) — clean on all 5 files
- [ ] PR's own CI run passes
- [ ] Push a no-op follow-up commit; earlier PR run shows as **Cancelled** within ~30s
- [ ] Post-merge `main` run completes normally (not cancelled)

## Out of scope

Per the brief: runner migration, job parallelization, cache strategy changes, permission minimization. Each tracked separately.
