### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-05-16
+
 ### Fixed
+
+- **Extended-const initializer / offset truncation** (LS-A-11, UCA-M-6,
+  H-1 / H-2 / H-3.3). Two const-expression parsers in meld-core read
+  only the first operator and discarded the rest, silently truncating
+  any wasm 2.0 `extended-const` expression. A data / element segment
+  with offset `(i32.const 5)(i32.const 10) i32.add` landed at offset 5
+  instead of 15; a global initialized to `(i32.const 100)(i32.const 23)
+  i32.add` (intended 123) was emitted as 100. Affected
+  `segments.rs::parse_const_expr_with_value` (data + element offsets)
+  and `merger.rs::convert_init_expr` (global initializers). Fix
+  introduces shared `fold_extended_const_i32` /
+  `fold_extended_const_i64` helpers that walk all operators with a
+  small stack-machine interpreter (i32/i64 add/sub/mul with wrapping
+  semantics) and return the folded scalar. Regression pinned by 6
+  tests covering all three arithmetic ops and the single-const
+  passthrough. Surfaced by the post-v0.8.0 Mythos delta-pass sweep on
+  the remaining 8 Tier-5 files (the protocol introduced in #151).
 
 - **Resource graph + merger key-matching bugs** (LS-A-17, LS-A-18, LS-A-19;
   UCA-F-2 / UCA-M-9). Four sites in `meld-core` either dropped the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts **v0.8.1**, carrying the post-v0.8.0 Mythos delta-pass sweep on
the 8 Tier-5 files that were unscanned at v0.8.0 cut time (per #151
gate scope).

Ten loss scenarios closed across 6 fix PRs (all merged), every one of
them **silent** (no host trap, no validator rejection — wrong-by-
construction outputs):

| LS | PR  | Area               | Headline |
|----|-----|--------------------|----------|
| LS-A-11 | #152 | segments, merger | Extended-const init/offset truncation |
| LS-A-12/13/14 | #153 | p3_async       | Mixed-mode stackful, decode over-count, substring type-class |
| LS-A-15 | #154 | merger, resolver | HashMap.iter().find non-determinism (3 sites) |
| LS-A-16 | #159 | component_wrap   | Source canonical options dropped for lifts |
| LS-A-17/18/19 | #156 | resource_graph, merger | (iface, rn) tuple key-matching |
| LS-A-20 | #157 | parser           | flags<N> modeled as Record<N × Bool> |

Plus under **Added**: the Mythos delta-pass CI gate (#151) that made
this sweep observable at PR time, and the stackful async-lift cross-
memory `(ptr, len)` return path that v0.8.0 had errored out on.

## Test plan

- [ ] CI green on this branch (Format / Clippy / Test / Coverage / Bench / Fuzz Smoke / Mythos gate)
- [ ] After merge: tag `v0.8.1`, push tag, watch `release.yml` build the 4 platform binaries
- [ ] No `--admin` bypass needed (advances #139 "3 consecutive non-admin merges" criterion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)