### PR TITLE
test(dwarf): LS-CP-4 aliases + gate scans integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- **LS-CP-4 regression coverage + LS-N gate integration-test scan**
+  (`tools/run_ls_verification.py`,
+  `meld-core/tests/dwarf_strip.rs`). The LS-N verification gate was
+  previously invoking `cargo test --lib`, which filtered out
+  integration tests under `<package>/tests/`. Three pre-existing
+  tests in `dwarf_strip.rs` (`default_strips_dwarf`,
+  `passthrough_preserves_dwarf`, `default_is_strip`) already pin
+  LS-CP-4 ("DWARF passthrough emits address-incorrect debug info on
+  fused output") via Phase 1.5's Strip-default policy, but the gate
+  reported the entry as missing because the test names didn't match
+  the `ls_cp_4_*` convention AND the integration-test binary
+  wasn't being scanned. Adds three convention aliases delegating to
+  the existing test bodies, and drops `--lib` from the gate runner
+  so both lib and integration tests participate. Gate verdict moves
+  from 16/19 verified to **17/19 verified**; remaining
+  missing-bucket entries are LS-A-8 and LS-A-9 (both need
+  net-new tests, not aliases).
+
 - **LS-A-19 regression coverage** (`meld-core/src/merger.rs`). PR #156
   fixed the `imp.name.ends_with(rn)` suffix-collision bug
   (`float` / `bigfloat` cross-resource confusion) but landed without

--- a/meld-core/tests/dwarf_strip.rs
+++ b/meld-core/tests/dwarf_strip.rs
@@ -115,3 +115,30 @@ fn default_is_strip() {
     let cfg = FuserConfig::default();
     assert_eq!(cfg.dwarf_handling, DwarfHandling::Strip);
 }
+
+// LS-N verification gate convention aliases. These delegate to the
+// existing tests above; their purpose is the discoverable
+// `ls_cp_4_*` name that `tools/run_ls_verification.py` matches
+// against. The original tests stay in place as the canonical bodies
+// (preserves git blame + grep continuity).
+//
+// LS-CP-4 ("DWARF passthrough emits address-incorrect debug info on
+// fused output") is the loss scenario the Strip-default policy
+// directly mitigates — Phase 1.5 made Strip the default so the
+// broken passthrough is no longer the silent fallback. These tests
+// pin that policy.
+
+#[test]
+fn ls_cp_4_default_strips_dwarf() {
+    default_strips_dwarf();
+}
+
+#[test]
+fn ls_cp_4_passthrough_preserves_dwarf_explicitly() {
+    passthrough_preserves_dwarf();
+}
+
+#[test]
+fn ls_cp_4_default_is_strip() {
+    default_is_strip();
+}

--- a/tools/run_ls_verification.py
+++ b/tools/run_ls_verification.py
@@ -76,25 +76,33 @@ _TEST_LINE = re.compile(r"^test result: (?P<verdict>ok|FAILED)\. "
 
 
 def run_prefix(package: str, prefix: str) -> tuple[int, int, int]:
-    """Return (matched, passed, failed) for `cargo test --lib <prefix>`.
+    """Return (matched, passed, failed) for `cargo test <prefix>`.
 
     `matched` = total selected tests (passed + failed + ignored). When
     cargo finds no matching tests, it reports `0 passed; 0 failed; 0
     ignored` and still exits 0; the caller treats matched=0 as missing.
+
+    Drops the `--lib` filter so integration tests under
+    `<package>/tests/` are also scanned. Several LS-N scenarios pin
+    their regression coverage in integration tests (e.g. LS-CP-4 in
+    `dwarf_strip.rs`); excluding them caused the gate to misreport
+    those entries as missing.
     """
     cmd = [
         "cargo",
         "test",
         "-p",
         package,
-        "--lib",
         "--no-fail-fast",
         "--",
-        "--exact" if False else "--test-threads=1",
+        "--test-threads=1",
         prefix,
     ]
     proc = subprocess.run(cmd, capture_output=True, text=True)
     passed = failed = ignored = 0
+    # cargo emits one `test result:` line per target (lib + each
+    # integration test binary), so we sum across all of them. A
+    # prefix that matches in *any* target counts as "matched".
     for line in proc.stdout.splitlines():
         m = _TEST_LINE.match(line)
         if m:


### PR DESCRIPTION
## Summary

Two related fixes for the LS-N verification gate's coverage of **LS-CP-4** ("DWARF passthrough emits address-incorrect debug info").

### Fix 1: Convention aliases in `dwarf_strip.rs`

The file already has three tests pinning Phase 1.5's Strip-default policy (the mitigation LS-CP-4 calls for): `default_strips_dwarf`, `passthrough_preserves_dwarf`, `default_is_strip`. The gate just couldn't find them by name. Adds three convention aliases delegating to the existing test bodies — same pattern as PR #161's five aliases.

### Fix 2: Gate scans integration tests too

`tools/run_ls_verification.py` was invoking `cargo test --lib`, which excludes `<package>/tests/`. Drops the `--lib` filter so both lib and integration-test binaries participate. One-line semantic change; the parser was already shaped to sum multiple `test result:` lines, so no other plumbing impact.

## Gate verdict

| State | Before | After |
|---|---|---|
| Verified | 16/19 | **17/19** |
| Missing | 3 (LS-CP-4, LS-A-8, LS-A-9) | 2 (LS-A-8, LS-A-9) |
| Failed | 0 | 0 |

Remaining two need **net-new** tests, not aliases — surveyed in task #52:
- **LS-A-9** (~1-2h): byte-pattern assertion on `generate_async_callback_adapter` emitted body for the WAIT||POLL OR-pattern
- **LS-A-8** (~2-4h): adversarial 2+ resource component fixture verifying rep_func selection

## Test plan

- [ ] CI green
- [ ] LS-N verification gate posts sticky comment showing 17/19 verified / 2 missing / 0 failed
- [ ] No production code paths touched; this is test/CI scaffolding only

🤖 Generated with [Claude Code](https://claude.com/claude-code)