### PR TITLE
fix(parser): fold extended-const init/offset expressions (LS-A-11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Extended-const initializer / offset truncation** (LS-A-11, UCA-M-6,
+  H-1 / H-2 / H-3.3). Two const-expression parsers in meld-core read
+  only the first operator and discarded the rest, silently truncating
+  any wasm 2.0 `extended-const` expression. A data / element segment
+  with offset `(i32.const 5)(i32.const 10) i32.add` landed at offset 5
+  instead of 15; a global initialized to `(i32.const 100)(i32.const 23)
+  i32.add` (intended 123) was emitted as 100. Affected
+  `segments.rs::parse_const_expr_with_value` (data + element offsets)
+  and `merger.rs::convert_init_expr` (global initializers). Fix
+  introduces shared `fold_extended_const_i32` /
+  `fold_extended_const_i64` helpers that walk all operators with a
+  small stack-machine interpreter (i32/i64 add/sub/mul with wrapping
+  semantics) and return the folded scalar. Regression pinned by 6
+  tests covering all three arithmetic ops and the single-const
+  passthrough. Surfaced by the post-v0.8.0 Mythos delta-pass sweep on
+  the remaining 8 Tier-5 files (the protocol introduced in #151).
+
 ### Added
 
 - **Mythos delta-pass CI gate** (`.github/workflows/mythos-gate.yml`,

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -2793,8 +2793,25 @@ fn convert_init_expr(
     };
 
     match op {
-        wasmparser::Operator::I32Const { value } => ConstExpr::i32_const(value),
-        wasmparser::Operator::I64Const { value } => ConstExpr::i64_const(value),
+        // For an i32 / i64 const, the wasm 2.0 extended-const proposal
+        // permits further `i32.add` / `i32.sub` / `i32.mul` (and i64
+        // counterparts) before `end`. Fold them into a single value via
+        // the shared helper so the merged global preserves the source's
+        // semantic initializer. Prior versions of this function read
+        // only the first op and silently dropped the rest, producing a
+        // wrong-valued global (LS-A-11).
+        wasmparser::Operator::I32Const { value } => {
+            match crate::segments::fold_extended_const_i32(&mut ops, value) {
+                Ok(folded) => ConstExpr::i32_const(folded),
+                Err(_) => ConstExpr::raw(bytes.iter().copied()),
+            }
+        }
+        wasmparser::Operator::I64Const { value } => {
+            match crate::segments::fold_extended_const_i64(&mut ops, value) {
+                Ok(folded) => ConstExpr::i64_const(folded),
+                Err(_) => ConstExpr::raw(bytes.iter().copied()),
+            }
+        }
         wasmparser::Operator::F32Const { value } => {
             ConstExpr::f32_const(f32::from_bits(value.bits()).into())
         }
@@ -4620,6 +4637,83 @@ mod tests {
         let comp = make_component_with_instances(vec![]);
         let result = Merger::check_no_duplicate_instantiations(&[comp]);
         assert!(result.is_ok());
+    }
+
+    // ---------------------------------------------------------------
+    // LS-A-11 — extended-const truncation in global initializers
+    //
+    // Prior to the fix, `convert_init_expr` read only the first
+    // operator of a global's init expression and emitted just that
+    // single const, silently dropping any subsequent extended-const
+    // ops. A global initialized with `(i32.const 100)(i32.const 23)
+    // i32.add` (intended value 123) was emitted as `(i32.const 100)`.
+    // ---------------------------------------------------------------
+
+    fn empty_merged_for_init_expr() -> MergedModule {
+        MergedModule {
+            types: Vec::new(),
+            imports: Vec::new(),
+            functions: Vec::new(),
+            tables: Vec::new(),
+            memories: Vec::new(),
+            globals: Vec::new(),
+            exports: Vec::new(),
+            start_function: None,
+            elements: Vec::new(),
+            data_segments: Vec::new(),
+            custom_sections: Vec::new(),
+            function_index_map: std::collections::HashMap::new(),
+            memory_index_map: std::collections::HashMap::new(),
+            table_index_map: std::collections::HashMap::new(),
+            global_index_map: std::collections::HashMap::new(),
+            type_index_map: std::collections::HashMap::new(),
+            realloc_map: std::collections::HashMap::new(),
+            import_counts: Default::default(),
+            import_memory_indices: Vec::new(),
+            import_realloc_indices: Vec::new(),
+            resource_rep_by_component: std::collections::HashMap::new(),
+            resource_new_by_component: std::collections::HashMap::new(),
+            handle_tables: std::collections::HashMap::new(),
+            task_return_shims: std::collections::HashMap::new(),
+            async_result_globals: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn ls_a_11_convert_init_expr_folds_extended_const_i32_add() {
+        // Init expr bytes WITHOUT trailing `end` (the function appends
+        // it). Use small operands that fit in single-byte sleb (no sign
+        // bit at position 6): i32.const 5, i32.const 10, i32.add → 15.
+        let bytes: Vec<u8> = vec![0x41, 5, 0x41, 10, 0x6A];
+        let merged = empty_merged_for_init_expr();
+
+        let expr = convert_init_expr(&bytes, 0, 0, &merged, &ValType::I32);
+
+        let mut encoded = Vec::new();
+        wasm_encoder::Encode::encode(&expr, &mut encoded);
+        let mut expected = Vec::new();
+        wasm_encoder::Encode::encode(&ConstExpr::i32_const(15), &mut expected);
+
+        assert_eq!(
+            encoded, expected,
+            "convert_init_expr must fold (i32.const 5)(i32.const 10) i32.add \
+             to i32.const 15; got bytes {encoded:?}",
+        );
+    }
+
+    #[test]
+    fn ls_a_11_convert_init_expr_preserves_single_const() {
+        // Regression: the fold path must not change behavior for a
+        // simple single-const initializer.
+        let bytes: Vec<u8> = vec![0x41, 5];
+        let merged = empty_merged_for_init_expr();
+
+        let expr = convert_init_expr(&bytes, 0, 0, &merged, &ValType::I32);
+        let mut encoded = Vec::new();
+        wasm_encoder::Encode::encode(&expr, &mut encoded);
+        let mut expected = Vec::new();
+        wasm_encoder::Encode::encode(&ConstExpr::i32_const(5), &mut expected);
+        assert_eq!(encoded, expected);
     }
 }
 

--- a/meld-core/src/segments.rs
+++ b/meld-core/src/segments.rs
@@ -366,23 +366,130 @@ fn parse_const_expr(expr: &wasmparser::ConstExpr<'_>) -> Result<ParsedConstExpr>
     parse_const_expr_with_value(expr).map(|(expr, _)| expr)
 }
 
+/// Fold a wasm 2.0 extended-const i32 expression that has already had its
+/// first `i32.const <initial>` consumed by the caller. Continues reading
+/// operators from `ops` until `End`, applying `i32.add` / `i32.sub` /
+/// `i32.mul` / further `i32.const` to a small evaluation stack with
+/// wrapping semantics per the wasm execution model.
+///
+/// Returns the final stack value if exactly one value remains at `End`.
+/// Rejects unsupported operators (any non-extended-const op) with a
+/// clear error so audit and CI surface the path instead of silently
+/// dropping operators (LS-A-11).
+pub(crate) fn fold_extended_const_i32(
+    ops: &mut wasmparser::OperatorsReader<'_>,
+    initial: i32,
+) -> Result<i32> {
+    let mut stack: Vec<i32> = vec![initial];
+    loop {
+        let op = ops.read()?;
+        match op {
+            Operator::End => break,
+            Operator::I32Const { value } => stack.push(value),
+            Operator::I32Add => fold_i32_binop(&mut stack, i32::wrapping_add)?,
+            Operator::I32Sub => fold_i32_binop(&mut stack, i32::wrapping_sub)?,
+            Operator::I32Mul => fold_i32_binop(&mut stack, i32::wrapping_mul)?,
+            other => {
+                return Err(Error::UnsupportedFeature(format!(
+                    "unsupported i32 extended-const operator: {other:?}"
+                )));
+            }
+        }
+    }
+    if stack.len() != 1 {
+        return Err(Error::UnsupportedFeature(format!(
+            "extended-const i32 expression left {} values on the stack \
+             (expected 1)",
+            stack.len()
+        )));
+    }
+    Ok(stack[0])
+}
+
+fn fold_i32_binop(stack: &mut Vec<i32>, op: fn(i32, i32) -> i32) -> Result<()> {
+    let b = stack.pop().ok_or_else(|| {
+        Error::UnsupportedFeature("i32 extended-const binop with empty stack".to_string())
+    })?;
+    let a = stack.pop().ok_or_else(|| {
+        Error::UnsupportedFeature("i32 extended-const binop with single operand".to_string())
+    })?;
+    stack.push(op(a, b));
+    Ok(())
+}
+
+/// i64 counterpart to `fold_extended_const_i32`.
+pub(crate) fn fold_extended_const_i64(
+    ops: &mut wasmparser::OperatorsReader<'_>,
+    initial: i64,
+) -> Result<i64> {
+    let mut stack: Vec<i64> = vec![initial];
+    loop {
+        let op = ops.read()?;
+        match op {
+            Operator::End => break,
+            Operator::I64Const { value } => stack.push(value),
+            Operator::I64Add => fold_i64_binop(&mut stack, i64::wrapping_add)?,
+            Operator::I64Sub => fold_i64_binop(&mut stack, i64::wrapping_sub)?,
+            Operator::I64Mul => fold_i64_binop(&mut stack, i64::wrapping_mul)?,
+            other => {
+                return Err(Error::UnsupportedFeature(format!(
+                    "unsupported i64 extended-const operator: {other:?}"
+                )));
+            }
+        }
+    }
+    if stack.len() != 1 {
+        return Err(Error::UnsupportedFeature(format!(
+            "extended-const i64 expression left {} values on the stack \
+             (expected 1)",
+            stack.len()
+        )));
+    }
+    Ok(stack[0])
+}
+
+fn fold_i64_binop(stack: &mut Vec<i64>, op: fn(i64, i64) -> i64) -> Result<()> {
+    let b = stack.pop().ok_or_else(|| {
+        Error::UnsupportedFeature("i64 extended-const binop with empty stack".to_string())
+    })?;
+    let a = stack.pop().ok_or_else(|| {
+        Error::UnsupportedFeature("i64 extended-const binop with single operand".to_string())
+    })?;
+    stack.push(op(a, b));
+    Ok(())
+}
+
 fn parse_const_expr_with_value(
     expr: &wasmparser::ConstExpr<'_>,
 ) -> Result<(ParsedConstExpr, Option<ConstExprValue>)> {
     let mut ops = expr.get_operators_reader();
 
-    // Read the first (and usually only) operator
+    // Read the first operator. For an i32 / i64 const, the expression may
+    // continue with extended-const ops (i32.add / i32.sub / i32.mul and
+    // their i64 counterparts) per the WebAssembly 2.0 extended-const
+    // proposal. Fold those into a single value via `fold_extended_const_*`
+    // so downstream consumers see the semantically correct initializer.
+    //
+    // LS-A-11 — silent extended-const truncation: prior versions returned
+    // only the first const and dropped the remaining operators, producing
+    // a global / data / element offset that differed from the source.
     let op = ops.read()?;
 
     let (const_expr, value) = match op {
-        Operator::I32Const { value } => (
-            ParsedConstExpr::I32Const(value),
-            Some(ConstExprValue::I32(value)),
-        ),
-        Operator::I64Const { value } => (
-            ParsedConstExpr::I64Const(value),
-            Some(ConstExprValue::I64(value)),
-        ),
+        Operator::I32Const { value } => {
+            let folded = fold_extended_const_i32(&mut ops, value)?;
+            (
+                ParsedConstExpr::I32Const(folded),
+                Some(ConstExprValue::I32(folded)),
+            )
+        }
+        Operator::I64Const { value } => {
+            let folded = fold_extended_const_i64(&mut ops, value)?;
+            (
+                ParsedConstExpr::I64Const(folded),
+                Some(ConstExprValue::I64(folded)),
+            )
+        }
         Operator::F32Const { value } => (
             ParsedConstExpr::F32Const(f32::from_bits(value.bits())),
             None,
@@ -767,5 +874,89 @@ mod tests {
             actual, expected,
             "concrete type index should be remapped from 0 to 4"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // LS-A-11 — extended-const truncation
+    //
+    // Prior to this fix, `parse_const_expr_with_value` read only the
+    // first operator and silently dropped the rest. Any wasm 2.0
+    // extended-const expression — e.g. `(i32.const 5)(i32.const 10)
+    // i32.add` — parsed as `i32.const 5` (value 5), producing data /
+    // element segment offsets at the wrong addresses.
+    // ---------------------------------------------------------------
+
+    /// Build a minimal active-data section with one segment whose offset
+    /// is an extended-const expression `(i32.const a)(i32.const b)(op)`,
+    /// then run parse_const_expr_with_value on it and return the
+    /// computed offset value.
+    fn parse_i32_extended_offset(a: i32, b: i32, opcode: u8) -> i32 {
+        let body: Vec<u8> = vec![
+            0x01, // segment count = 1
+            0x00, // flags = active mem 0
+            0x41, a as u8, // i32.const a
+            0x41, b as u8, // i32.const b
+            opcode,  // i32.add / sub / mul
+            0x0B,    // end
+            0x00,    // data count = 0
+        ];
+
+        let br = wasmparser::BinaryReader::new(&body, 0);
+        let reader = wasmparser::DataSectionReader::new(br).unwrap();
+        let mut value: Option<i32> = None;
+        for d in reader {
+            let d = d.unwrap();
+            if let wasmparser::DataKind::Active { offset_expr, .. } = d.kind {
+                let (_pce, v) = parse_const_expr_with_value(&offset_expr).unwrap();
+                if let Some(ConstExprValue::I32(n)) = v {
+                    value = Some(n);
+                }
+            }
+        }
+        value.expect("offset value present")
+    }
+
+    #[test]
+    fn ls_a_11_extended_const_i32_add_is_folded() {
+        // (i32.const 5)(i32.const 10) i32.add  →  15
+        assert_eq!(parse_i32_extended_offset(5, 10, 0x6A), 15);
+    }
+
+    #[test]
+    fn ls_a_11_extended_const_i32_sub_is_folded() {
+        // (i32.const 20)(i32.const 7) i32.sub  →  13
+        assert_eq!(parse_i32_extended_offset(20, 7, 0x6B), 13);
+    }
+
+    #[test]
+    fn ls_a_11_extended_const_i32_mul_is_folded() {
+        // (i32.const 6)(i32.const 7) i32.mul  →  42
+        assert_eq!(parse_i32_extended_offset(6, 7, 0x6C), 42);
+    }
+
+    #[test]
+    fn ls_a_11_single_const_still_works() {
+        // Plain `(i32.const 42) end` — no extended-const ops, must still
+        // round-trip as before. (42 fits in single-byte sleb128; 99 would
+        // need a 2-byte encoding due to sign-bit at position 6.)
+        let body: Vec<u8> = vec![
+            0x01, // segment count = 1
+            0x00, // flags = active mem 0
+            0x41, 42,   // i32.const 42
+            0x0B, // end
+            0x00, // data count = 0
+        ];
+        let br = wasmparser::BinaryReader::new(&body, 0);
+        let reader = wasmparser::DataSectionReader::new(br).unwrap();
+        for d in reader {
+            let d = d.unwrap();
+            if let wasmparser::DataKind::Active { offset_expr, .. } = d.kind {
+                let (_pce, v) = parse_const_expr_with_value(&offset_expr).unwrap();
+                assert!(
+                    matches!(v, Some(ConstExprValue::I32(42))),
+                    "expected Some(I32(42)), got {v:?}",
+                );
+            }
+        }
     }
 }

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -774,6 +774,54 @@ loss-scenarios:
     status: approved
     priority: high
 
+  - id: LS-A-11
+    title: Extended-const initializer / offset expression silently truncated
+    uca: UCA-M-6
+    hazards: [H-1, H-2, H-3.3]
+    type: inadequate-control-algorithm
+    scenario: >
+      Two const-expression parsers in meld-core read only the first
+      operator of an init expression and discarded the rest. Affected
+      sites: `meld-core/src/segments.rs::parse_const_expr_with_value`
+      (parses data / element segment offset expressions; pre-fix at
+      lines 369-425) and `meld-core/src/merger.rs::convert_init_expr`
+      (parses global initializer expressions; pre-fix at lines
+      2771-2844). Any input whose const expression uses the WebAssembly
+      2.0 `extended-const` proposal — `(i32.const A)(i32.const B)
+      i32.add` and friends — was silently truncated to its first
+      constant. Concrete impact: a data segment `(data (offset
+      (i32.const 5)(i32.const 10) i32.add) "...")` landed at offset 5
+      instead of 15; a global `(global i32 (i32.const 100)(i32.const 23)
+      i32.add)` was emitted with init value 100 instead of 123;
+      element-segment offsets and table fills land at wrong slots. Wasm
+      validator accepts both inputs because the truncated form is still
+      a well-typed single const. Affects every downstream runtime;
+      silent data corruption with no trap [H-1 semantic divergence,
+      H-2 wrong memory address, H-3.3 index/init-expr stopped too
+      soon]. Wasmparser 0.246 (meld's bundled version) enables
+      `WasmFeatures::extended_const` by default, so any input authored
+      after wit-bindgen / clang-wasi grew extended-const support can
+      trigger this. Surfaced by the v0.8.0 Mythos delta-pass on
+      segments.rs and merger.rs (#151 gate). Fix: shared helpers
+      `fold_extended_const_i32` / `fold_extended_const_i64` in
+      `segments.rs` walk all operators with a small stack-machine
+      interpreter, applying `i32.add` / `i32.sub` / `i32.mul` (and i64
+      counterparts) with wrapping semantics, and return the folded
+      scalar value. Both emitters route through these helpers. Regression
+      pinned by 6 tests (4 in segments, 2 in merger) including all three
+      arithmetic ops and the single-const passthrough case.
+    causal-factors:
+      - "`OperatorsReader::read` was called exactly once; subsequent operators were silently discarded"
+      - Extended-const proposal was enabled in wasmparser via default
+        features but no upstream test in meld exercised it
+      - Both parsers (segments.rs and merger.rs) had the same bug,
+        independently — a refactor would have surfaced it earlier
+      - No "shape" test pinned the full operator sequence — existing
+        tests checked the round-tripped value for single-const inputs
+        only
+    status: approved
+    priority: high
+
   # ==========================================================================
   # Merger scenario (discovered during gap analysis)
   # ==========================================================================


### PR DESCRIPTION
## Summary

First fix from the post-v0.8.0 Mythos delta-pass sweep on the 8 Tier-5
files unscanned at v0.8.0 cut time. Two const-expression parsers in
meld-core read only the first operator and silently dropped the rest,
silently truncating any wasm 2.0 \`extended-const\` expression.

## The bug

| Site | Effect |
|---|---|
| \`segments.rs::parse_const_expr_with_value\` | Data / element segment offsets with extended-const land at wrong addresses |
| \`merger.rs::convert_init_expr\` | Global initializers compute the wrong value |

Concrete example: a global initialized to \`(i32.const 100)(i32.const 23) i32.add\` (intended value 123) was emitted as \`(i32.const 100)\`. A data segment with offset \`(i32.const 5)(i32.const 10) i32.add\` landed at offset 5 instead of 15.

wasmparser 0.246 enables \`WasmFeatures::extended_const\` by default, so any input authored after wit-bindgen / clang-wasi grew extended-const support can trigger this. The wasm validator accepts the truncated form because a single well-typed const is still valid; the bug is silent data corruption with no trap, affecting every downstream runtime.

## Fix

New shared helpers \`fold_extended_const_i32\` / \`fold_extended_const_i64\`
in \`segments.rs\` walk all operators with a small stack-machine
interpreter:

\`\`\`rust
loop {
    let op = ops.read()?;
    match op {
        Operator::End => break,
        Operator::I32Const { value } => stack.push(value),
        Operator::I32Add => fold_i32_binop(&mut stack, i32::wrapping_add)?,
        Operator::I32Sub => fold_i32_binop(&mut stack, i32::wrapping_sub)?,
        Operator::I32Mul => fold_i32_binop(&mut stack, i32::wrapping_mul)?,
        other => return Err(UnsupportedFeature(...)),
    }
}
\`\`\`

Both \`parse_const_expr_with_value\` and \`convert_init_expr\` route
their \`I32Const\` / \`I64Const\` arms through these helpers. Unsupported
operators (e.g., \`global.get\` mixed with arithmetic) error out
explicitly rather than silently truncating.

## Tests (6 new)

- \`segments::ls_a_11_extended_const_i32_{add,sub,mul}_is_folded\` — all three arithmetic ops
- \`segments::ls_a_11_single_const_still_works\` — regression for simple single-const
- \`merger::ls_a_11_convert_init_expr_folds_extended_const_i32_add\`
- \`merger::ls_a_11_convert_init_expr_preserves_single_const\` — regression

## Safety case

**LS-A-11** added to \`safety/stpa/loss-scenarios.yaml\` under UCA-M-6 with approved status. Hazards: H-1 (semantic divergence), H-2 (wrong memory address), H-3.3 (init-expr stopped too soon).

## Tier-5 gate

This PR touches \`segments.rs\` and \`merger.rs\`, both Tier-5. The new \`mythos-gate\` workflow will fire and request the \`mythos-pass-done\` label. The pass IS the work in this PR (Mythos discovery → validation via concrete PoC failure → fix → regression test).

## Test plan

- [x] \`cargo test -p meld-core --lib\` — 214 pass (208 prior + 6 new)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] YAML lint on safety/stpa/loss-scenarios.yaml
- [ ] CI green on smithy runners
- [ ] mythos-pass-done label applied

## Refs

- LS-A-11 (new, approved this PR)
- UCA-M-6
- H-1, H-2, H-3.3
- Discovered by Mythos delta-pass on segments.rs and merger.rs
- Part of post-v0.8.0 Tier-5 sweep (6 more cluster fixes pending across follow-up PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)