### PR TITLE
feat(p3-async): stackful lifting ABI foundation (#140 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **P3 stackful lifting — ABI foundation** (#140 / SR-32, sub-#94).
+  Adds four new host-intrinsic imports under `pulseengine:async` —
+  `thread_new`, `thread_switch_to`, `thread_yield`, `thread_exit` —
+  exposed as `HostIntrinsic::Thread*` variants with pinned signatures
+  and a new `thread` constants module. `P3AsyncFeatures::uses_stackful_lift()`
+  returns true when a component declares `(canon lift ... async ...)`
+  without a `(callback ...)` option. ADR-1 addendum (2026-05-13)
+  documents the two-mode lifting policy and emission contract. The
+  stackful trampoline emitter that consumes these intrinsics ships in
+  a follow-up PR within the v0.8.0 milestone; this PR is the ABI
+  foundation that downstream tooling (kiln runtime) can already
+  implement against. Verified by `stackful_intrinsic_signatures_pinned`
+  and `stackful_lift_is_async_without_callback`.
+
 ## [0.7.0] — 2026-05-11
 
 ### Added

--- a/meld-core/src/p3_async.rs
+++ b/meld-core/src/p3_async.rs
@@ -222,6 +222,54 @@ pub mod stream {
     pub const DROP_WRITABLE: &str = "stream_drop_writable";
 }
 
+/// Names of all stackful-lifting host intrinsic imports.
+///
+/// P3 async exports come in two lifting modes:
+///
+/// * **Callback** (currently the only mode meld emits, see [`callback`]) —
+///   the component declares a `(callback ...)` option on its `canon lift`;
+///   meld emits a trampoline that re-enters the guest on every event.
+///   One shared stack per component. Preferred for embedded targets.
+/// * **Stackful** — the component uses `task.wait` / `task.yield` to
+///   suspend; the host saves and restores the wasm stack across the
+///   yield. One stack per in-flight async call. Natural for Rust /
+///   Go / Java guest async.
+///
+/// Issue #140 / SR-32 declares the stackful host-intrinsic ABI. The
+/// stackful trampoline emitter ships in a follow-up PR within the
+/// v0.8.0 milestone; until then components requiring stackful mode are
+/// detected and rejected with a clear "stackful lifting not yet
+/// emitted" error rather than silently producing a callback trampoline.
+pub mod thread {
+    /// `(start_fn: i32, arg: i32) -> i32` — create a new fiber.
+    ///
+    /// The runtime allocates a fresh stack and registers `start_fn`
+    /// (a core-wasm function index in the fused module) as its entry
+    /// point. `arg` is passed to `start_fn` on first switch-in.
+    ///
+    /// Returns a non-negative thread handle on success, or a negative
+    /// [`AbiError`] code (typically [`AbiError::Oom`]) on failure.
+    pub const NEW: &str = "thread_new";
+    /// `(thread: i32) -> ()` — yield the current fiber and resume the
+    /// fiber identified by `thread`.
+    ///
+    /// The caller's stack is saved by the runtime; the call returns
+    /// only when some other fiber switches back. Switching to a
+    /// non-existent or exited thread traps.
+    pub const SWITCH_TO: &str = "thread_switch_to";
+    /// `() -> ()` — yield the current fiber so the runtime can schedule
+    /// another runnable fiber. Equivalent to `thread_switch_to` to a
+    /// runtime-chosen target; control returns when the scheduler picks
+    /// this fiber again.
+    pub const YIELD: &str = "thread_yield";
+    /// `() -> ()` — exit the current fiber.
+    ///
+    /// Marks the fiber's stack for release and yields permanently.
+    /// Subsequent `thread_switch_to(<this fiber>)` traps. Hosts may
+    /// reclaim the stack synchronously or via a sweep.
+    pub const EXIT: &str = "thread_exit";
+}
+
 /// Names of all future-related host intrinsic imports.
 pub mod future {
     /// `() -> i64` — allocate a new future. Returns packed (write << 32 | read).
@@ -530,6 +578,22 @@ pub enum HostIntrinsic {
     /// value will arrive). Subsequent reads also return
     /// [`AbiError::Closed`].
     FutureDropWritable,
+    /// `(start_fn: i32, arg: i32) -> i32` — create a new fiber with
+    /// entry point `start_fn` (a core-wasm function index in the fused
+    /// module). See [`thread::NEW`].
+    ///
+    /// Part of the **stackful** lifting-mode ABI (SR-32, #140).
+    /// The stackful trampoline emitter that uses this intrinsic ships
+    /// in a follow-up PR; this enum variant is the foundation that
+    /// downstream tooling (kiln runtime) can already implement against.
+    ThreadNew,
+    /// `(thread: i32)` — yield the current fiber and resume `thread`.
+    /// See [`thread::SWITCH_TO`].
+    ThreadSwitchTo,
+    /// `()` — yield to the runtime scheduler. See [`thread::YIELD`].
+    ThreadYield,
+    /// `()` — terminate the current fiber. See [`thread::EXIT`].
+    ThreadExit,
 }
 
 impl HostIntrinsic {
@@ -550,6 +614,10 @@ impl HostIntrinsic {
             Self::FutureCancelWrite => future::CANCEL_WRITE,
             Self::FutureDropReadable => future::DROP_READABLE,
             Self::FutureDropWritable => future::DROP_WRITABLE,
+            Self::ThreadNew => thread::NEW,
+            Self::ThreadSwitchTo => thread::SWITCH_TO,
+            Self::ThreadYield => thread::YIELD,
+            Self::ThreadExit => thread::EXIT,
         }
     }
 
@@ -585,6 +653,12 @@ impl HostIntrinsic {
             | Self::StreamDropWritable
             | Self::FutureDropReadable
             | Self::FutureDropWritable => (vec![I32], vec![]),
+            // thread_new : (start_fn, arg) -> i32
+            Self::ThreadNew => (vec![I32, I32], vec![I32]),
+            // thread_switch_to : (thread) -> ()
+            Self::ThreadSwitchTo => (vec![I32], vec![]),
+            // thread_yield / thread_exit : () -> ()
+            Self::ThreadYield | Self::ThreadExit => (vec![], vec![]),
         }
     }
 
@@ -863,6 +937,20 @@ impl P3AsyncFeatures {
     /// callback) construct.
     pub fn uses_control_plane(&self) -> bool {
         self.uses_async_lift || self.uses_callback_lift || self.uses_async_lower
+    }
+
+    /// `true` if any async lift is **stackful** — i.e. uses `async`
+    /// without a `(callback ...)` option.
+    ///
+    /// Stackful mode requires the trampoline shape declared in [`thread`]
+    /// (`thread_new` / `thread_switch_to` / `thread_yield` / `thread_exit`).
+    /// The emitter for that trampoline ships in a follow-up PR within
+    /// the v0.8.0 milestone (SR-32, #140). Until then, callers SHOULD
+    /// surface a clear "stackful lifting not yet emitted by meld" error
+    /// rather than silently fall through to the callback path, which
+    /// would produce a wrong trampoline.
+    pub fn uses_stackful_lift(&self) -> bool {
+        self.uses_async_lift && !self.uses_callback_lift
     }
 }
 
@@ -1464,8 +1552,86 @@ mod tests {
             HostIntrinsic::FutureCancelWrite,
             HostIntrinsic::FutureDropReadable,
             HostIntrinsic::FutureDropWritable,
+            HostIntrinsic::ThreadNew,
+            HostIntrinsic::ThreadSwitchTo,
+            HostIntrinsic::ThreadYield,
+            HostIntrinsic::ThreadExit,
         ];
         let names: std::collections::HashSet<&'static str> = all.iter().map(|i| i.name()).collect();
         assert_eq!(names.len(), all.len(), "intrinsic names must be unique");
+    }
+
+    /// SR-32 / #140 — stackful lifting ABI shape pin.
+    ///
+    /// Changing the signature or name of any `Thread*` intrinsic is a
+    /// breaking change to the `pulseengine:async` ABI and requires a
+    /// version bump + ADR update.
+    #[test]
+    fn stackful_intrinsic_signatures_pinned() {
+        use wasm_encoder::ValType::I32;
+
+        assert_eq!(HostIntrinsic::ThreadNew.name(), "thread_new");
+        assert_eq!(
+            HostIntrinsic::ThreadNew.signature(),
+            (vec![I32, I32], vec![I32]),
+            "thread_new : (start_fn, arg) -> i32"
+        );
+
+        assert_eq!(HostIntrinsic::ThreadSwitchTo.name(), "thread_switch_to");
+        assert_eq!(
+            HostIntrinsic::ThreadSwitchTo.signature(),
+            (vec![I32], vec![]),
+            "thread_switch_to : (thread) -> ()"
+        );
+
+        assert_eq!(HostIntrinsic::ThreadYield.name(), "thread_yield");
+        assert_eq!(
+            HostIntrinsic::ThreadYield.signature(),
+            (vec![], vec![]),
+            "thread_yield : () -> ()"
+        );
+
+        assert_eq!(HostIntrinsic::ThreadExit.name(), "thread_exit");
+        assert_eq!(
+            HostIntrinsic::ThreadExit.signature(),
+            (vec![], vec![]),
+            "thread_exit : () -> ()"
+        );
+
+        // All four belong to the same import module as the data plane.
+        for v in [
+            HostIntrinsic::ThreadNew,
+            HostIntrinsic::ThreadSwitchTo,
+            HostIntrinsic::ThreadYield,
+            HostIntrinsic::ThreadExit,
+        ] {
+            assert_eq!(v.import().0, HOST_INTRINSIC_MODULE);
+        }
+    }
+
+    /// SR-32 / #140 — `P3AsyncFeatures::uses_stackful_lift()` derived flag.
+    ///
+    /// A component is in **stackful** mode iff it has an async lift
+    /// without a `(callback ...)` option. This pins the contract that
+    /// callers can use to decide whether to invoke the stackful emitter
+    /// (when it ships) or surface a "not yet emitted" error.
+    #[test]
+    fn stackful_lift_is_async_without_callback() {
+        let mut feats = P3AsyncFeatures::default();
+        assert!(!feats.uses_stackful_lift(), "empty: no stackful");
+
+        feats.uses_async_lift = true;
+        feats.uses_callback_lift = false;
+        assert!(feats.uses_stackful_lift(), "async + !callback => stackful");
+
+        feats.uses_callback_lift = true;
+        assert!(
+            !feats.uses_stackful_lift(),
+            "async + callback => callback mode, NOT stackful"
+        );
+
+        feats.uses_async_lift = false;
+        feats.uses_callback_lift = false;
+        assert!(!feats.uses_stackful_lift(), "no async => no stackful");
     }
 }

