### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-20
+
 ### Fixed
 
 - **mythos-auto aggregate job: `gh` → `curl`**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts **v0.9.0** — the P3 cross-component stream-pair detection foundation plus a now-fully-operational Mythos delta-pass auto-runner. 12 commits since v0.8.1.

| Area | PRs |
|---|---|
| Cross-component `stream<T>` pairing detection (#141, ADR-3) | #173 |
| Mythos delta-pass auto-runner — 5 plumbing fixes to working state | #162, #164, #170, #173, #175 |
| LS-N verification gate — 19/19 approved loss-scenarios verified | #161, #165 |
| DWARF / witness-mapping discovery (Phase 1 of #130) | #131 |
| Regression coverage LS-A-8/9/19, LS-CP-4 | #163, #165, #166, #169 |
| CI footprint reduction (path filters) | #171 |
| fuzz.yml musl-target drop (closes #168) | #170 |

Milestone-consistent: #141 was milestoned v0.9.0.

## Not in this release (tracked for v0.10+)

- #141 stream-adapter **emitter** — ring-buffer / copy-chain codegen, runtime-verified follow-up (ADR-3 Path N)
- #142 static stream validation — checks (i) type-compat + (iii) circular-deps targeted for v0.10.0; (ii) bounded-channel + (iv) resource-lifetime need a bounded-channel feature first
- #143/#144 DWARF Phase 2/3 — milestoned v0.10.0/v0.11.0

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.9.0`, push tag, watch `release.yml` build the 4 platform binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)