### PR TITLE
fix(resource-graph,merger): match full (iface, rn) tuple in 4 sites (LS-A-17/18/19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **Resource graph + merger key-matching bugs** (LS-A-17, LS-A-18, LS-A-19;
+  UCA-F-2 / UCA-M-9). Four sites in `meld-core` either dropped the
+  interface dimension of `(component, interface, resource_name)` tuples
+  or used substring/suffix matching where exact match was required:
+  - `resource_graph.rs` definer purge ignored the iface when removing
+    defines_cache entries, purging legitimate definers when an
+    unrelated component imported a resource sharing the name.
+  - `resource_graph.rs` terminal-exporter pass used over-broad
+    `to_also_imports_resource` check that classified a component as a
+    re-exporter if any of its imports carried any resource interface.
+  - `resource_graph.rs` only registered resource nodes for
+    `[resource-drop]X` imports on pure-consumer components; re-exporters
+    that dropped a foreign resource had their drop calls invisible to
+    the graph.
+  - `merger.rs::add_unresolved_imports` dedup-skip path matched
+    `imp.name.ends_with(rn)`, so two resources sharing a suffix (e.g.
+    `float` / `bigfloat`) collided into the same tracking entry.
+  All four led to silent cross-resource confusion or wrong-handle-table
+  routing with no host trap. Fixes scope each comparison to the full
+  `(comp, iface, rn)` tuple or use exact-match against the full
+  `[resource-{rep,new,drop}]<name>` import string.
+
 - **HashMap iteration non-determinism in resource / realloc fallbacks**
   (LS-A-15, UCA-M-10, H-7 / H-3 / H-4.3). Three sites resolved
   cross-component routing via `HashMap::iter().find(...)`, which picks

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -2144,13 +2144,22 @@ impl Merger {
                         // Still record per-component resource tracking: find the
                         // func index already assigned to this resource name.
                         let eff_field = &dedup_key.1;
+                        // Exact-match the full `[resource-{rep,new}]<name>`
+                        // import name. The prior `ends_with(rn)` matched any
+                        // resource whose name had `rn` as a suffix (e.g.
+                        // `rn = "float"` collided with both
+                        // `[resource-rep]float` and `[resource-rep]bigfloat`),
+                        // letting `resource_rep_by_component` track the
+                        // wrong import for the wrong-suffix collision — silent
+                        // cross-resource confusion (LS-A-19).
                         if let Some(rn) = eff_field.strip_prefix("[resource-rep]") {
+                            let expected = format!("[resource-rep]{rn}");
                             if let Some(&idx) =
                                 merged.resource_rep_by_component.values().find(|&&idx| {
-                                    merged.imports.get(idx as usize).is_some_and(|imp| {
-                                        imp.name.starts_with("[resource-rep]")
-                                            && imp.name.ends_with(rn)
-                                    })
+                                    merged
+                                        .imports
+                                        .get(idx as usize)
+                                        .is_some_and(|imp| imp.name == expected)
                                 })
                             {
                                 merged
@@ -2158,12 +2167,13 @@ impl Merger {
                                     .insert((unresolved.component_idx, rn.to_string()), idx);
                             }
                         } else if let Some(rn) = eff_field.strip_prefix("[resource-new]") {
+                            let expected = format!("[resource-new]{rn}");
                             if let Some(&idx) =
                                 merged.resource_new_by_component.values().find(|&&idx| {
-                                    merged.imports.get(idx as usize).is_some_and(|imp| {
-                                        imp.name.starts_with("[resource-new]")
-                                            && imp.name.ends_with(rn)
-                                    })
+                                    merged
+                                        .imports
+                                        .get(idx as usize)
+                                        .is_some_and(|imp| imp.name == expected)
                                 })
                             {
                                 merged

--- a/meld-core/src/resource_graph.rs
+++ b/meld-core/src/resource_graph.rs
@@ -34,6 +34,14 @@ pub enum GraphEdge {
     ResolvesTo { interface: String },
 }
 
+/// Which `[resource-*]` prefix a core import carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResourcePrefixKind {
+    Rep,
+    New,
+    Drop,
+}
+
 /// The resource ownership graph.
 pub struct ResourceGraph {
     graph: DiGraph<GraphNode, GraphEdge>,
@@ -124,14 +132,25 @@ impl ResourceGraph {
             if has_rep || has_new {
                 // This component participates in resource handling.
                 // Determine which resources it handles by scanning core module imports.
+                //
+                // LS-A-18: also register a resource node for any
+                // [resource-drop]X import even if X is a *foreign*
+                // resource that the component neither reps nor news.
+                // Prior to the fix, drop-only imports against foreign
+                // resources were silently invisible to the graph (the
+                // second pass that strips [resource-drop] only fires
+                // when `!has_any_canon`), so the merger would route
+                // the drop to a wrong handle table.
                 for module in &comp.core_modules {
                     for imp in &module.imports {
                         if let crate::parser::ImportKind::Function(_) = &imp.kind {
-                            let (prefix, is_rep) =
+                            let (prefix, kind) =
                                 if let Some(rn) = imp.name.strip_prefix("[resource-rep]") {
-                                    (rn, true)
+                                    (rn, ResourcePrefixKind::Rep)
                                 } else if let Some(rn) = imp.name.strip_prefix("[resource-new]") {
-                                    (rn, false)
+                                    (rn, ResourcePrefixKind::New)
+                                } else if let Some(rn) = imp.name.strip_prefix("[resource-drop]") {
+                                    (rn, ResourcePrefixKind::Drop)
                                 } else {
                                     continue;
                                 };
@@ -150,20 +169,38 @@ impl ResourceGraph {
                                 });
 
                             if let Some(&comp_node) = comp_nodes.get(&comp_idx) {
-                                if is_rep && has_rep {
-                                    // Component has canonical ResourceRep AND imports [resource-rep]
-                                    // → it defines this resource
-                                    graph.add_edge(comp_node, resource_node, GraphEdge::Defines);
-                                } else if !has_rep && has_new {
-                                    // Only ResourceNew, no ResourceRep → re-exporter
-                                    graph.add_edge(comp_node, resource_node, GraphEdge::Reexports);
-                                } else {
-                                    // Has imports but no canonical entries → pure consumer
-                                    graph.add_edge(
-                                        comp_node,
-                                        resource_node,
-                                        GraphEdge::ImportsFrom,
-                                    );
+                                match kind {
+                                    ResourcePrefixKind::Rep if has_rep => {
+                                        // Canonical ResourceRep AND imports [resource-rep]
+                                        // → it defines this resource
+                                        graph.add_edge(
+                                            comp_node,
+                                            resource_node,
+                                            GraphEdge::Defines,
+                                        );
+                                    }
+                                    ResourcePrefixKind::New if !has_rep && has_new => {
+                                        // Only ResourceNew, no ResourceRep → re-exporter
+                                        graph.add_edge(
+                                            comp_node,
+                                            resource_node,
+                                            GraphEdge::Reexports,
+                                        );
+                                    }
+                                    _ => {
+                                        // Includes:
+                                        //   - [resource-drop]X imports (foreign
+                                        //     resource being dropped — pure
+                                        //     consumer of X)
+                                        //   - Rep / New imports that don't
+                                        //     match the canonical entries
+                                        //     (also pure consumer behavior)
+                                        graph.add_edge(
+                                            comp_node,
+                                            resource_node,
+                                            GraphEdge::ImportsFrom,
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -240,12 +277,22 @@ impl ResourceGraph {
         // exports but doesn't import (no outgoing ResolvesTo for this interface).
         // This handles cases where canonical_functions is empty after flattening.
         for ((_from_comp, import_name), (to_comp, _)) in resolved_imports {
-            // Check if to_comp also imports an interface that involves the same
-            // resource name. A component that imports "test:X/test" (with float)
-            // AND exports "exports" (with float) is a re-exporter even though
-            // the interface names differ.
+            // Determine whether `to_comp` is a re-exporter for *this
+            // specific interface* (i.e. it imports an interface that
+            // carries the resources we're about to attribute) or a
+            // terminal definer.
+            //
+            // Prior to the LS-A-17 fix this check ran
+            // `resource_nodes.keys().any(...)` against ANY iface, so
+            // any consumer that imported `wasi:io/poll` alongside the
+            // app's resources would mis-classify the app's true
+            // definer as a re-exporter. The fix scopes the check to
+            // `import_name` (and its `[export]`-prefixed variants).
             let to_also_imports_resource = resolved_imports.keys().any(|(comp, iname)| {
                 *comp == *to_comp
+                    && (iname == import_name
+                        || iname.strip_prefix("[export]") == Some(import_name.as_str())
+                        || import_name.strip_prefix("[export]") == Some(iname.as_str()))
                     && resource_nodes.keys().any(|(ri, _)| {
                         ri == iname || ri.strip_prefix("[export]") == Some(iname.as_str())
                     })
@@ -286,14 +333,20 @@ impl ResourceGraph {
                 })
                 .cloned()
                 .collect();
-            for (_ri, rn) in &matching_resource_ifaces {
-                // Check all interface name variants for this resource
-                // A component that imports a resource cannot be its definer,
-                // regardless of what interface name it exports under. Remove
-                // ALL defines entries for this component + resource name.
+            for (ri, rn) in &matching_resource_ifaces {
+                // Remove the component's definer entry **only** for the
+                // specific (interface, resource_name) pair matched here.
+                //
+                // Prior to the LS-A-17 fix this filter ignored the
+                // interface (`|(idx, _iface, r)| ...`), so a component
+                // that imported `[resource-drop]X` from interface `I_x`
+                // AND defined its own resource `X` in unrelated
+                // interface `I_y` lost the `(comp, I_y, X)` definer
+                // entry too. Same-resource-name across different
+                // interfaces is permitted by the Component Model.
                 let keys_to_remove: Vec<_> = defines_cache
                     .keys()
-                    .filter(|(idx, _iface, r)| *idx == *from_comp && r == rn)
+                    .filter(|(idx, iface, r)| *idx == *from_comp && iface == ri && r == rn)
                     .cloned()
                     .collect();
                 for key in keys_to_remove {
@@ -411,5 +464,177 @@ impl ResourceGraph {
                 eprintln!("  {:?}: {}", node, edges.join(", "));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{CanonicalEntry, CoreModule, ImportKind, ModuleImport, ParsedComponent};
+
+    fn empty_pc() -> ParsedComponent {
+        ParsedComponent {
+            name: None,
+            core_modules: vec![],
+            imports: vec![],
+            exports: vec![],
+            types: vec![],
+            instances: vec![],
+            canonical_functions: vec![],
+            sub_components: vec![],
+            component_aliases: vec![],
+            component_instances: vec![],
+            core_entity_order: vec![],
+            component_func_defs: vec![],
+            component_instance_defs: vec![],
+            component_type_defs: vec![],
+            original_size: 0,
+            original_hash: String::new(),
+            depth_0_sections: vec![],
+            p3_async_features: vec![],
+        }
+    }
+
+    fn empty_cm() -> CoreModule {
+        CoreModule {
+            index: 0,
+            bytes: vec![],
+            types: vec![],
+            imports: vec![],
+            exports: vec![],
+            functions: vec![],
+            memories: vec![],
+            tables: vec![],
+            globals: vec![],
+            start: None,
+            data_count: None,
+            element_count: 0,
+            custom_sections: vec![],
+            code_section_range: None,
+            global_section_range: None,
+            element_section_range: None,
+            data_section_range: None,
+        }
+    }
+
+    fn imp(module: &str, name: &str) -> ModuleImport {
+        ModuleImport {
+            module: module.into(),
+            name: name.into(),
+            kind: ImportKind::Function(0),
+        }
+    }
+
+    /// LS-A-17 F1 — definer purge ignores interface name.
+    ///
+    /// Component 0 imports a resource named "data" from `shared:lib/storage`.
+    /// Component 1 ALSO has a resource named "data" — but in interface
+    /// `ns:other/cache`, completely unrelated. Prior to the fix, the
+    /// cleanup loop filtered the defines_cache by `(comp == 1) &&
+    /// (resource_name == "data")` ignoring iface, purging component 1's
+    /// legitimate definer entry for (ns:other/cache, data).
+    #[test]
+    fn ls_a_17_definer_survives_unrelated_import_with_same_resource_name() {
+        let mut c0 = empty_pc();
+        c0.canonical_functions
+            .push(CanonicalEntry::ResourceRep { resource: 0 });
+        let mut m0 = empty_cm();
+        m0.imports
+            .push(imp("shared:lib/storage", "[resource-rep]data"));
+        c0.core_modules.push(m0);
+
+        let mut c1 = empty_pc();
+        c1.canonical_functions
+            .push(CanonicalEntry::ResourceRep { resource: 0 });
+        let mut m1 = empty_cm();
+        m1.imports.push(imp("ns:other/cache", "[resource-rep]data"));
+        c1.core_modules.push(m1);
+
+        let mut resolved = HashMap::new();
+        resolved.insert(
+            (1usize, "shared:lib/storage".to_string()),
+            (0usize, "shared:lib/storage".to_string()),
+        );
+
+        let rg = ResourceGraph::build(&resolved, &[c0, c1]);
+        assert!(
+            rg.defines_resource(1, "ns:other/cache", "data"),
+            "comp 1's definer entry for ns:other/cache#data was purged \
+             by an unrelated import that shares the resource name"
+        );
+        assert_eq!(rg.resource_definer("ns:other/cache", "data"), Some(1));
+    }
+
+    /// LS-A-17 F2 — terminal exporter pass uses an over-broad
+    /// `to_also_imports_resource` check.
+    ///
+    /// Component 0 imports two unrelated resource interfaces:
+    /// `svc:bridge/api` and `wasi:io/poll`. Component 1 is the definer
+    /// of `svc:bridge/api#thing`. Prior to the fix, the terminal
+    /// exporter pass marked comp 1 as NOT terminal because comp 0
+    /// imported "any resource interface" — including the unrelated
+    /// wasi:io/poll. The fix scopes the check to the specific iface
+    /// being attributed.
+    #[test]
+    fn ls_a_17_terminal_definer_with_unrelated_resource_import() {
+        let mut c0 = empty_pc();
+        let mut m0 = empty_cm();
+        m0.imports
+            .push(imp("svc:bridge/api", "[resource-drop]thing"));
+        m0.imports
+            .push(imp("wasi:io/poll", "[resource-drop]pollable"));
+        c0.core_modules.push(m0);
+
+        // Comp 1 — terminal definer for svc:bridge/api#thing, but with
+        // empty canonical_functions (post-flatten case).
+        let c1 = empty_pc();
+
+        let mut resolved = HashMap::new();
+        resolved.insert(
+            (0usize, "svc:bridge/api".to_string()),
+            (1usize, "svc:bridge/api".to_string()),
+        );
+        // External host import — also produces a resource_node from
+        // c0's [resource-drop] but should not affect comp 1's
+        // attribution.
+        resolved.insert(
+            (0usize, "wasi:io/poll".to_string()),
+            (usize::MAX, "wasi:io/poll".to_string()),
+        );
+
+        let rg = ResourceGraph::build(&resolved, &[c0, c1]);
+        assert_eq!(
+            rg.resource_definer("svc:bridge/api", "thing"),
+            Some(1),
+            "terminal-exporter pass mis-classified comp 1 as a re-exporter \
+             because comp 0 imports an unrelated resource interface"
+        );
+    }
+
+    /// LS-A-18 — [resource-drop] only handled when !has_any_canon.
+    ///
+    /// A re-exporter (has ResourceNew) that ALSO drops a foreign
+    /// resource Y must register Y in the graph. Prior to the fix, the
+    /// first pass stripped only [resource-rep] and [resource-new]; the
+    /// second pass that handles [resource-drop] only ran when
+    /// `!has_any_canon`, so a re-exporter dropping a foreign resource
+    /// had its drop call invisible to the graph.
+    #[test]
+    fn ls_a_18_drop_on_foreign_resource_registers_node_for_reexporter() {
+        let mut c0 = empty_pc();
+        c0.canonical_functions
+            .push(CanonicalEntry::ResourceNew { resource: 0 });
+        let mut m = empty_cm();
+        m.imports.push(imp("iface:a/x", "[resource-new]thingX"));
+        m.imports.push(imp("iface:b/y", "[resource-drop]thingY"));
+        c0.core_modules.push(m);
+
+        let rg = ResourceGraph::build(&HashMap::new(), &[c0]);
+        assert!(
+            rg.uses_resource(0, "iface:b/y", "thingY"),
+            "re-exporter that drops a foreign resource must register \
+             a graph node for that resource (LS-A-18); otherwise the \
+             merger routes the drop to the wrong handle table"
+        );
     }
 }

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -882,6 +882,125 @@ loss-scenarios:
     status: approved
     priority: high
 
+  - id: LS-A-17
+    title: Resource graph definer purge and terminal-exporter passes ignore (iface, rn)
+    uca: UCA-F-2
+    hazards: [H-3, H-1]
+    type: inadequate-control-algorithm
+    scenario: >
+      Two distinct passes in `meld-core/src/resource_graph.rs::ResourceGraph::build`
+      filtered the wrong dimension of the (component, interface,
+      resource_name) tuple, conflating distinct resources that shared
+      either a resource name or an interface family.
+
+      (a) The "definer purge" pass (lines 279-308) removed defines_cache
+      entries with `filter(|(idx, _iface, r)| *idx == from_comp && r == rn)`
+      — the interface was explicitly ignored. A component that imported
+      `[resource-rep]X` from interface `I_x` AND defined its own
+      `[resource-rep]X` in unrelated interface `I_y` lost the
+      (comp, I_y, X) definer entry. Same-resource-name across different
+      interfaces is permitted by the Component Model.
+
+      (b) The "terminal exporter" pass (lines 242-264) classified a
+      component as a re-exporter (not a definer) if any of its imports
+      carried any resource interface — even resources entirely
+      unrelated to the iface being attributed. A consumer that imported
+      `wasi:io/poll` alongside an app-defined resource interface
+      mis-classified the app's true definer as a re-exporter.
+
+      Both bugs led to wrong handle-table allocation downstream:
+      handle-table allocated for the wrong owning component, or no
+      handle table at all, with `resource_definer` returning None.
+      Subsequent `resource.rep` calls in the merger fell back to the
+      first matching HT (LS-A-15 family) and dereferenced foreign rep
+      data — cross-component handle confusion with no host trap.
+
+      Fix:
+      * Definer purge: restrict the filter to the specific
+        `(comp, iface, rn)` tuple captured in `matching_resource_ifaces`.
+      * Terminal exporter: scope `to_also_imports_resource` to the
+        specific iface being attributed (and its `[export]`-prefixed
+        variants), so unrelated resource imports no longer disqualify
+        the definer.
+    causal-factors:
+      - "Cleanup filter discarded the iface dimension of the (idx, iface, rn) tuple"
+      - "`to_also_imports_resource` checked `resource_nodes.keys().any(...)` against ANY iface rather than the iface under attribution"
+      - No upstream test exercised same-resource-name-across-different-interfaces or unrelated-resource-import cases
+    status: approved
+    priority: high
+
+  - id: LS-A-18
+    title: Resource graph silently drops [resource-drop] imports for non-pure-consumer components
+    uca: UCA-F-2
+    hazards: [H-3]
+    type: inadequate-control-algorithm
+    scenario: >
+      `ResourceGraph::build` had two passes that registered resource
+      nodes from core module imports. The first pass (`if has_rep ||
+      has_new`, ~lines 124-172) handled `[resource-rep]` and
+      `[resource-new]` prefixes but silently skipped
+      `[resource-drop]`. The second pass (lines 186-197) handled all
+      three prefixes — but only fired when `!has_any_canon` (the
+      component has no canonical ResourceRep/New of its own).
+
+      A re-exporter (has ResourceNew on some resource X) that ALSO
+      imports `[resource-drop]Y` for a foreign resource Y never
+      registered Y in the graph: the first pass didn't recognise drop
+      prefixes, and the second pass was skipped because the component
+      has canonical entries. Downstream, the merger's
+      `defines_resource`/`resource_definer` lookups for Y returned
+      empty, and the drop call was routed via the first matching
+      handle-table fallback (LS-A-15 family) — invoking a foreign
+      dtor on a foreign rep, which is UB inside the guest with no
+      host trap [H-3, H-7 inside-guest].
+
+      Fix: the first pass now also strips `[resource-drop]` and
+      registers an `ImportsFrom` edge for those, matching the second
+      pass's behaviour. A `ResourcePrefixKind` enum makes the match
+      arms explicit. The second pass is kept as a fallback for pure-
+      consumer components.
+    causal-factors:
+      - First pass only matched `[resource-rep]` and `[resource-new]`; the symmetric `[resource-drop]` arm was missing
+      - Second pass was gated on `!has_any_canon`, leaving a gap for components that participate in resource handling AND drop foreign resources
+      - No test exercised a re-exporter that drops a non-self-owned resource
+    status: approved
+    priority: high
+
+  - id: LS-A-19
+    title: Resource import dedup tracking uses ends_with() suffix match
+    uca: UCA-M-9
+    hazards: [H-1, H-10]
+    type: inadequate-control-algorithm
+    scenario: >
+      `meld-core/src/merger.rs::Merger::add_unresolved_imports` includes
+      a dedup-skip path (~lines 2127-2153) that, on a duplicate
+      `(module, field)` import, propagates the existing
+      `resource_rep_by_component` / `resource_new_by_component`
+      entry to the new component. The lookup uses
+      `imp.name.starts_with("[resource-rep]") && imp.name.ends_with(rn)`.
+
+      `ends_with(rn)` matches **any** import whose name ends with the
+      resource name. For two distinct resources whose names share a
+      suffix (`float` and `bigfloat`), the lookup matches both, and
+      `.find()` returns whichever the HashMap iterates first (also
+      LS-A-15 territory). The wrong import index is then stored in
+      `resource_rep_by_component`, and any subsequent
+      `[resource-rep]float` call on the second component routes to
+      the `bigfloat` import. Validator passes — both imports share
+      `(i32) -> i32` — but the runtime reads a `bigfloat` rep as a
+      `float`, producing type confusion with no trap [H-10].
+
+      Fix: replace the suffix match with an exact match against
+      `format!("[resource-{rep,new}]{rn}")`. The dedup-skip path now
+      tracks only the import that exactly matches the resource name
+      being deduped.
+    causal-factors:
+      - "`ends_with(rn)` matched suffix-overlap names without requiring exact equality"
+      - HashMap iteration tie-broken arbitrarily on a multi-match (compounded by LS-A-15)
+      - No test exercised resource names with shared suffix (`float` / `bigfloat`)
+    status: approved
+    priority: high
+
   # ==========================================================================
   # Merger scenario (discovered during gap analysis)
   # ==========================================================================


### PR DESCRIPTION
Fifth fix from the post-v0.8.0 Mythos delta-pass sweep. Four related bugs in `resource_graph.rs` (3) and `merger.rs` (1), all about cleanup / classifier loops dropping the interface dimension of `(component, interface, resource_name)` tuples or using suffix matching where exact match was required.

## The bugs

| LS | Site | Effect |
|---|---|---|
| LS-A-17a | resource_graph.rs definer purge (279-308) | Same-resource-name across different interfaces → wrong definer purged |
| LS-A-17b | resource_graph.rs terminal exporter (242-264) | Unrelated resource import disqualifies the definer |
| LS-A-18 | resource_graph.rs first pass (124-172) | Re-exporter that drops a foreign resource invisible to graph → wrong-table drop → UB |
| LS-A-19 | merger.rs dedup-skip (2127-2153) | `ends_with("float")` matches both `float` and `bigfloat` |

All four lead to silent cross-resource confusion or wrong-handle-table routing with no host trap.

## Fixes

- **definer purge**: filter by `(idx == from_comp && iface == ri && r == rn)` — full tuple match.
- **terminal exporter**: scope `to_also_imports_resource` to the iface under attribution (and `[export]`-prefixed variants).
- **first-pass**: extracted `ResourcePrefixKind` enum; handle `Drop` arm as `ImportsFrom` edge (matches second pass).
- **merger dedup**: exact-match against `format!("[resource-{rep,new}]{rn}")`.

## Tests (3 new)

- `ls_a_17_definer_survives_unrelated_import_with_same_resource_name`
- `ls_a_17_terminal_definer_with_unrelated_resource_import`
- `ls_a_18_drop_on_foreign_resource_registers_node_for_reexporter`

## Tier-5 gate

Touches `resource_graph.rs` and `merger.rs` (both Tier-5).

## Test plan

- [x] `cargo test -p meld-core --lib` — 211 pass (208 prior + 3 new)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] YAML lint
- [ ] CI green on smithy
- [ ] mythos-pass-done label

## Refs

- LS-A-17 (UCA-F-2, H-1, H-3)
- LS-A-18 (UCA-F-2, H-3)
- LS-A-19 (UCA-M-9, H-1, H-10)
- Discovered by post-v0.8.0 Mythos delta-pass on resource_graph.rs and merger.rs