--- a/safety/adr/ADR-1-p3-async-lowering.md
+++ b/safety/adr/ADR-1-p3-async-lowering.md
@@ -236,3 +236,67 @@ contract** are now pinned, even though the lowering pass that rewrites
   blocking is the runtime's responsibility against `[waitable-set-poll]`
   semantics. If the spec ever splits poll into a distinct host
   intrinsic, the trampoline will need a third arm.
+
+---
+
+## Addendum 2026-05-13 — Two-mode lifting policy (SR-32 / #140)
+
+P3 async exports come in two lifting modes per the Component Model:
+
+| Mode | Component opt-in | Trampoline cost | Use case |
+|---|---|---|---|
+| **Callback** (shipped) | `(canon lift ... async ... (callback $cb))` | One shared stack per component | Embedded / `cFS`-style "one message at a time" guests |
+| **Stackful** (foundation in this PR, emitter follow-up) | `(canon lift ... async ...)` with **no** `(callback ...)` | One stack per in-flight async call | Languages with native async/await (Rust, Go, Java) |
+
+**Detection.** `P3AsyncFeatures::uses_stackful_lift()` returns true iff
+the component has any `(canon lift ... async ...)` *without* a
+`(callback ...)` option. Mutually exclusive with the callback case on
+a per-lift basis; a single component may declare both kinds of lifts,
+in which case meld will emit both trampolines.
+
+**ABI surface.** Four new host-intrinsic imports under the existing
+`pulseengine:async` module:
+
+```wasm
+(import "pulseengine:async" "thread_new"        (func (param i32 i32) (result i32)))
+(import "pulseengine:async" "thread_switch_to"  (func (param i32)))
+(import "pulseengine:async" "thread_yield"      (func))
+(import "pulseengine:async" "thread_exit"       (func))
+```
+
+`thread_new(start_fn, arg) -> i32` returns a non-negative thread handle
+on success or a negative [`AbiError`] (typically [`AbiError::Oom`]) on
+failure. `thread_switch_to` traps if the target thread is exited or
+unknown. `thread_yield` lets the runtime scheduler pick another fiber.
+`thread_exit` permanently releases the current fiber.
+
+These names and signatures are pinned by
+`p3_async::tests::stackful_intrinsic_signatures_pinned`. Changing them
+is a breaking change to `pulseengine:async` and requires a version bump.
+
+**Emission policy.** Until the stackful trampoline emitter ships in a
+follow-up PR within the v0.8.0 milestone, meld surfaces a clear error
+for components that need stackful lifting rather than silently
+generating a callback trampoline (which would corrupt the suspended-
+stack semantics the guest expects).
+
+**Why not unify with `task.wait` / `task.yield` parsing.** Those
+component-model canon builtins are *what the guest emits inside its own
+body* to suspend; they go through the existing `P3BuiltinOp` lowering
+path in `component_wrap.rs`. The new `thread_*` intrinsics are *what
+meld synthesises* around the lifted function so the host can save and
+restore the wasm stack. The two are connected (the stackful trampoline
+turns `task.wait` body invocations into `thread_yield` / waitable
+registration sequences) but live at different abstraction layers.
+
+### What this addendum leaves deferred
+
+* **Stackful trampoline emitter** — separate follow-up PR under v0.8.0
+  / #140. The emitter generates: (a) a host-visible export function
+  that creates a fresh fiber on each async invocation, and (b)
+  in-body rewrites of `task.wait` to `thread_yield` + waitable
+  registration. ABI-level shape pins exist; structural test for the
+  generated trampoline will land with the emitter.
+* **Stackful + callback in the same component.** Permitted by the
+  Component Model. The emitter will produce both trampolines without
+  cross-talk; the test for that case ships with the emitter.

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -684,7 +684,7 @@ artifacts:
       `pulseengine:async::thread_new`, `thread_switch_to`, `thread_yield`,
       `thread_exit` host intrinsics and provides one stack per in-flight
       async call. Documented in ADR-1 addendum.
