### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.7.0] — 2026-05-11
 
 ### Added
 
@@ -16,12 +16,21 @@ All notable changes to this project will be documented in this file.
   `PassThrough` is opt-in for the rare case a caller wants the lossy
   prior behaviour. Recorded in attestation `tool_parameters` as
   `dwarf_handling = "strip" | "passthrough"`. Verified by
-  `meld-core/tests/dwarf_strip.rs`.
+  `meld-core/tests/dwarf_strip.rs`. Lands #135.
 
 ### Safety / STPA
 
 - New approved loss scenario: **LS-CP-4** (DWARF passthrough emits
   address-incorrect debug info on fused output, [H-7]).
+
+### Breaking
+
+- Default DWARF handling changed: `.debug_*` sections are now dropped
+  from fused output by default. Callers that previously relied on
+  passed-through DWARF must opt in with
+  `FuserConfig { dwarf_handling: DwarfHandling::PassThrough, .. }`,
+  understanding that the addresses inside those sections do not match
+  the merged code section.
 
 ## [0.6.0] — Unreleased
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Release v0.7.0. Single feature: DWARF Phase 1.5 (#135, lands sub-#130).

## Behaviour change

Default `FuserConfig.dwarf_handling` flips from implicit
passthrough to explicit `DwarfHandling::Strip`. Callers that
previously relied on DWARF being passed through must opt in:

```rust
let config = FuserConfig {
    dwarf_handling: DwarfHandling::PassThrough,
    ..FuserConfig::default()
};
```

Rationale: the passthrough is *wrong* — addresses reference per-input
code-section offsets, not the merged code section. Downstream MC/DC
tooling (`pulseengine/witness`) was silently getting bad source
attribution. Phase 2 (#130) will add a real address-remap pass; until
then, `Strip` is the only non-corrupting setting.

## Changelog

See `CHANGELOG.md` `[0.7.0]` for the full entry, including the new
**Breaking** section.

## Safety

- New approved loss scenario: **LS-CP-4** (#135).

## Test plan

- [ ] CI green on smithy
- [ ] After merge: tag `v0.7.0`, push tag, verify release.yml builds
      binaries for all four targets and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)