### PR TITLE
fix(adapter): pad CABI alignment in async-lift retptr writeback (LS-A-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CABI alignment padding in async-lift retptr writeback** (LS-A-10,
+  UCA-A-13, H-4 / H-4.5). Both `generate_async_callback_adapter` and
+  `generate_async_stackful_adapter` advanced the retptr byte offset by
+  only the flat size of each result global (4 or 8 bytes) and never
+  aligned up to the next field's natural alignment. For any P3 async
+  lift returning an aggregate whose flat lowering mixes 4- and 8-byte
+  values (record `{u32, u64}`, tuple `(s32, s64)`, `result<u64, u32>`,
+  etc.), the i64 / f64 field was stored at the wrong canonical-ABI
+  offset and the caller's canon.lower read stale/zero bytes. Silent
+  data corruption — wasm engines treat `MemArg.align` as a hint and
+  do not trap. Fix extracts the writeback into a shared
+  `emit_globals_to_retptr_cabi` helper that pads via `align_up` before
+  each store. Surfaced by the v0.8.0 pre-release Mythos delta-pass on
+  `adapter/fact.rs`; regression pinned by
+  `cabi_alignment_stackful_retptr_writes_i64_at_offset_8`.
+
 ### Added
 
 - **P3 stackful lifting — ABI foundation** (#140 / SR-32, sub-#94).

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -4239,41 +4239,13 @@ impl FactStyleGenerator {
                     body.instruction(&Instruction::I32Store(mem_arg_4));
                 } else {
                     // Non-pointer results: write globals directly to retptr
-                    let mut offset = 0u32;
-                    for (global_idx, val_ty) in &info.result_globals {
-                        body.instruction(&Instruction::LocalGet(retptr_local));
-                        body.instruction(&Instruction::GlobalGet(*global_idx));
-                        let mem_arg = wasm_encoder::MemArg {
-                            offset: offset as u64,
-                            align: match val_ty {
-                                wasm_encoder::ValType::I64 | wasm_encoder::ValType::F64 => 3,
-                                _ => 2,
-                            },
-                            memory_index: caller_memory,
-                        };
-                        match val_ty {
-                            wasm_encoder::ValType::I32 => {
-                                body.instruction(&Instruction::I32Store(mem_arg));
-                                offset += 4;
-                            }
-                            wasm_encoder::ValType::I64 => {
-                                body.instruction(&Instruction::I64Store(mem_arg));
-                                offset += 8;
-                            }
-                            wasm_encoder::ValType::F32 => {
-                                body.instruction(&Instruction::F32Store(mem_arg));
-                                offset += 4;
-                            }
-                            wasm_encoder::ValType::F64 => {
-                                body.instruction(&Instruction::F64Store(mem_arg));
-                                offset += 8;
-                            }
-                            _ => {
-                                body.instruction(&Instruction::I32Store(mem_arg));
-                                offset += 4;
-                            }
-                        }
-                    }
+                    // with canonical-ABI alignment padding between fields.
+                    self.emit_globals_to_retptr_cabi(
+                        &mut body,
+                        retptr_local,
+                        &info.result_globals,
+                        caller_memory,
+                    );
                 }
             } else {
                 // Push result values onto the stack
@@ -4455,6 +4427,79 @@ impl FactStyleGenerator {
             .exports
             .iter()
             .any(|e| e.kind == wasm_encoder::ExportKind::Func && e.name == callback_export_name)
+    }
+
+    /// Emit the canonical-ABI store sequence that writes each task.return
+    /// result global to the caller's retptr buffer at the spec-required
+    /// offset. Both the callback and stackful async-lift emitters use
+    /// this so the writeback contract has a single source of truth.
+    ///
+    /// Critical invariant — alignment padding between fields:
+    ///
+    /// The canonical ABI aligns every record/tuple field up to its
+    /// natural alignment before placing it. For example, a result whose
+    /// flat lowering contains `[I32, I64]` lays out as i32 at offset 0,
+    /// 4 bytes of padding, i64 at offset 8 (record size 16). A naïve
+    /// "advance offset by flat byte size" loop would write the i64 at
+    /// offset 4 — the caller's canon.lower then reads stale/zero bytes
+    /// at offset 8. Wasm engines treat `MemArg.align` as a hint and do
+    /// not trap on misalignment, so the bug is silent data corruption.
+    ///
+    /// Surfaced by the v0.8.0 pre-release Mythos delta-pass; pinned by
+    /// `cabi_alignment_stackful_retptr_writes_i64_at_offset_8`.
+    fn emit_globals_to_retptr_cabi(
+        &self,
+        body: &mut Function,
+        retptr_local: u32,
+        result_globals: &[(u32, wasm_encoder::ValType)],
+        caller_memory: u32,
+    ) {
+        fn align_up(n: u32, a: u32) -> u32 {
+            (n + a - 1) & !(a - 1)
+        }
+        fn natural(val_ty: &wasm_encoder::ValType) -> (u32, u32) {
+            // (size, alignment) per canonical-ABI flattening; align is
+            // identical to size for primitive numeric types.
+            match val_ty {
+                wasm_encoder::ValType::I64 | wasm_encoder::ValType::F64 => (8, 8),
+                wasm_encoder::ValType::I32 | wasm_encoder::ValType::F32 => (4, 4),
+                _ => (4, 4),
+            }
+        }
+
+        let mut offset = 0u32;
+        for (global_idx, val_ty) in result_globals {
+            let (size, align) = natural(val_ty);
+            offset = align_up(offset, align);
+            body.instruction(&Instruction::LocalGet(retptr_local));
+            body.instruction(&Instruction::GlobalGet(*global_idx));
+            let mem_arg = wasm_encoder::MemArg {
+                offset: offset as u64,
+                align: match val_ty {
+                    wasm_encoder::ValType::I64 | wasm_encoder::ValType::F64 => 3,
+                    _ => 2,
+                },
+                memory_index: caller_memory,
+            };
+            match val_ty {
+                wasm_encoder::ValType::I32 => {
+                    body.instruction(&Instruction::I32Store(mem_arg));
+                }
+                wasm_encoder::ValType::I64 => {
+                    body.instruction(&Instruction::I64Store(mem_arg));
+                }
+                wasm_encoder::ValType::F32 => {
+                    body.instruction(&Instruction::F32Store(mem_arg));
+                }
+                wasm_encoder::ValType::F64 => {
+                    body.instruction(&Instruction::F64Store(mem_arg));
+                }
+                _ => {
+                    body.instruction(&Instruction::I32Store(mem_arg));
+                }
+            }
+            offset += size;
+        }
     }
 
     /// Emit the stackful-mode async-lift trampoline (SR-32, #140).
@@ -4639,43 +4684,16 @@ impl FactStyleGenerator {
                 }
 
                 // Write each result global directly to the caller's
-                // retptr buffer at sequential offsets.
+                // retptr buffer with canonical-ABI alignment padding
+                // between fields (shared helper, see
+                // `emit_globals_to_retptr_cabi`).
                 let retptr_local = callee_param_count as u32;
-                let mut offset = 0u32;
-                for (global_idx, val_ty) in &info.result_globals {
-                    body.instruction(&Instruction::LocalGet(retptr_local));
-                    body.instruction(&Instruction::GlobalGet(*global_idx));
-                    let mem_arg = wasm_encoder::MemArg {
-                        offset: offset as u64,
-                        align: match val_ty {
-                            wasm_encoder::ValType::I64 | wasm_encoder::ValType::F64 => 3,
-                            _ => 2,
-                        },
-                        memory_index: caller_memory,
-                    };
-                    match val_ty {
-                        wasm_encoder::ValType::I32 => {
-                            body.instruction(&Instruction::I32Store(mem_arg));
-                            offset += 4;
-                        }
-                        wasm_encoder::ValType::I64 => {
-                            body.instruction(&Instruction::I64Store(mem_arg));
-                            offset += 8;
-                        }
-                        wasm_encoder::ValType::F32 => {
-                            body.instruction(&Instruction::F32Store(mem_arg));
-                            offset += 4;
-                        }
-                        wasm_encoder::ValType::F64 => {
-                            body.instruction(&Instruction::F64Store(mem_arg));
-                            offset += 8;
-                        }
-                        _ => {
-                            body.instruction(&Instruction::I32Store(mem_arg));
-                            offset += 4;
-                        }
-                    }
-                }
+                self.emit_globals_to_retptr_cabi(
+                    &mut body,
+                    retptr_local,
+                    &info.result_globals,
+                    caller_memory,
+                );
             } else {
                 // Push result values onto the stack for the caller.
                 for (global_idx, _) in &info.result_globals {
@@ -5324,6 +5342,116 @@ mod tests {
             Some(&0x0B),
             "stackful trampoline body must end with `end` (0x0B); \
              body={body:?}",
+        );
+    }
+
+    fn read_uleb(buf: &[u8]) -> (u64, usize) {
+        let mut result: u64 = 0;
+        let mut shift = 0;
+        let mut consumed = 0;
+        for b in buf {
+            consumed += 1;
+            result |= ((b & 0x7f) as u64) << shift;
+            if b & 0x80 == 0 {
+                break;
+            }
+            shift += 7;
+        }
+        (result, consumed)
+    }
+
+    /// Regression test for the alignment-padding bug surfaced by the
+    /// v0.8.0 pre-release Mythos delta-pass on adapter/fact.rs.
+    ///
+    /// The stackful and callback emitters both advance the retptr
+    /// write offset by only the flat size of each result global (4 or
+    /// 8 bytes) without aligning up to the next field's natural
+    /// alignment. For a result whose flat lowering contains
+    /// `[I32, I64]` (record `{u32, u64}`, tuple `(s32, s64)`,
+    /// `result<u64, u32>`, etc.), the canonical-ABI offset of the i64
+    /// is 8 (i32 at 0, 4 bytes padding, i64 at 8 — record size 16).
+    /// The emitter produced 4. Callers reading the retptr per CABI
+    /// see stale/zero bytes for the high-order field.
+    ///
+    /// Hazard: H-4 (canonical ABI lowering mismatch). Maps to UCA-A-13
+    /// generically — the stated context is "variants with i64/f64
+    /// payload" but any aggregate whose flat lowering interleaves
+    /// 4-byte and 8-byte fields realises the same defect.
+    ///
+    /// Engines treat MemArg `align` as a hint, so this is silent data
+    /// corruption with no trap.
+    #[test]
+    fn cabi_alignment_stackful_retptr_writes_i64_at_offset_8() {
+        let gen_ = FactStyleGenerator::new(AdapterConfig::default());
+        let mut merged = empty_merged();
+
+        // Caller type: (retptr: i32) -> ()
+        merged.types.push(crate::merger::MergedFuncType {
+            params: vec![wasm_encoder::ValType::I32],
+            results: vec![],
+        });
+        // Lift type: () -> ()
+        merged.types.push(crate::merger::MergedFuncType {
+            params: vec![],
+            results: vec![],
+        });
+        merged.functions.push(crate::merger::MergedFunction {
+            type_idx: 1,
+            body: wasm_encoder::Function::new([]),
+            origin: (1, 0, 0),
+        });
+        merged.function_index_map.insert((1, 0, 0), 0);
+
+        let lookup_name = "[async-lift]mixed".to_string();
+        let globals = vec![
+            (10u32, wasm_encoder::ValType::I32),
+            (11u32, wasm_encoder::ValType::I64),
+        ];
+        merged
+            .async_result_globals
+            .insert((1, lookup_name.clone()), globals.clone());
+        merged.task_return_shims.insert(
+            0,
+            crate::merger::TaskReturnShimInfo {
+                shim_func: 0,
+                result_globals: globals.clone(),
+                component_idx: 1,
+                import_name: "[task-return]0".into(),
+                original_func_name: lookup_name.clone(),
+                result_type: None,
+            },
+        );
+
+        let mut site = async_lift_site("[async-lift]mixed");
+        site.import_func_type_idx = Some(0);
+        site.crosses_memory = false;
+
+        let adapter = gen_
+            .generate_async_stackful_adapter(&site, &merged)
+            .expect("stackful emitter must succeed");
+
+        let raw = adapter.body.into_raw_body();
+
+        // i64.store opcode is 0x37 followed by LEB align then LEB offset.
+        let mut i = 0;
+        let mut found_offset: Option<u64> = None;
+        while i < raw.len() {
+            if raw[i] == 0x37 {
+                let (_align, n1) = read_uleb(&raw[i + 1..]);
+                let (offset, _n2) = read_uleb(&raw[i + 1 + n1..]);
+                found_offset = Some(offset);
+                break;
+            }
+            i += 1;
+        }
+
+        let offset = found_offset.expect("body must contain i64.store");
+        assert_eq!(
+            offset, 8,
+            "i64 result must store at CABI-aligned offset 8 for record \
+             {{i32, i64}} (i32 at 0, 4 bytes padding, i64 at 8); emitter \
+             produced offset {offset} — callers reading retptr per CABI \
+             would see stale bytes",
         );
     }
 }

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -730,6 +730,50 @@ loss-scenarios:
     status: approved
     priority: high
 
+  - id: LS-A-10
+    title: Async-lift retptr writeback skips CABI alignment padding
+    uca: UCA-A-13
+    hazards: [H-4, H-4.5]
+    type: inadequate-control-algorithm
+    scenario: >
+      Both `FactStyleGenerator::generate_async_callback_adapter` and
+      `FactStyleGenerator::generate_async_stackful_adapter` in
+      meld-core/src/adapter/fact.rs (pre-fix lines ~4240-4277 and
+      ~4686-4723) wrote each task.return shim result global to the
+      caller's retptr buffer by advancing the byte offset by only the
+      flat size of the value (4 bytes for i32/f32, 8 bytes for i64/f64)
+      and never aligning up to the next field's natural alignment. For a
+      P3 async lift whose flat-lowered result globals contain `[I32,
+      I64]` — e.g. a record `{u32, u64}`, tuple `(s32, s64)`, or
+      `result<u64, u32>` — the canonical ABI requires the i64 at offset
+      8 (i32 at 0, 4 bytes padding, i64 at 8, record size 16). The
+      adapter wrote the i64 at offset 4. Wasm engines treat
+      `MemArg.align` as a hint and do not trap on misalignment, so the
+      bug is silent data corruption: the caller's canon.lower reads the
+      retptr per canonical ABI and sees stale/zero bytes at offset 8
+      [H-4, H-4.5]. Affects every downstream runtime consuming a meld-
+      fused module (kiln, wasmtime, browsers) because the misalignment
+      is baked into the emitted wasm. Surfaced by the v0.8.0 pre-release
+      Mythos delta-pass on `adapter/fact.rs`; PoC test
+      `cabi_alignment_stackful_retptr_writes_i64_at_offset_8`
+      reproduces with a concrete `[I32, I64]` result-global pair. Fix:
+      extracted shared helper `emit_globals_to_retptr_cabi` that calls
+      `align_up(offset, natural_align(val_ty))` before each store; both
+      emitters now route through this single CABI-correct writeback.
+    causal-factors:
+      - Offset advanced by flat size, never aligned up to the next
+        field's natural alignment
+      - Both emitters carried the same defect — the recent step 0.5
+        refactor for code reuse did not cover the retptr writeback, so
+        the bug remained duplicated across the two emitters
+      - Pin tests covered opcode shape (call/drop/global.get/end) and
+        the simple push-results-on-stack path, but no test exercised
+        the retptr writeback with mixed-size aggregate results
+      - Wasm `MemArg.align` is a hint; engines do not trap on
+        misalignment, so the bug is invisible at runtime
+    status: approved
+    priority: high
+
   # ==========================================================================
   # Merger scenario (discovered during gap analysis)
   # ==========================================================================


### PR DESCRIPTION
## Summary

Pre-release Mythos delta-pass on \`meld-core/src/adapter/fact.rs\` (the
Tier-5 file changed by v0.8.0) found a real bug. **Release-blocking
for v0.8.0** — this PR fixes it.

## The bug

Both \`generate_async_callback_adapter\` and the new
\`generate_async_stackful_adapter\` wrote each task.return result global
to the caller's retptr buffer with the byte offset advanced by only
the flat size of the value (4 or 8 bytes) — never aligning up to the
next field's natural alignment.

For any P3 async lift returning an aggregate whose flat lowering mixes
4-byte and 8-byte values — record \`{u32, u64}\`, tuple \`(s32, s64)\`,
\`result<u64, u32>\` — the canonical ABI requires the 8-byte field at
offset 8 (with 4 bytes of padding after the 4-byte field). The emitters
wrote it at offset 4.

Wasm engines treat \`MemArg.align\` as a hint and do not trap on
misalignment, so this was **silent data corruption**: the caller's
canon.lower reads the retptr per canonical ABI and sees stale / zero
bytes for the high-order field. Affects every downstream runtime
consuming a meld-fused module (kiln, wasmtime, browsers).

## Why both emitters?

The defect pre-dated #146 / #147. The recent stackful emitter inherited
it via a faithful pattern copy from the callback emitter — exactly the
*shared-pattern bug* category where a refactor for code reuse amplifies
a latent defect because the original code looked correct enough to
copy.

The \`emit_param_copy_step\` refactor in #147 covered step 0.5 but did
not cover the step-3 retptr writeback. This PR closes that gap.

## Fix

New \`emit_globals_to_retptr_cabi\` helper:

\`\`\`rust
let (size, align) = natural(val_ty);
offset = align_up(offset, align);
// emit store at offset
offset += size;
\`\`\`

\`align_up\` is the standard power-of-two bit-twiddle
\`(n + a - 1) & !(a - 1)\`. Both emitters now route through this single
CABI-correct writeback.

## Test

Regression test \`cabi_alignment_stackful_retptr_writes_i64_at_offset_8\`
builds a synthetic component with \`[I32, I64]\` result globals, decodes
the emitted \`i64.store\` offset via ULEB128, and asserts it equals 8.

Before fix: test fails with offset 4 (confirmed).
After fix: test passes; 207/207 lib + 11/11 P3 async integration green.

## Safety case

- New loss scenario **LS-A-10** approved in
  \`safety/stpa/loss-scenarios.yaml\` under UCA-A-13 (H-4 / H-4.5).
- Causal factors documented including the "shared-pattern bug" trap
  and the "wasm align is a hint" silent-corruption multiplier.
- Discovered by the v0.8.0 pre-release Mythos delta-pass per
  \`scripts/mythos/discover.md\`. Oracle pair: Kani harness + PoC test.

## v0.8.0 release gate

Per \`docs/roadmap.md\`: "Releases without a Mythos delta-pass on
changed Tier-5 files are blocked." The pass ran, surfaced LS-A-10,
this PR fixes it and adds the regression. v0.8.0 cut proceeds after
this lands.

## Test plan

- [x] \`cargo test -p meld-core --lib\` — 207 pass
- [x] \`cargo test -p meld-core --test p3_async_lowering\` — 11 pass
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] CI green on smithy runners

## Refs

- LS-A-10 (new, approved this PR)
- UCA-A-13 (existing)
- H-4 / H-4.5
- Mythos finding from v0.8.0 delta-pass on \`adapter/fact.rs\`
- Pre-existing bug; affects merged callback emitter from #128 onward
  and stackful emitter from #147
- Milestone: v0.8.0 (release gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)