-    status: planned
+    status: in-progress
     tags: [roadmap, p3-async, v0.8.0]
     links:
       - type: derives-from
@@ -692,11 +692,15 @@ artifacts:
       - type: tracked-by
         target: "#140"
     fields:
-      implementation: meld-core/src/adapter/fact.rs
+      implementation:
+        - meld-core/src/p3_async.rs        # ABI foundation landed
+        - meld-core/src/adapter/fact.rs    # trampoline emitter — follow-up PR
       verification-method: test
       verification-description: >
-        Shape-pin test mirroring async_callback_trampoline_shape_canonical;
-        end-to-end stackful suspend/resume case.
+        Foundation: stackful_intrinsic_signatures_pinned +
+        stackful_lift_is_async_without_callback (this PR). Emitter:
+        shape-pin test mirroring async_callback_trampoline_shape_canonical;
+        end-to-end stackful suspend/resume case (follow-up PR).
       milestone: v0.8.0
 
   - id: SR-33

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -319,11 +319,14 @@ verification-status:
   # planned -> in-progress -> implemented as the milestone proceeds.
 
   SR-32:
-    implementation-files: []
-    tests: []
+    implementation-files:
+      - meld-core/src/p3_async.rs
+    tests:
+      - p3_async::tests::stackful_intrinsic_signatures_pinned
+      - p3_async::tests::stackful_lift_is_async_without_callback
     proofs: []
