### PR TITLE
fix(determinism): replace HashMap.iter().find with sorted-key iteration (LS-A-15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,26 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- **Extended-const initializer / offset truncation** (LS-A-11, UCA-M-6,
-  H-1 / H-2 / H-3.3). Two const-expression parsers in meld-core read
-  only the first operator and discarded the rest, silently truncating
-  any wasm 2.0 `extended-const` expression. A data / element segment
-  with offset `(i32.const 5)(i32.const 10) i32.add` landed at offset 5
-  instead of 15; a global initialized to `(i32.const 100)(i32.const 23)
-  i32.add` (intended 123) was emitted as 100. Affected
-  `segments.rs::parse_const_expr_with_value` (data + element offsets)
-  and `merger.rs::convert_init_expr` (global initializers). Fix
-  introduces shared `fold_extended_const_i32` /
-  `fold_extended_const_i64` helpers that walk all operators with a
-  small stack-machine interpreter (i32/i64 add/sub/mul with wrapping
-  semantics) and return the folded scalar. Regression pinned by 6
-  tests covering all three arithmetic ops and the single-const
-  passthrough. Surfaced by the post-v0.8.0 Mythos delta-pass sweep on
-  the remaining 8 Tier-5 files (the protocol introduced in #151).
+- **HashMap iteration non-determinism in resource / realloc fallbacks**
+  (LS-A-15, UCA-M-10, H-7 / H-3 / H-4.3). Three sites resolved
+  cross-component routing via `HashMap::iter().find(...)`, which picks
+  an arbitrary entry per hash-seed-randomised iteration order. When
+  multiple entries matched, the chosen entry varied per run —
+  producing non-reproducible fused output bytes and, in some cases,
+  routing a call to the wrong target. Affected:
+  - `merger.rs::component_realloc_index` fallback when a component
+    has multiple modules each with `cabi_realloc` — could pick a
+    realloc bound to a different memory than the calling site.
+  - `merger.rs` handle-table fallbacks at two sites — ties between
+    candidate handle tables broken by iteration order.
+  - `resolver.rs::resolve_resource_positions` last-resort fallback
+    on `[resource-rep]` / `[resource-new]` prefix collisions.
+  Fix: collect candidate keys, sort, pick `.first()`. Deterministic
+  tie-breaking by lowest module index / smallest type-id /
+  lexicographic key. Picks may still be semantically wrong if
+  multiple distinct resources share a prefix (Step 6 alias propagation
+  is the right structural mitigation), but the output is now
+  reproducible across runs.
 
 ### Added
 

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -1037,11 +1037,21 @@ impl Merger {
                                 // peers will hand it pointers it can't
                                 // dereference. Match by resource_name only
                                 // since the iface differs across the alias.
-                                let found = merged
+                                // Sort keys for deterministic tie-breaking
+                                // (LS-A-15).
+                                let mut keys: Vec<&(
+                                    usize,
+                                    String,
+                                    String,
+                                )> = merged
                                     .handle_tables
-                                    .iter()
-                                    .find(|((_, _, r), _)| r == rn)
-                                    .map(|(_, ht)| ht);
+                                    .keys()
+                                    .filter(|(_, _, r)| r == rn)
+                                    .collect();
+                                keys.sort();
+                                let found = keys
+                                    .first()
+                                    .and_then(|k| merged.handle_tables.get(*k));
                                 if found.is_some() {
                                     log::info!(
                                         "alias-fallback: comp {} mod {} import {}/{} → ht for resource '{}'",
@@ -1087,17 +1097,27 @@ impl Merger {
                             if self_owns_specific {
                                 None
                             } else {
-                                merged
+                                // Look up (any-owner, iface, rn) first, then
+                                // fall back to (any-owner, any-iface, rn).
+                                // Iterate in sorted-key order so ties are
+                                // broken deterministically (LS-A-15).
+                                let mut iface_keys: Vec<&(usize, String, String)> = merged
                                     .handle_tables
-                                    .iter()
-                                    .find(|((_, i, r), _)| i == iface && r == rn)
-                                    .map(|(_, ht)| ht)
+                                    .keys()
+                                    .filter(|(_, i, r)| i == iface && r == rn)
+                                    .collect();
+                                iface_keys.sort();
+                                iface_keys
+                                    .first()
+                                    .and_then(|k| merged.handle_tables.get(*k))
                                     .or_else(|| {
-                                        merged
+                                        let mut any_keys: Vec<&(usize, String, String)> = merged
                                             .handle_tables
-                                            .iter()
-                                            .find(|((_, _, r), _)| r == rn)
-                                            .map(|(_, ht)| ht)
+                                            .keys()
+                                            .filter(|(_, _, r)| r == rn)
+                                            .collect();
+                                        any_keys.sort();
+                                        any_keys.first().and_then(|k| merged.handle_tables.get(*k))
                                     })
                             }
                         };
@@ -2921,18 +2941,32 @@ pub(crate) fn component_memory_index(merged: &MergedModule, comp_idx: usize) -> 
 }
 
 /// Find the merged function index of a component's cabi_realloc.
+///
+/// Prefers module 0's realloc (the main module). If module 0 has no
+/// realloc, falls back to the realloc bound to the **lowest** module
+/// index for this component — chosen deterministically rather than via
+/// HashMap iteration order, which would let the hasher state pick a
+/// different module on every run and produce non-reproducible output
+/// (LS-A-15).
 pub(crate) fn component_realloc_index(merged: &MergedModule, comp_idx: usize) -> Option<u32> {
     // Prefer module 0's realloc (the main module)
     if let Some(&idx) = merged.realloc_map.get(&(comp_idx, 0)) {
         return Some(idx);
     }
-    // Fallback: any module's realloc for this component
-    for (&(ci, _mi), &merged_idx) in &merged.realloc_map {
-        if ci == comp_idx {
-            return Some(merged_idx);
-        }
-    }
-    None
+    // Fallback: pick the smallest module index belonging to this component,
+    // deterministically. HashMap.iter() returns entries in hash-seed
+    // order, which varies per process; collect-and-sort gives reproducible
+    // output and removes the multi-realloc race condition.
+    let mut module_idxs: Vec<usize> = merged
+        .realloc_map
+        .keys()
+        .filter(|(ci, _)| *ci == comp_idx)
+        .map(|(_, mi)| *mi)
+        .collect();
+    module_idxs.sort_unstable();
+    module_idxs
+        .first()
+        .and_then(|mi| merged.realloc_map.get(&(comp_idx, *mi)).copied())
 }
 
 ///
@@ -4641,15 +4675,12 @@ mod tests {
 
     // ---------------------------------------------------------------
     // LS-A-11 — extended-const truncation in global initializers
+    // LS-A-15 — HashMap iteration non-determinism
     //
-    // Prior to the fix, `convert_init_expr` read only the first
-    // operator of a global's init expression and emitted just that
-    // single const, silently dropping any subsequent extended-const
-    // ops. A global initialized with `(i32.const 100)(i32.const 23)
-    // i32.add` (intended value 123) was emitted as `(i32.const 100)`.
+    // Shared empty-merged fixture used by both regression suites.
     // ---------------------------------------------------------------
 
-    fn empty_merged_for_init_expr() -> MergedModule {
+    fn empty_merged_fixture() -> MergedModule {
         MergedModule {
             types: Vec::new(),
             imports: Vec::new(),
@@ -4679,13 +4710,15 @@ mod tests {
         }
     }
 
+    // LS-A-11: convert_init_expr must fold multi-op extended-const
+    // expressions (was previously truncating to the first operator).
     #[test]
     fn ls_a_11_convert_init_expr_folds_extended_const_i32_add() {
         // Init expr bytes WITHOUT trailing `end` (the function appends
         // it). Use small operands that fit in single-byte sleb (no sign
         // bit at position 6): i32.const 5, i32.const 10, i32.add → 15.
         let bytes: Vec<u8> = vec![0x41, 5, 0x41, 10, 0x6A];
-        let merged = empty_merged_for_init_expr();
+        let merged = empty_merged_fixture();
 
         let expr = convert_init_expr(&bytes, 0, 0, &merged, &ValType::I32);
 
@@ -4706,7 +4739,7 @@ mod tests {
         // Regression: the fold path must not change behavior for a
         // simple single-const initializer.
         let bytes: Vec<u8> = vec![0x41, 5];
-        let merged = empty_merged_for_init_expr();
+        let merged = empty_merged_fixture();
 
         let expr = convert_init_expr(&bytes, 0, 0, &merged, &ValType::I32);
         let mut encoded = Vec::new();
@@ -4714,6 +4747,52 @@ mod tests {
         let mut expected = Vec::new();
         wasm_encoder::Encode::encode(&ConstExpr::i32_const(5), &mut expected);
         assert_eq!(encoded, expected);
+    }
+
+    // LS-A-15: component_realloc_index fallback must be deterministic
+    // when multiple modules carry cabi_realloc (was hash-seed dependent).
+    #[test]
+    fn ls_a_15_component_realloc_index_picks_lowest_module_deterministically() {
+        // Component 0 has reallocs at modules 1 (idx 10), 2 (idx 11),
+        // and 3 (idx 12), but no module 0. The function must
+        // deterministically pick the realloc bound to the LOWEST module
+        // index (module 1 → idx 10), not whatever HashMap happens to
+        // iterate first.
+        //
+        // Rebuilding the HashMap from scratch each iteration gives
+        // each instance a fresh hash seed, so iteration order varies
+        // across iterations — if the impl picked an arbitrary entry,
+        // we'd see more than one observed value.
+        let mut observed = std::collections::HashSet::new();
+        for _ in 0..64 {
+            let mut merged = empty_merged_fixture();
+            merged.realloc_map.insert((0, 1), 10);
+            merged.realloc_map.insert((0, 2), 11);
+            merged.realloc_map.insert((0, 3), 12);
+            let got = component_realloc_index(&merged, 0).unwrap();
+            observed.insert(got);
+        }
+        assert_eq!(
+            observed.len(),
+            1,
+            "component_realloc_index must return a deterministic value \
+             across runs; saw {observed:?}",
+        );
+        assert!(
+            observed.contains(&10),
+            "lowest module index (1 → realloc 10) must be selected; \
+             observed {observed:?}",
+        );
+    }
+
+    #[test]
+    fn ls_a_15_component_realloc_index_prefers_module_0() {
+        // Regression: when module 0 has a realloc, the function must
+        // return it regardless of other modules in the map.
+        let mut merged = empty_merged_fixture();
+        merged.realloc_map.insert((0, 0), 100);
+        merged.realloc_map.insert((0, 1), 200);
+        assert_eq!(component_realloc_index(&merged, 0), Some(100));
     }
 }
 

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -1300,11 +1300,25 @@ fn resolve_resource_positions(
                 // cases). Step 6 normally covers this, but keep as a
                 // safety net for components whose ExportAlias chain isn't
                 // captured.
-                resource_map
+                //
+                // Determinism: iterate in sorted type-id order rather than
+                // HashMap iteration order, so a tie between two resource
+                // imports with the same prefix is broken by the lowest
+                // type-id deterministically rather than by HashMap hasher
+                // state. Picks may still be wrong if two distinct resources
+                // share a prefix (Step 6 alias propagation is the right
+                // mitigation), but at least the output is now reproducible
+                // across runs (LS-A-15).
+                let mut keys: Vec<(u32, &str)> = resource_map
                     .by_type_id
-                    .iter()
-                    .find(|((_, k), _)| *k == field_prefix)
-                    .map(|(_, v)| (v.clone(), false))
+                    .keys()
+                    .filter(|(_, k)| *k == field_prefix)
+                    .map(|(ti, k)| (*ti, *k))
+                    .collect();
+                keys.sort_unstable_by_key(|(ti, _)| *ti);
+                keys.first()
+                    .and_then(|k| resource_map.by_type_id.get(k))
+                    .map(|v| (v.clone(), false))
             });
         if let Some(((module_name, field_name), via_name_fallback)) = lookup {
             // Check if the callee truly defines this resource (has ownership of the

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -822,6 +822,66 @@ loss-scenarios:
     status: approved
     priority: high
 
+  - id: LS-A-15
+    title: HashMap iteration non-determinism in resource / realloc lookups
+    uca: UCA-M-10
+    hazards: [H-7, H-3, H-4.3]
+    type: inadequate-control-algorithm
+    scenario: >
+      Three sites in `meld-core` resolved cross-component routing via
+      `HashMap::iter().find(...)` over keyed maps. HashMap iteration
+      order is hash-seed-randomised per process, so when more than one
+      entry matched the lookup predicate the chosen entry varied
+      across runs — producing **non-reproducible** fused output bytes
+      and, in some cases, routing a call to the wrong target on a
+      given run.
+
+      Affected sites:
+      * `merger.rs::component_realloc_index` (lines 2907-2919) — when
+        a component has multiple modules each carrying a
+        `cabi_realloc` and module 0 is not among them, the fallback
+        picked whichever module HashMap iteration visited first. The
+        chosen realloc may be bound to a different linear memory than
+        the calling site, producing cross-memory address corruption
+        [H-4.3].
+      * `merger.rs` handle-table fallbacks (~lines 1040 and 1090-1100)
+        — when looking up a handle table by `(any-owner, iface, rn)`
+        or `(any-owner, any-iface, rn)`, ties were broken by iteration
+        order.
+      * `resolver.rs::resolve_resource_positions` last-resort fallback
+        (lines 1295-1308) — `by_type_id.iter().find(|((_, k), _)| ...)`
+        on `[resource-rep]` / `[resource-new]` / `[resource-drop]`
+        prefix collisions returned an arbitrary import; cross-resource
+        confusion at the adapter call site [H-3].
+
+      Validator does not catch any of these because the structural
+      types match across candidates (all reallocs share
+      `(i32, i32, i32, i32) -> i32`; all resource-rep imports share
+      `(i32) -> i32`).
+
+      Fix: collect candidate keys, sort, then pick `.first()`.
+      `component_realloc_index` now deterministically chooses the
+      lowest module index. Resource fallback picks the lowest type-id
+      with the matching prefix. Handle-table fallbacks pick the
+      lexicographically smallest `(owner, iface, rn)` tuple. Picks may
+      still be wrong if multiple distinct resources share a prefix
+      (Step 6 alias propagation is the right structural mitigation),
+      but the output is now reproducible across runs.
+
+      Hazards: H-7 (non-deterministic output for identical inputs),
+      H-3 (cross-component reference integrity when the wrong target
+      is chosen), H-4.3 (canonical-ABI realloc bound to wrong memory).
+    causal-factors:
+      - "`HashMap::iter().find(predicate)` was used as a \"pick any matching\" idiom without recognising that the choice is hash-seed-randomised"
+      - No reproducibility test on the fuser's output bytes for
+        inputs with multi-module realloc or with prefix-collision
+        resource imports
+      - Three distinct sites carried the same bug pattern in
+        different files; a refactor pass would have surfaced them
+        together
+    status: approved
+    priority: high
+
   # ==========================================================================
   # Merger scenario (discovered during gap analysis)
   # ==========================================================================


### PR DESCRIPTION
## Summary

Third fix from the post-v0.8.0 Mythos delta-pass sweep. Three sites in
meld-core resolved cross-component routing via \`HashMap::iter().find(...)\`,
which picks a hash-seed-randomised entry. When multiple entries
matched, the chosen entry varied per run.

## The bugs

| Site | Effect |
|---|---|
| \`merger.rs::component_realloc_index\` fallback (2907-2919) | Multi-module component with reallocs in modules other than 0 picks an arbitrary realloc — may be bound to wrong memory (H-4.3) |
| \`merger.rs\` handle-table fallbacks (~1040, 1090-1100) | Ties between candidate handle tables broken by iteration order |
| \`resolver.rs::resolve_resource_positions\` last-resort (1295-1308) | Resource-rep / -new / -drop prefix collisions return arbitrary import → cross-resource confusion (H-3) |

The wasm validator does not catch any of these because structural types match across candidates: all reallocs share \`(i32,i32,i32,i32) -> i32\`; all resource-rep imports share \`(i32) -> i32\`.

## Fix

Collect candidate keys → sort → pick \`.first()\`. Deterministic tie-breaking:
- \`component_realloc_index\` picks the lowest module index
- Handle-table fallbacks pick lexicographically smallest \`(owner, iface, rn)\`
- Resource type-id fallback picks the smallest matching type-id

Picks may still be semantically wrong if multiple distinct resources share a prefix (Step 6 alias propagation is the right structural mitigation), but the output is now reproducible across runs.

## Tests (2 new)

- \`ls_a_15_component_realloc_index_picks_lowest_module_deterministically\` —
  rebuilds the MergedModule across 64 iterations (each with fresh HashMap
  hash seed) and asserts a single observed value.
- \`ls_a_15_component_realloc_index_prefers_module_0\` — regression
  for the primary path.

## Tier-5 gate

Touches \`merger.rs\` and \`resolver.rs\` (both Tier-5). Mythos pass evidence
in a comment below.

## Test plan

- [x] \`cargo test -p meld-core --lib\` — 210 pass (208 prior + 2 new)
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] YAML lint
- [ ] CI green on smithy
- [ ] \`mythos-pass-done\` label applied

## Refs

- LS-A-15 (UCA-M-10, H-7, H-3, H-4.3)
- Discovered by post-v0.8.0 Mythos delta-pass on merger.rs and resolver.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)