### PR TITLE
ci: skip bench/fuzz/ci on docs/safety-only changes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,8 +21,18 @@ concurrency:
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'safety/**'
+      - 'scripts/mythos/**'
+      - 'tools/*.py'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'safety/**'
+      - 'scripts/mythos/**'
+      - 'tools/*.py'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,23 @@ concurrency:
 on:
   push:
     branches: [main]
+    # Skip CI on docs/safety-only changes — they don't affect code
+    # behavior. Reduces meld's draw on the shared smithy rust-cpu
+    # fleet. Conservative exclusion: anything that could affect
+    # cargo build/test/clippy/fmt outputs (.rs, Cargo.{toml,lock},
+    # workflows themselves) still triggers.
+    paths-ignore:
+      - '**/*.md'
+      - 'safety/**'
+      - 'scripts/mythos/**'
+      - 'tools/*.py'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'safety/**'
+      - 'scripts/mythos/**'
+      - 'tools/*.py'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,8 +23,18 @@ concurrency:
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'safety/**'
+      - 'scripts/mythos/**'
+      - 'tools/*.py'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'safety/**'
+      - 'scripts/mythos/**'
+      - 'tools/*.py'
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **CI workflows now skip on docs/safety-only changes**
+  (`.github/workflows/{bench,fuzz,ci}.yml`). Adds conservative
+  `paths-ignore` filters to bench, fuzz, and ci workflows: PRs that
+  only edit Markdown, `safety/`, `scripts/mythos/`, or
+  `tools/*.py` skip the rust-cpu-hungry jobs (~9 jobs saved per
+  docs-only PR). The LS-N gate, mythos-gate, and mythos-auto
+  workflows are untouched — they need to keep firing on those very
+  paths (`safety/stpa/loss-scenarios.yaml` is what the LS-N gate
+  reads). Substantive code PRs are unaffected. Pulls meld's
+  footprint on the shared smithy fleet down without losing
+  regression signal on real changes.
+
 ### Fixed
 
 - **LS-A-8 regression coverage** (`meld-core/src/adapter/fact.rs`).


### PR DESCRIPTION
## Summary

Reduces meld's draw on the shared smithy rust-cpu fleet by adding conservative `paths-ignore` filters to `bench.yml`, `fuzz.yml`, and `ci.yml`. PRs that only edit Markdown, `safety/`, `scripts/mythos/`, or `tools/*.py` skip the rust-cpu jobs (~9 jobs saved per docs-only PR). Substantive code PRs unaffected.

This was prompted by today's repeated fleet capacity crunches — but the framing isn't "save the fleet from us." Smithy's 7 rust-cpu runners are MORE resources than GitHub-hosted would give us; the right response is to be a leaner consumer, not to push other repos off.

## Workflows NOT touched

| Workflow | Why filtering would defeat its purpose |
|---|---|
| `mythos-gate.yml` | Fires on Tier-5 `.rs` changes (already implicitly filtered) |
| `mythos-auto.yml` | Same |
| `verification-gate.yml` | Fires on `safety/stpa/loss-scenarios.yaml` — silencing that workflow on safety changes is exactly what we don't want |
| `release.yml` | Tag-triggered, not PR-triggered |
| `fixtures.yml` | Manual `workflow_dispatch` only |

## Tradeoff

Docs-only PRs get no compile-check. This is fine because they have nothing to compile. The risk is a Markdown-only PR somehow breaking the code — basically impossible for the path types we're excluding.

## Sequencing

This PR itself touches only `.github/workflows/**` + CHANGELOG, so:
- bench/fuzz/ci WILL still trigger on this PR (workflows themselves aren't in paths-ignore)
- Once merged, the NEXT PR that's docs-only will see the savings
- The LS-N gate, mythos-gate, mythos-auto continue firing as before

## Test plan

- [ ] All CI workflows fire normally on this PR (path filters don't apply to themselves)
- [ ] After merge, open a docs-only test PR to verify the skip behavior
- [ ] No required-check breakage on merge (path-filtered workflows simply don't run; they don't fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)