### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-14
+
 ### Fixed
 
 - **CABI alignment padding in async-lift retptr writeback** (LS-A-10,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Release **v0.8.0** — P3 stackful lifting trampoline emitter.

| Phase | PR | Status |
|---|---|---|
| ABI foundation | #146 | merged |
| Trampoline emitter | #147 | merged, closed #140 |
| Pre-release Mythos finding fix (LS-A-10) | #148 | merged |
| **Release tag** | **this PR** | — |

## What ships

**P3 stackful lifting (#140, SR-32)** — async-lift exports declared as
\`(canon lift ... async ...)\` without a \`(callback ...)\` option now
flow through a dedicated trampoline. The runtime treats the lift call
as a transparent fiber boundary; the adapter copies params and reads
results without explicit fiber orchestration. The Phase 1
\`thread_new\` / \`thread_switch_to\` / \`thread_yield\` / \`thread_exit\`
host-intrinsic ABI remains valid for component-internal concurrency
but is reserved — the trampoline does not consume it. See ADR-1
addendums 2026-05-13 (a) and (b).

**Pre-release Mythos delta-pass surfaced LS-A-10** — a CABI
alignment-padding bug in the async-lift retptr writeback that
predated this milestone. The defect affected both callback (#128) and
stackful (#147) emitters identically; #148 extracted the writeback
into a shared CABI-correct helper and added the regression test.
Without the Mythos gate this would have shipped invisible.

## Deferred from v0.8.0 (tracked, not blocking)

- Cross-memory \`(ptr, len)\` result returns from stackful mode — the
  emitter errors clearly rather than emit wrong wasm. Follow-up under
  #140 reopen if a real component needs it.
- v0.9.0 begins cross-component stream adapter (#141, SR-33) plus
  optional static validation (#142, SR-34).

## Test plan

- [x] \`cargo test -p meld-core --lib\` — 207 pass
- [x] \`cargo test -p meld-core --test p3_async_lowering\` — 11 pass
- [x] \`cargo build\` — clean at v0.8.0
- [x] Cargo.lock regenerated with new version
- [x] CHANGELOG promoted [Unreleased] → [0.8.0] — 2026-05-14
- [x] Mythos delta-pass on adapter/fact.rs — LS-A-10 found and fixed
      before tag
- [ ] CI green on smithy runners

## Post-merge

1. Tag \`v0.8.0\` on the merge commit, push tag
2. Watch \`release.yml\` workflow build the 4 platform binaries
   (aarch64-darwin, x86_64-darwin, aarch64-linux-gnu, x86_64-linux-gnu)
3. Verify GitHub Release page lists all 4 assets

## Refs

- #94 — P3 async umbrella
- #140 — closed by #147
- #146 / #147 / #148 — the three PRs that produced this tag
- SR-32 — implemented
- LS-A-10 — approved, fixed by #148
- ADR-1 — 2026-05-13 (a) + (b) addendums
- Milestone: v0.8.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)