### PR TITLE
docs: roadmap v0.8 → v0.11 + rivet SDLC artifacts

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,148 @@
+# Meld release roadmap (v0.8 → v0.11)
+
+> Drafted 2026-05-12. Living document — update each release.
+
+Released so far through 2026-05-11: **v0.7.0**. See `CHANGELOG.md`.
+
+This roadmap walks the residual P3-async (#94) and DWARF (#130) umbrellas
+to completion across four minor releases, batching related work and
+respecting the "no `--admin` bypass" gate from #139 (smithy reliability).
+
+## Cadence
+
+- Five releases in two weeks (v0.3 → v0.7, 2026-04-28 → 2026-05-11) was
+  faster than downstream consumers (witness, gale, kiln) can absorb.
+- Going forward: target **~one minor release per 3–4 weeks**. Batch 1–3
+  thematically related issues per release; cut at a feature boundary,
+  not on a clock.
+- Pre-release Mythos pass (per `scripts/mythos/discover.md`) is the
+  cutting gate. Releases without a Mythos delta-pass on changed Tier-5
+  files are blocked.
+- Smithy CI must be "stable enough" per #139's acceptance bar before a
+  release ships without `--admin`. If smithy is not yet there, the
+  release is documented as admin-merged in the PR body and the
+  precedent is reset to zero on #139.
+
+## Release plan
+
+### v0.8.0 — Stackful P3 lifting
+
+| Item | Issue | Rivet |
+|---|---|---|
+| Stackful lifting trampoline (`task.wait`/`task.yield` + `thread_new`/`thread_switch_to`) | #140 | SR-32 |
+
+**Why first.** Smallest touch among the three #94 sub-items. Parallels
+the callback trampoline from #128 — limited merger-side change. Also
+the first release after the v0.7 smithy incidents; small scope means
+the release validates that CI stability has improved before we throw a
+larger PR at it.
+
+**Pre-release Mythos surface.** Tier-5 file changed: `adapter/fact.rs`
+(new stackful trampoline emitter). Standard Tier-5 scan.
+
+### v0.9.0 — Cross-component stream + (stretch) validation
+
+| Item | Issue | Rivet |
+|---|---|---|
+| Cross-component stream adapter (same-mem zero-copy + cross-mem chain) | #141 | SR-33 |
+| Stream-graph static validation (type / capacity / cycle / lifetime) | #142 | SR-34 |
+
+**Why this bundle.** #142 *uses* the artefact #141 produces — type
+compatibility, cycle detection, and resource-lifetime tracking all
+operate on the stream-pair graph that the adapter pass builds. Landing
+them together avoids a "we shipped the adapter but it's not validated"
+gap.
+
+**Stretch.** If #142 isn't ready by the v0.9 cut, slip to v0.10 — do
+not delay the adapter for the checker.
+
+**Mythos surface.** New emitter (Tier-5), new resolver pass (Tier-4).
+Two scans.
+
+### v0.10.0 — DWARF Phase 2 (address remap)
+
+| Item | Issue | Rivet |
+|---|---|---|
+| `.debug_line` / `.debug_info` / `.debug_ranges` address remap into merged code section | #143 | SR-35 |
+| `DwarfHandling::Remap` variant — opt-in this release, default in a future release after witness validates | #143 | (SR-35) |
+
+**Why solo.** Real DWARF surgery (gimli read + write or a thin
+standalone writer helper). Cross-repo verification loop with witness
+needs to be set up. Bundling this with anything else dilutes the
+release-note story and the testing focus.
+
+**Mythos surface.** New module, new dependency (`gimli`). Tier-5 by
+default for the new module; cross-component invariants check that
+non-DWARF behaviour is unchanged when `DwarfHandling::Strip` (the v0.7
+default) remains selected.
+
+### v0.11.0 — DWARF Phase 3 (adapter DIEs)
+
+| Item | Issue | Rivet |
+|---|---|---|
+| Synthesised DIEs for meld-generated adapter functions | #144 | SR-36 |
+
+**Why last.** Blocked on #143. Closes out the witness MC/DC story for
+fused output: every `br_if` in the fused module gets a source
+attribution, including the ones meld synthesised.
+
+After v0.11 ships and witness confirms attribution coverage, consider
+flipping `DwarfHandling::Remap` to the default in a v0.11.1 or v0.12.
+
+## Cross-cutting tracks
+
+These don't ride a single release — they're ongoing.
+
+- **Smithy reliability** (#139). Acceptance bar is the gate for
+  lifting `--admin`-merge precedent. Closed when three consecutive
+  meld releases ship without admin-bypass.
+- **Mythos delta passes.** Run on every release per the existing
+  pattern (LS-P-4 v0.3, LS-A-8 v0.3, LS-P-5 v0.5, LS-A-9 v0.6,
+  LS-CP-4 v0.7).
+- **RFC #46 alignment.** Track
+  [bytecodealliance/rfcs#46](https://github.com/bytecodealliance/rfcs/pull/46).
+  Two upcoming meld touchpoints are anticipated from
+  alexcrichton's 2026-04-08 comment:
+  - Document that `pulseengine:async` already satisfies the "no
+    injected linear memories — all CM intrinsics are host imports"
+    constraint (update ADR-1).
+  - Investigate adding a sibling output mode `OutputFormat::MultiModule`
+    so meld can be adopted inside wasmtime under the "emit N modules +
+    metadata" strategy rather than the current single-module fusion.
+
+## SDLC tracking
+
+Each numbered deliverable above has:
+
+| Artefact | Where |
+|---|---|
+| Issue with milestone | GitHub `pulseengine/meld` |
+| Rivet requirement | `safety/requirements/safety-requirements.yaml` (SR-N) or `safety/requirements/p3-async.yaml` (feature subset) |
+| Verification linkage | `safety/requirements/traceability.yaml` |
+| ADR (where design-level) | `safety/adr/ADR-N-<topic>.md` |
+| LS-N (where a loss scenario applies) | `safety/stpa/loss-scenarios.yaml` (status `approved` only after the fix lands) |
+| CHANGELOG entry | `CHANGELOG.md` `[Unreleased]` → renamed at release PR |
+| Pre-release Mythos pass note | release PR body + CHANGELOG |
+
+A release is "done" when:
+
+1. All milestone issues are closed.
+2. Their rivet requirements show `status: implemented` in
+   `safety-requirements.yaml`.
+3. Their entries in `traceability.yaml::verification-status` point at
+   real test files / proof paths, not TBD.
+4. CHANGELOG entry under `[Unreleased]` is renamed to `[vX.Y.Z] — <date>`.
+5. Pre-release Mythos scan completed on Tier-5 + Tier-4 files changed
+   since the previous release; findings either fixed in the same
+   release PR or filed as a follow-up.
+6. Tag `vX.Y.Z` pushed; release.yml produced all 4 binaries.
+
+## Out of scope for this roadmap
+
+- Variable-level DWARF (`.debug_loc`, `.debug_loclists`) — explicit
+  non-goal per #130.
+- `OutputFormat::MultiModule` — design exploration first; not yet a
+  scheduled deliverable.
+- Performance regression detection on fused output — WarpL evaluation
+  (`docs/arxiv-2604.13693-warpl-evaluation.md`) recommended deferring;
+  if this becomes a real need, it'll get its own issue + roadmap entry.

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -663,3 +663,153 @@ artifacts:
       references:
         - "BA RFC #46 discussion: cfallin on multiply-instantiated modules"
         - "safety/stpa/rfc46-comparative-analysis.md section 4 Q1"
+
+  # ==========================================================================
+  # Roadmap requirements v0.8 → v0.11 (SR-32..SR-36)
+  #
+  # Each entry tracks a deliverable from docs/roadmap.md. `status` starts at
+  # `planned`, moves to `in-progress` when a PR opens, and to `implemented`
+  # when the release that contains it ships. Tagged `roadmap` so a future
+  # validation tool can cross-check open milestones against requirement
+  # status.
+  # ==========================================================================
+
+  - id: SR-32
+    type: requirement
+    title: Stackful P3 lifting mode emission
+    description: >
+      In addition to the callback trampoline (shipped #128), meld shall
+      emit a stackful lifting trampoline for components that suspend via
+      `task.wait` / `task.yield`. The trampoline imports
+      `pulseengine:async::thread_new`, `thread_switch_to`, `thread_yield`,
+      `thread_exit` host intrinsics and provides one stack per in-flight
+      async call. Documented in ADR-1 addendum.
+    status: planned
+    tags: [roadmap, p3-async, v0.8.0]
+    links:
+      - type: derives-from
+        target: "#94"
+      - type: tracked-by
+        target: "#140"
+    fields:
+      implementation: meld-core/src/adapter/fact.rs
+      verification-method: test
+      verification-description: >
+        Shape-pin test mirroring async_callback_trampoline_shape_canonical;
+        end-to-end stackful suspend/resume case.
+      milestone: v0.8.0
+
+  - id: SR-33
+    type: requirement
+    title: Cross-component `stream<T>` fusion at merge time
+    description: >
+      When two fused components share a `stream<T>` endpoint, meld shall
+      emit an in-module adapter that bridges the two sides without round-
+      tripping through the host. Two modes:
+      (a) same-memory (single-memory fusion): direct in-module ring buffer,
+      zero-copy.
+      (b) different-memory (multi-memory): `stream_read` → in-module copy
+      loop → `stream_write` chain, with `cabi_realloc` null-guard policy
+      per LS-A-7.
+    status: planned
+    tags: [roadmap, p3-async, v0.9.0]
+    links:
+      - type: derives-from
+        target: "#94"
+      - type: tracked-by
+        target: "#141"
+    fields:
+      implementation:
+        - meld-core/src/adapter/fact.rs
+        - meld-core/src/resolver.rs
+      verification-method: test
+      verification-description: >
+        Same-memory zero-copy fixture; different-memory chain fixture;
+        backpressure propagation; EOF passthrough.
+      milestone: v0.9.0
+
+  - id: SR-34
+    type: requirement
+    title: Static `stream<T>` validation
+    description: >
+      Build-time validation passes for cross-component streams:
+      (i) source `stream<A>` and sink `stream<B>` types must match;
+      (ii) bounded channels must declare capacity;
+      (iii) the stream-endpoint graph must be acyclic (no deadlock);
+      (iv) `own<T>` handles passed through a stream must outlive every
+      receiver. Each violation returns a typed `Error::ValidationError`
+      with the offending site.
+    status: planned
+    tags: [roadmap, p3-async, v0.9.0]
+    links:
+      - type: derives-from
+        target: "#94"
+      - type: tracked-by
+        target: "#142"
+      - type: depends-on
+        target: SR-33
+    fields:
+      implementation: meld-core/src/resolver.rs
+      verification-method: test+proof
+      verification-description: >
+        Regression test per check; Kani harness for cycle detection.
+        Approved LS-N per violation class.
+      milestone: v0.9.0
+
+  - id: SR-35
+    type: requirement
+    title: DWARF address remap into merged code section
+    description: >
+      A new `DwarfHandling::Remap` policy on `FuserConfig` shall rewrite
+      `.debug_line`, `.debug_info` (address-bearing DIEs), `.debug_ranges`
+      / `.debug_rnglists` so addresses inside those sections reference the
+      merged code section rather than per-input code sections.
+      `.debug_str` / `.debug_abbrev` pass through with string-pool dedup /
+      byte-equal merge. End-to-end verified by witness MC/DC integration:
+      ≥ X% of `br_if` byte offsets in fused output resolve to source.
+    status: planned
+    tags: [roadmap, dwarf, witness-mc-dc, v0.10.0]
+    links:
+      - type: derives-from
+        target: "#130"
+      - type: tracked-by
+        target: "#143"
+      - type: supersedes-default-of
+        target: LS-CP-4
+    fields:
+      implementation: meld-core/src/dwarf_remap.rs
+      verification-method: test+cross-repo
+      verification-description: >
+        Unit tests on `.debug_line` rewrite; cross-repo smoke against
+        `pulseengine/witness` confirming attribution coverage on a fused
+        wit-bindgen fixture.
+      milestone: v0.10.0
+
+  - id: SR-36
+    type: requirement
+    title: Synthesised DWARF DIEs for meld-generated adapter functions
+    description: >
+      For every adapter function meld emits (cross-component lift/lower,
+      `cabi_realloc` trampoline, `memory.copy` transcode loop), the
+      output module shall carry a synthesised DIE pointing at a
+      placeholder source file `<meld-adapter>` line N where N encodes
+      the adapter class. Witness then surfaces these as "adapter"
+      branches in its MC/DC line map rather than as un-attributed gaps.
+    status: planned
+    tags: [roadmap, dwarf, witness-mc-dc, v0.11.0]
+    links:
+      - type: derives-from
+        target: "#130"
+      - type: tracked-by
+        target: "#144"
+      - type: depends-on
+        target: SR-35
+    fields:
+      implementation:
+        - meld-core/src/dwarf_remap.rs
+        - meld-core/src/adapter/fact.rs
+      verification-method: test+cross-repo
+      verification-description: >
+        Witness confirms adapter ranges resolve to `<meld-adapter>:N`
+        rather than `unknown`; LS-N approved for MC/DC adapter accounting.
+      milestone: v0.11.0

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -315,6 +315,44 @@ verification-status:
     status: not-verified
     note: "CRITICAL: No detection of multiply-instantiated modules. Silent corruption risk."
 
+  # Roadmap entries (SR-32..SR-36) — see docs/roadmap.md. status moves
+  # planned -> in-progress -> implemented as the milestone proceeds.
+
+  SR-32:
+    implementation-files: []
+    tests: []
+    proofs: []
+    status: planned
+    note: "v0.8.0 — Stackful P3 lifting mode (#140). Implementation lands in adapter/fact.rs."
+
+  SR-33:
+    implementation-files: []
+    tests: []
+    proofs: []
+    status: planned
+    note: "v0.9.0 — Cross-component stream<T> fusion (#141). adapter/fact.rs + resolver.rs."
+
+  SR-34:
+    implementation-files: []
+    tests: []
+    proofs: []
+    status: planned
+    note: "v0.9.0 — Static stream<T> validation (#142). Depends on SR-33."
+
+  SR-35:
+    implementation-files: []
+    tests: []
+    proofs: []
+    status: planned
+    note: "v0.10.0 — DWARF Phase 2 address remap (#143). New module meld-core/src/dwarf_remap.rs."
+
+  SR-36:
+    implementation-files: []
+    tests: []
+    proofs: []
+    status: planned
+    note: "v0.11.0 — DWARF Phase 3 adapter DIEs (#144). Depends on SR-35."
+
 # wit-bindgen fixture coverage (14 fixtures × 3 levels = 42 integration tests)
 wit-bindgen-fixtures:
   passing-all-3-levels:


### PR DESCRIPTION
## Summary

Plans the residual work from the two open umbrellas (#94 P3 async,
#130 DWARF / witness MC/DC) across four minor releases and ties each
deliverable to a rivet requirement + traceability entry.

## Release plan

| Milestone | Issue | Rivet | Scope |
|---|---|---|---|
| v0.8.0 | #140 | SR-32 | Stackful P3 lifting mode (#94 sub-C) |
| v0.9.0 | #141 | SR-33 | Cross-component \`stream<T>\` adapter (#94 sub-A) |
| v0.9.0 (stretch) | #142 | SR-34 | Static stream validation (#94 sub-B) — slips to v0.10 if #141 not in time |
| v0.10.0 | #143 | SR-35 | DWARF Phase 2 — address remap (#130) |
| v0.11.0 | #144 | SR-36 | DWARF Phase 3 — synthesised adapter DIEs (#130) |

## What lands in this PR

- \`docs/roadmap.md\` (148 lines) — human-facing living plan with rationale, cadence, and SDLC checklist.
- \`safety/requirements/safety-requirements.yaml\` — five new rivet artifacts SR-32..SR-36, each tagged \`roadmap\` with \`status: planned\` and linked to its tracking issue + dependency requirement.
- \`safety/requirements/traceability.yaml\` — \`verification-status\` placeholders for each new SR (\`status: planned\`, empty test/proof lists, populated as work lands).

## Cadence change

Five releases in two weeks (v0.3 → v0.7) was faster than downstream consumers can absorb. Targeting ~one minor per 3–4 weeks going forward, batched thematically. Smithy reliability gate (#139) must clear before lifting \`--admin\`-merge precedent.

## Cross-cutting tracks documented in the roadmap

- #139 smithy reliability acceptance bar
- Mythos delta passes per release (existing pattern)
- RFC #46 alignment — two anticipated meld touchpoints from alexcrichton's 2026-04-08 comment (no injected memories, multi-module output mode)

## SDLC definition of "release done"

The roadmap encodes a 6-step gate every release must pass:

1. All milestone issues closed
2. Their rivet requirements marked \`status: implemented\`
3. Their traceability entries point at real test files / proof paths
4. CHANGELOG \`[Unreleased]\` renamed to \`[vX.Y.Z] — <date>\`
5. Pre-release Mythos scan completed; findings fixed or filed
6. Tag pushed; release.yml produced all 4 binaries

Same shape as v0.3 → v0.7 already followed, now written down.

## Out of scope explicitly

- Variable-level DWARF (\`.debug_loc\`, \`.debug_loclists\`)
- \`OutputFormat::MultiModule\` (RFC #46 alignment work — design exploration first)
- Runtime perf regression detection (WarpL deferred per docs/arxiv-2604.13693-warpl-evaluation.md)

## Test plan

- [ ] Roadmap renders cleanly in GitHub markdown
- [ ] Five new SR entries pass any rivet schema validation in CI
- [ ] traceability.yaml is parseable as YAML
- [ ] Milestone references in issues match the created milestones