### PR TITLE
feat(ci): Mythos delta-pass gate on Tier-5 file changes

### DIFF
--- a/.github/workflows/mythos-gate.yml
+++ b/.github/workflows/mythos-gate.yml
@@ -1,0 +1,155 @@
+name: Mythos delta-pass gate
+
+# Blocks merge of PRs that touch Tier-5 source files until a Mythos
+# delta-pass has been recorded on the PR (label `mythos-pass-done`).
+#
+# Why this exists: LS-A-10 (CABI alignment padding in async-lift retptr
+# writeback) was found by the v0.8.0 pre-release Mythos pass on
+# `adapter/fact.rs` — but it had silently lived in the callback emitter
+# since #128 (~6 releases). A PR-time gate would have caught it then
+# instead of at release time.
+#
+# This is a gate, not an automated scan: the actual Mythos pass is run
+# by a human applying scripts/mythos/discover.md against the touched
+# file(s), then attaching the finding (or "no findings") as a PR
+# comment and adding the `mythos-pass-done` label. The gate fails until
+# the label is present.
+#
+# Tier-5 set tracks scripts/mythos/rank.md. Path globs encode the
+# rubric's "5 (fusion correctness)" tier in concrete repo paths. Drift
+# review: if a Tier-5 file is added that isn't listed here, the gate
+# silently lets it through — review the path list whenever rank.md
+# changes.
+
+concurrency:
+  group: mythos-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate:
+    name: Mythos delta-pass gate
+    runs-on: [self-hosted, linux, x64, light]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect Tier-5 file changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Tier-5 path patterns per scripts/mythos/rank.md — concrete
+          # globs that match the current repo layout. Add new patterns
+          # here when rank.md grows.
+          patterns=(
+            "meld-core/src/parser.rs"
+            "meld-core/src/merger.rs"
+            "meld-core/src/resolver.rs"
+            "meld-core/src/rewriter.rs"
+            "meld-core/src/component_wrap.rs"
+            "meld-core/src/p3_async.rs"
+            "meld-core/src/adapter/"
+            "meld-core/src/resource_graph.rs"
+            "meld-core/src/segments.rs"
+          )
+
+          # Diff base...head to find changed files in this PR.
+          changed=$(git diff --name-only "$BASE_SHA"..."$HEAD_SHA")
+
+          touched=()
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            for p in "${patterns[@]}"; do
+              case "$f" in
+                $p*) touched+=("$f"); break;;
+              esac
+            done
+          done <<< "$changed"
+
+          if [ ${#touched[@]} -eq 0 ]; then
+            echo "tier5_touched=false" >> "$GITHUB_OUTPUT"
+            echo "No Tier-5 files touched — gate passes by default."
+            exit 0
+          fi
+
+          echo "tier5_touched=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "files<<MYTHOSEOF"
+            printf '%s\n' "${touched[@]}"
+            echo "MYTHOSEOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Tier-5 files touched:"
+          printf '  - %s\n' "${touched[@]}"
+
+      - name: Check for mythos-pass-done label
+        id: label-check
+        if: steps.detect.outputs.tier5_touched == 'true'
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+        run: |
+          set -euo pipefail
+          if printf '%s' "$LABELS" | grep -q '"mythos-pass-done"'; then
+            echo "has_label=true" >> "$GITHUB_OUTPUT"
+            echo "Label mythos-pass-done present — gate passes."
+          else
+            echo "has_label=false" >> "$GITHUB_OUTPUT"
+            echo "Label mythos-pass-done missing — gate will fail."
+          fi
+
+      - name: Post / refresh sticky comment
+        if: steps.detect.outputs.tier5_touched == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: mythos-gate
+          message: |
+            ## Mythos delta-pass required
+
+            This PR modifies one or more Tier-5 source files (per
+            [`scripts/mythos/rank.md`](../blob/main/scripts/mythos/rank.md)):
+
+            ```
+            ${{ steps.detect.outputs.files }}
+            ```
+
+            **Before merge**, run the Mythos discover protocol on the
+            modified Tier-5 files:
+
+            1. Follow [`scripts/mythos/discover.md`](../blob/main/scripts/mythos/discover.md)
+               — one fresh agent session per touched Tier-5 file.
+            2. For each finding, the agent must produce **both** a Kani
+               harness and a failing PoC test (per the protocol's
+               "if you cannot produce both, do not report" rule).
+            3. Attach a comment on this PR with either the findings
+               (formatted per `discover.md`'s output schema) or
+               **NO FINDINGS**.
+            4. Add the `mythos-pass-done` label to this PR.
+
+            **Why this gate exists:** [LS-A-10](../blob/main/safety/stpa/loss-scenarios.yaml)
+            (CABI alignment padding in async-lift retptr writeback) was
+            found by the v0.8.0 pre-release Mythos pass — but it had
+            lived in the callback emitter since #128, across six
+            releases. A PR-time gate would have caught it at review
+            time instead of at the release boundary.
+
+            The gate check on this PR will pass once the label is
+            applied.
+
+      - name: Fail if label missing
+        if: >-
+          steps.detect.outputs.tier5_touched == 'true' &&
+          steps.label-check.outputs.has_label != 'true'
+        run: |
+          echo "::error::Mythos delta-pass gate: Tier-5 files modified but mythos-pass-done label is not applied. Run discover.md and attach findings, then add the label."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Mythos delta-pass CI gate** (`.github/workflows/mythos-gate.yml`,
+  `scripts/mythos/HOWTO-gate.md`). Blocks merge of PRs that modify
+  Tier-5 source files (parser, merger, resolver, rewriter,
+  component_wrap, p3_async, adapter/, resource_graph, segments) until
+  the author records a Mythos delta-pass on the touched files —
+  evidence as a PR comment plus the `mythos-pass-done` label.
+  Motivated by LS-A-10 (CABI alignment padding in async-lift retptr
+  writeback), which the v0.8.0 pre-release pass found but which had
+  silently lived in the callback emitter since #128. A PR-time gate
+  would have caught it at review time rather than at the release
+  boundary. The gate does not automate the LLM-driven pass itself;
+  that's tracked separately and requires API-key / cost design.
+
 - **Stackful async-lift cross-memory `(ptr, len)` return** (SR-32 follow-up,
   sub-#94). The stackful trampoline emitter now handles the case where a
   stackful async lift returns a `string` or `list<T>` and the caller and

--- a/scripts/mythos/HOWTO-gate.md
+++ b/scripts/mythos/HOWTO-gate.md
@@ -1,0 +1,85 @@
+# Mythos delta-pass gate — reviewer / author guide
+
+This document is what to do when the `mythos-gate` CI check fails on
+your PR. The gate is defined in `.github/workflows/mythos-gate.yml`.
+
+## When the gate fires
+
+A PR modifies one or more **Tier-5** source files per the rubric in
+[`scripts/mythos/rank.md`](rank.md). The current Tier-5 path list lives
+in `mythos-gate.yml`; it tracks the rubric but is concrete repo paths,
+not glob patterns.
+
+When the gate fires, the PR gets a sticky comment from `mythos-gate`
+listing the touched files, and the check fails until the
+`mythos-pass-done` label is applied.
+
+## What to do
+
+For each Tier-5 file touched by this PR:
+
+1. **Spawn a fresh agent session** (Claude Code, claude.ai, or
+   equivalent) pointed at the repo.
+2. **Hand it [`scripts/mythos/discover.md`](discover.md)** with the
+   target file substituted. One file per agent session — don't ask a
+   single agent to scan multiple files.
+3. **Wait for the structured report.** The agent must produce, for any
+   reported finding:
+   - A `#[kani::proof]` harness that fails today and passes after fix.
+   - A failing `#[test]` (or `proptest!`) reproducing the bug with
+     concrete inputs.
+
+   "If you cannot produce both, do not report" is load-bearing in the
+   protocol — the agent should return **NO FINDINGS** rather than
+   speculate.
+
+4. **Validate any findings** by spawning a *second* fresh agent
+   session and handing it [`validate.md`](validate.md). The validator
+   must independently re-run the oracle pair against the current code
+   and confirm both halves fail. Hypotheses that don't survive the
+   fresh-validator round are discarded.
+
+5. **Attach the result to the PR** as a comment:
+   - For each touched Tier-5 file: a section with either the validated
+     findings (per `discover.md`'s output schema) or **NO FINDINGS**.
+   - Multiple files → multiple sections in one comment.
+
+6. **Add the `mythos-pass-done` label** to the PR. The gate check
+   re-runs on label change and passes.
+
+## What to do with a confirmed finding
+
+- File the finding as a draft loss-scenario entry in
+  [`safety/stpa/loss-scenarios.yaml`](../../safety/stpa/loss-scenarios.yaml)
+  via [`emit.md`](emit.md). Promote to `approved` status once the fix
+  PR is ready.
+- The fix may land in the same PR (if scope-aligned) or in a separate
+  PR that blocks merge of this one.
+
+## Why this gate exists
+
+LS-A-10 (CABI alignment padding in async-lift retptr writeback) was
+found by the v0.8.0 pre-release Mythos pass on `adapter/fact.rs`. It
+had silently lived in the callback emitter since #128, affecting six
+releases. A PR-time gate catches LS-A-10-class defects at review time
+instead of release time.
+
+The gate does **not** automate the LLM invocation — it gates on a
+human-verified label. Automating the discover/validate pipeline in CI
+requires API keys, cost budgeting, and a way to surface findings as
+checks; that's tracked separately. The gate ships the value of the
+process (no Tier-5 PR merges without a recorded pass) without the
+infra cost of the LLM-in-CI step.
+
+## Adjusting the Tier-5 path list
+
+If you add a file that the Tier-5 rubric in `rank.md` would classify as
+fusion-critical (parser, fuser, type-checker, writer, canonical-ABI
+emitter), add its path to the `patterns` array in
+`.github/workflows/mythos-gate.yml`. The workflow's audit comment in
+that file documents this requirement.
+
+If you intentionally bypass the gate for a Tier-5 file change (e.g.,
+pure rename, comment-only edit, whitespace cleanup with no semantic
+change), record the bypass reason in the PR description before
+applying the label.


### PR DESCRIPTION
## Summary

Adds a PR-time gate that fails when a PR modifies a Tier-5 source file
(per [\`scripts/mythos/rank.md\`](../blob/main/scripts/mythos/rank.md))
and the \`mythos-pass-done\` label is not applied. Posts a sticky
comment on first touch explaining what the author / reviewer must do.

## Motivation — LS-A-10

The v0.8.0 pre-release Mythos pass on \`adapter/fact.rs\` found
[LS-A-10](../blob/main/safety/stpa/loss-scenarios.yaml) (CABI alignment
padding in async-lift retptr writeback). The defect had **silently
lived in the callback emitter since #128**, across six releases —
v0.4, v0.5, v0.6, v0.7, plus the data-plane intrinsics PRs. A PR-time
gate would have caught it at review time, not the release boundary.

## What this gate does

| Condition | Result |
|---|---|
| PR touches no Tier-5 file | passes immediately |
| PR touches Tier-5 file, no label | fails + sticky comment posted |
| PR touches Tier-5 file, \`mythos-pass-done\` label applied | passes |

The label is applied by humans after running the pass per
\`scripts/mythos/HOWTO-gate.md\` (also added in this PR).

## What this gate does NOT do

- **Does not invoke an LLM in CI.** Automating the discover/validate
  pipeline requires API keys, cost budget, headless-claude tooling, and
  a way to surface findings as checks. That's a separate design pass.
  The gate ships the process value (no Tier-5 merge without a recorded
  pass) without the LLM-in-CI infra cost.
- **Does not auto-update the Tier-5 path list.** Currently hardcoded
  in the workflow with a drift note pointing at \`rank.md\`. If you add
  a new Tier-5 file, update the workflow's \`patterns\` array.

## Self-applying

This PR does not touch Tier-5 files (only \`.github/workflows/\`,
\`scripts/mythos/\`, \`CHANGELOG.md\`), so the gate would pass on this PR
when applied.

## Test plan

- [x] YAML lints (\`python3 -c 'import yaml; yaml.safe_load(...)'\`)
- [x] \`mythos-pass-done\` label created on repo (green, \`#0E8A16\`)
- [ ] CI green on smithy runners
- [ ] Manual verification: next PR that touches \`meld-core/src/\`
      will trigger the gate; gate should comment + fail until label
      applied. (This is best verified by the *next* PR after this one
      merges, not by this PR itself.)

## Refs

- LS-A-10 (the inciting incident)
- \`scripts/mythos/rank.md\` (Tier-5 rubric)
- \`scripts/mythos/discover.md\` (the protocol the gate enforces)
- \`scripts/mythos/HOWTO-gate.md\` (added here — what to do when the gate fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)