-    status: planned
-    note: "v0.8.0 — Stackful P3 lifting mode (#140). Implementation lands in adapter/fact.rs."
+    status: in-progress
+    note: "v0.8.0 — Stackful P3 lifting mode (#140). ABI foundation landed (thread_* intrinsics + uses_stackful_lift detector). Trampoline emitter in adapter/fact.rs follow-up PR."
 
   SR-33:
     implementation-files: []


### PR DESCRIPTION
## Summary

First phase of the **two-mode P3 async lifting** work tracked under #94 / #140 / SR-32. Lands the host-intrinsic ABI surface a stackful lift needs; the actual trampoline emitter in \`adapter/fact.rs\` is the follow-up phase. Mirrors the proven #124 → #129 split that landed the data-plane (stream/future) intrinsics.

Closes nothing yet — #140 stays open until the emitter phase lands.

## What lands

- **4 new \`HostIntrinsic\` variants** in \`meld-core/src/p3_async.rs\`:
  - \`ThreadNew(i32, i32) -> i32\`
  - \`ThreadSwitchTo(i32) -> ()\`
  - \`ThreadYield() -> ()\`
  - \`ThreadExit() -> ()\`
  All under the \`pulseengine:async\` import module, names pinned by test.
- **\`thread::*\` name constants module** so the emitter (phase 2) and any future call sites resolve names by symbol, not string literal.
- **\`uses_stackful_lift()\` derived helper** on \`P3AsyncFeatures\` — \`uses_async_lift && !uses_callback_lift\`. Encoding it as a method keeps the two parser booleans as source of truth and prevents a drifting third boolean.
- **Two new tests** (15 total in p3_async now pass):
  - \`stackful_intrinsic_signatures_pinned\` — 4 names + signatures + import module
  - \`stackful_lift_is_async_without_callback\` — 4-case truth table of the derived flag
- **ADR-1 addendum 2026-05-13** — two-mode policy documented side-by-side (callback vs stackful), ABI surface, detection, emission policy.
- **SR-32 flipped \`planned\` → \`in-progress\`** in \`safety/requirements/safety-requirements.yaml\`; \`traceability.yaml\` updated to point at the new code + tests.
- \`CHANGELOG.md\` [Unreleased] entry.

## What does NOT land

- The stackful trampoline emitter in \`adapter/fact.rs\` — phase 2 follow-up (separate PR, same milestone).
- Component-level behavior: a component requesting stackful lift still hits the **existing clear error path**. The intrinsics are wired into the enum but not yet emitted by the adapter.

## Why split

Same reason the data-plane intrinsics split worked (#124 lands enum + signatures, #129 lands emitter): the ABI surface is small, frozen, and audit-relevant; the emitter is large, churnier, and benefits from being reviewed against a stable ABI baseline. Splitting keeps the safety requirement traceable to a small, testable PR.

## Test plan

- [x] \`cargo test -p meld-core --lib p3_async\` — 15 pass (13 prior + 2 new)
- [x] \`cargo build\` — clean
- [x] \`cargo clippy -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] pre-commit hooks — all 7 pass (incl. cargo-test)
- [ ] CI green on smithy runners (or admin-merge per #139 policy if known-infra)

## Refs

- #94 — P3 async umbrella
- #140 — this milestone deliverable (stays open through phase 2)
- SR-32 — stackful lifting safety requirement
- ADR-1 — P3 async lowering, 2026-05-13 addendum
- Precedent: #124 → #129 (data-plane split)
- Milestone: v0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)