### PR TITLE
fix(ci): drop musl target from fuzz.yml + add id-token to mythos-auto (#168)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -48,10 +48,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Do NOT install the `x86_64-unknown-linux-musl` toolchain target.
+      # musl statically links libc, which is incompatible with the
+      # AddressSanitizer that `cargo-fuzz` injects via
+      # `-Z sanitizer=address`. The build then fails with
+      #   error: sanitizer is incompatible with statically linked libc,
+      #          disable it using `-C target-feature=-crt-static`
+      # cargo-fuzz's `--release` reuse path can pick up a musl target if
+      # a stale `fuzz/target/` is restored from cache. We default to the
+      # host gnu target (no `targets:` line, no `--target` flag on
+      # `cargo fuzz run`) so the sanitizer stays compatible.
+      # Inputs here are workflow-static (no untrusted event payloads):
+      # `matrix.target` is hardcoded in the strategy matrix and
+      # `runner.os` is GitHub-provided runner metadata.
+      # See pulseengine/meld#168 for the recurring failure pattern.
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@nightly
-        with:
-          targets: x86_64-unknown-linux-musl
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
@@ -64,8 +76,12 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-fuzz-${{ matrix.target }}-${{ hashFiles('fuzz/Cargo.toml', 'meld-core/Cargo.toml') }}
-          restore-keys: ${{ runner.os }}-fuzz-${{ matrix.target }}-
+          # Cache key version-bumped to `v2-` once to bust any snapshots
+          # taken while the toolchain still had musl as an extra target
+          # (#168). Bump again if a future change should invalidate all
+          # existing caches in lock-step.
+          key: ${{ runner.os }}-fuzz-v2-${{ matrix.target }}-${{ hashFiles('fuzz/Cargo.toml', 'meld-core/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-fuzz-v2-${{ matrix.target }}-
 
       - name: Run target for 60 s
         run: cargo +nightly fuzz run --release "$FUZZ_TARGET" -- -max_total_time=60

--- a/.github/workflows/mythos-auto.yml
+++ b/.github/workflows/mythos-auto.yml
@@ -60,6 +60,15 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  # `id-token: write` lets the action mint an OIDC token from the
+  # GitHub Actions OIDC issuer. claude-code-action calls
+  # `core.getIDToken()` (`@actions/core/lib/oidc-utils.js:71`) early in
+  # `setupGitHubToken`; without this permission the call throws
+  # "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable" and the
+  # action aborts before running its prompt. The token is workflow-
+  # scoped and signed by GitHub; it does not grant access to anything
+  # beyond what the workflow already has.
+  id-token: write
 
 jobs:
   detect:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ All notable changes to this project will be documented in this file.
   invalidate any contaminated snapshots. Root-cause analysis
   contributed by smithy team on the #168 thread.
 
+- **mythos-auto.yml missing `id-token: write` permission**
+  (`.github/workflows/mythos-auto.yml`). After the unzip block on
+  rust-cpu runners cleared (#167), the next mythos-auto run
+  surfaced a third plumbing issue: claude-code-action calls
+  `core.getIDToken()` early in `setupGitHubToken`, which requires
+  the OIDC token issuer URL. Without `id-token: write` in
+  `permissions:`, the action gets "Unable to get
+  ACTIONS_ID_TOKEN_REQUEST_URL env variable" and aborts before
+  running its prompt. Adds the permission with an inline comment
+  explaining the requirement. Discovered by PR #169's matrix scan
+  on the now-unzip-fixed runner image.
+
 - **LS-A-9 regression coverage** (`meld-core/src/adapter/fact.rs`).
   PR fixed the callback-mode `if code == WAIT` branch that silently
   treated `POLL (3)` as a YIELD fall-through (dropping host-ready

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ All notable changes to this project will be documented in this file.
   18/19 verified to **19/19 — full coverage**. The advisory
   missing-bucket is now empty.
 
+- **Fuzz smoke `sanitizer is incompatible with statically linked
+  libc` recurrence** (`.github/workflows/fuzz.yml`, #168). The
+  toolchain install was requesting `x86_64-unknown-linux-musl` as
+  an extra target. cargo-fuzz's `--release` reuse path can pick up
+  that musl target on cache restore, and musl statically links libc
+  which is incompatible with the AddressSanitizer cargo-fuzz
+  injects. The fuzz_parse_component / fuzz_resolver_terminates
+  failures attributed to runner config-drift (#139 §3) were
+  actually workflow-side: same failure on the "good" runner-7 once
+  the musl cache hit. Drops the `targets: x86_64-unknown-linux-musl`
+  line and version-bumps the `actions/cache` key to `v2-` to
+  invalidate any contaminated snapshots. Root-cause analysis
+  contributed by smithy team on the #168 thread.
+
 - **LS-A-9 regression coverage** (`meld-core/src/adapter/fact.rs`).
   PR fixed the callback-mode `if code == WAIT` branch that silently
   treated `POLL (3)` as a YIELD fall-through (dropping host-ready


### PR DESCRIPTION
## Summary

Two CI workflow plumbing fixes bundled. Both surfaced by PR #169's matrix scan once smithy's #167 (unzip) fix landed on the runner image.

### Fix 1: drop musl target from `fuzz.yml` (closes #168)

Per smithy team's root-cause analysis on [#168](https://github.com/pulseengine/meld/issues/168):

The "sanitizer is incompatible with statically linked libc" error was **NOT** runner config drift. All 7 rust-cpu runners have identical toolchains. The actual problem: `dtolnay/rust-toolchain@nightly with: targets: x86_64-unknown-linux-musl` installed the musl toolchain target. cargo-fuzz's `--release` reuse path can pick up a musl-built artifact on cache restore, and musl statically links libc which is incompatible with the AddressSanitizer cargo-fuzz injects.

| Change | Why |
|---|---|
| Drop `targets: x86_64-unknown-linux-musl` from toolchain install | cargo-fuzz uses the host gnu target by default, sanitizer-compatible |
| Bump `actions/cache` key prefix to `v2-` | Invalidate ALL existing cache snapshots once, including musl-contaminated ones |

The musl target isn't referenced anywhere else in the repo (`grep -rn musl meld-core/ fuzz/` → 0 matches outside the dropped line).

### Fix 2: add `id-token: write` to `mythos-auto.yml`

After #167's unzip fix landed and PR #169's matrix scan ran far enough to invoke claude-code-action, a third plumbing issue surfaced:

```
error: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Attempt 3 failed: Could not fetch an OIDC token. Did you remember to
add `id-token: write` to your workflow permissions?
```

claude-code-action calls `core.getIDToken()` early in `setupGitHubToken`. The OIDC issuer URL is injected as `ACTIONS_ID_TOKEN_REQUEST_URL` env var only when the workflow has `permissions.id-token: write`. Adds the permission with inline rationale.

The token is workflow-scoped and signed by GitHub; doesn't grant access beyond what the workflow already has.

## Test plan

- [ ] CI green on this PR (note: own mythos-auto won't fire — workflow changes aren't Tier-5 source)
- [ ] Next Tier-5 PR (e.g., #169 if re-pushed) sees fuzz smokes pass without `gh run rerun --failed`
- [ ] Next Tier-5 PR sees mythos-auto actually run claude-code-action through prompt completion (the unzip ✓ + OIDC ✓ combination)
- [ ] Advances #139's "3 consecutive non-admin merges" criterion

## Sequencing

- #167 (unzip on rust-cpu) ✅ closed by smithy
- **This PR (#170)**: meld-side workflow fixes
- After merge: PR #169 (LS-A-8) should pass fuzz cleanly and trigger a real mythos-auto matrix scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)