### PR TITLE
fix(ci): mythos-auto plumbing — slug ordering, unzip install

### DIFF
--- a/.github/workflows/mythos-auto.yml
+++ b/.github/workflows/mythos-auto.yml
@@ -145,6 +145,42 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      # Slugify before discover so the placeholder-write step below
+      # always has a non-empty `steps.slug.outputs.slug` to reference
+      # — even when the discover step fails and skips. (PR #163's
+      # first run skipped this step because it sat AFTER discover
+      # with no `if: always()`, leaving artifact paths as
+      # `mythos-out/.json`.)
+      - name: Slugify file path for artifact name
+        id: slug
+        env:
+          F: ${{ matrix.file }}
+        run: |
+          # actions/upload-artifact rejects '/' in names.
+          slug=${F//\//__}
+          echo "slug=${slug}" >> "$GITHUB_OUTPUT"
+
+      # The action's `oven-sh/setup-bun` step requires `unzip`, which
+      # is not installed by default on rust-cpu runners. Best-effort
+      # apt install; mirrors the action's own subprocess-isolation
+      # install pattern. Continues on failure so non-Debian runners
+      # don't break the workflow — if unzip is genuinely unavailable
+      # the next setup-bun step fails and the placeholder fallback
+      # fires correctly.
+      - name: Install unzip (required by setup-bun)
+        continue-on-error: true
+        run: |
+          if command -v unzip >/dev/null 2>&1; then
+            echo "unzip already present"
+            exit 0
+          fi
+          if command -v apt-get >/dev/null && command -v sudo >/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends unzip
+          else
+            echo "::warning::no apt-get/sudo; setup-bun will likely fail"
+          fi
+
       - name: Run Mythos discover.md on ${{ matrix.file }}
         id: discover
         # claude-code-action v1 pinned by commit SHA (not the `v1`
@@ -175,32 +211,28 @@ jobs:
             --max-turns 30
             --json-schema '{"type":"object","required":["verdict"],"properties":{"verdict":{"type":"string","enum":["NO_FINDINGS","FINDING"]},"file":{"type":"string"},"function":{"type":"string"},"hypothesis":{"type":"string"},"impact":{"type":"string"},"candidate_uca":{"type":"string"},"kani_harness":{"type":"string"},"poc_test":{"type":"string"}}}'
 
-      - name: Slugify file path for artifact name
-        id: slug
-        env:
-          F: ${{ matrix.file }}
-        run: |
-          # actions/upload-artifact rejects '/' in names.
-          slug=${F//\//__}
-          echo "slug=${slug}" >> "$GITHUB_OUTPUT"
-
       - name: Save structured output as artifact
         if: always()
         env:
           RESULT_JSON: ${{ steps.discover.outputs.structured_output }}
+          SLUG: ${{ steps.slug.outputs.slug }}
           F: ${{ matrix.file }}
         run: |
           mkdir -p mythos-out
+          if [ -z "${SLUG:-}" ]; then
+            echo "::error::slug step output is empty — refusing to write to mythos-out/.json"
+            exit 1
+          fi
           # If the action failed before emitting structured output,
           # synthesize a FINDING-shaped placeholder so the aggregator
           # treats this file as blocking rather than silently passing.
           if [ -z "${RESULT_JSON:-}" ]; then
             RESULT_JSON='{"verdict":"FINDING","file":"'"$F"'","hypothesis":"discover step failed before emitting structured output — see workflow logs"}'
           fi
-          printf '%s' "$RESULT_JSON" > "mythos-out/${{ steps.slug.outputs.slug }}.json"
+          printf '%s' "$RESULT_JSON" > "mythos-out/${SLUG}.json"
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: always()
+        if: always() && steps.slug.outputs.slug != ''
         with:
           name: mythos-result-${{ steps.slug.outputs.slug }}
           path: mythos-out/${{ steps.slug.outputs.slug }}.json


### PR DESCRIPTION
## Summary

Three plumbing fixes for `mythos-auto.yml`, all surfaced by PR #163's first end-to-end run. None of these affect Mythos discover semantics — they all live in the workflow scaffolding around the action.

## What broke on PR #163

```
14:32:12 Error: Unable to locate executable file: unzip. Please verify either the file path exists...
14:32:12 /var/lib/runners/runner5/_work/_temp/.../d9f8a6f8.sh: line 3: bun: command not found
14:32:12 ##[error]Process completed with exit code 127.
14:32:14 ##[error]No files were found with the provided path: mythos-out/.json. No artifacts will be uploaded.
```

Three discrete bugs cascaded:

| # | Bug | Effect |
|---|---|---|
| 1 | `unzip` missing on rust-cpu runners | `oven-sh/setup-bun` fails → claude-code-action's bun-based entrypoints exit 127 |
| 2 | Slug step had no `if: always()` and ran AFTER discover | When discover failed, slug was skipped; `steps.slug.outputs.slug` empty |
| 3 | Empty slug interpolated silently into `mythos-out/.json` path | upload-artifact failed; no per-file result; aggregate ran on missing data |

## Fixes

| Fix | What it does |
|---|---|
| Move slug step **BEFORE** discover | Slug is now always set regardless of discover outcome. No `if: always()` needed — slug + discover share the same precondition. |
| New `Install unzip (required by setup-bun)` step | Best-effort apt install, `continue-on-error: true`. Mirrors the action's own subprocess-isolation install pattern. Non-Debian runners log a warning and proceed. |
| Read SLUG from env in save-step, fail loudly on empty | Pulls slug out of `${{ }}` interpolation into env var `SLUG`. Explicit `[ -z "$SLUG" ]` check writes a `::error::` log instead of silently producing `mythos-out/.json`. |
| Guard upload-artifact with `steps.slug.outputs.slug != ''` | Even if save-step somehow runs with empty slug, upload-artifact won't try to use it as a name. |

The placeholder-FINDING fallback that surfaced these issues (writes `"discover step failed before emitting structured output"` when `RESULT_JSON` is empty) is **intentional and stays** — it's what makes the gate block on workflow failures rather than silently passing.

## Test plan

- [ ] CI green
- [ ] Mythos auto-runner fires end-to-end on this PR (touches `.github/workflows/mythos-auto.yml` — not a Tier-5 file, so the auto-runner's detect job will set `any=false` and the scan job will skip cleanly). To exercise the matrix path end-to-end we need the next Tier-5 PR.
- [ ] Watch for: any new "::error::" logs from the SLUG-empty guard

## Sequencing

This is PR #164 in the post-v0.8.1 cycle:
- #161 LS-N gate ✅
- #162 mythos-auto.yml (this workflow) ✅
- #163 LS-A-19 regression — first end-to-end mythos-auto run ✅ (admin-merged, surfaced these issues)
- **#164 (this PR)** plumbing fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)