### PR TITLE
ci: temporary fallback to ubuntu-latest (smithy offline)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   bench-smoke:
     name: Bench compile-only
-    runs-on: [self-hosted, linux, x64, rust-cpu]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: [self-hosted, linux, x64, rust-cpu]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -47,7 +47,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: [self-hosted, linux, x64, rust-cpu]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -83,7 +83,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: [self-hosted, linux, x64, rust-cpu]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -99,7 +99,7 @@ jobs:
 
   fmt:
     name: Format
-    runs-on: [self-hosted, linux, x64, light]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   update-fixtures:
     name: Generate wit-bindgen fixtures
-    runs-on: [self-hosted, linux, x64, rust-cpu]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   fuzz-smoke:
     name: Fuzz smoke (${{ matrix.target }})
-    runs-on: [self-hosted, linux, x64, rust-cpu]
+    runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runner: [self-hosted, linux, x64, rust-cpu]
+            runner: ubuntu-latest
             use_cross: false
           # Stays on ubuntu-latest: `cross` launches a Docker container;
           # podman-docker compat shim on smithy is untested for cross images.
@@ -66,7 +66,7 @@ jobs:
   release:
     name: Release
     needs: build
-    runs-on: [self-hosted, linux, x64, light]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

Smithy fleet (all 8 `pulseengine-ci-01-*` runners) reports
`status=offline` and jobs have been queued for hours with no pickup.
This PR flips every workflow back to `ubuntu-latest` so PRs can land
while the fleet is being recovered.

After smithy is back online, **revert this commit** to restore the
migration from #134.

## Scope

| Workflow | Before | After |
|---|---|---|
| ci.yml (test/coverage/clippy) | `[self-hosted, linux, x64, rust-cpu]` | `ubuntu-latest` |
| ci.yml (fmt) | `[self-hosted, linux, x64, light]` | `ubuntu-latest` |
| bench.yml | `[self-hosted, linux, x64, rust-cpu]` | `ubuntu-latest` |
| fixtures.yml | `[self-hosted, linux, x64, rust-cpu]` | `ubuntu-latest` |
| fuzz.yml | `[self-hosted, linux, x64, rust-cpu]` | `ubuntu-latest` |
| release.yml (x86_64-linux-gnu) | `[self-hosted, linux, x64, rust-cpu]` | `ubuntu-latest` |
| release.yml (release publish) | `[self-hosted, linux, x64, light]` | `ubuntu-latest` |

macOS and cross-compile targets in `release.yml` are unchanged.

## Test plan

- [ ] CI runs on `ubuntu-latest` and goes green
- [ ] No leftover smithy-only labels referenced
- [ ] Revert this PR (or restore #134's hashes) once smithy is back

🤖 Generated with [Claude Code](https://claude.com/claude-code)