### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-24
+
 ### Fixed
 
 - **UTF-8→UTF-16 transcoding read 1–3 bytes past the input buffer for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
Canonical-ABI correctness sweep — 15 fixes since v0.9.0, all driven by the mythos-auto delta-pass on #179. Bumps `meld-core` and `meld-cli` from 0.9.0 → 0.10.0.

## Headline (memory-safety / priority high)

- **LS-P-6** params/return-area accumulator wrap → OOB write in `cabi_realloc` (now saturating).
- **LS-P-7** conditional-pointer `CopyLayout` per-leaf instead of composite-payload (7/8 under-copy for `list<u64>` inside option/result).
- **LS-P-8** Record/Tuple field-walk used unpadded child size at 25 sites; spec-correct now uses `canonical_abi_element_size`.
- **LS-P-9** `total_flat_params` saturating fold (was `sum::<u32>`); fixes calling-convention swap.
- **LS-P-10** nested-conditional outer-guard chain on `ConditionalPointerPair` — closes an arbitrary-cross-component-memory-read with attacker-controlled `(ptr, len)` for `result<option<string>, u32>` etc.
- **LS-P-14** nested-list inner-copy `buf_len` overflow guard.
- **LS-P-16** UTF-16→UTF-8 lone-high-surrogate OOB read; conservative trap (U+FFFD upgrade is follow-up).
- **LS-P-19** UTF-8→UTF-16 mirror: each multi-byte branch guards continuation-byte reads.

## Defensive mitigations / hardening

- **LS-P-12** + **LS-P-18** refuse `list<option/result/variant-with-pointer>` (silent stale-pointer corruption); full per-element conditional fixup is follow-up.
- **LS-P-11** flat-name resolver rejects duplicate module exports.
- **LS-P-13** async adapter param-copy uses resolver positions, not the `(i32,i32)` heuristic.
- **LS-P-15** OOB `resource_type_id` dropped + warned, not silently misclassified.
- **LS-P-17** warn on mixed-encoding caller before the heuristic fallback miscompiles `string_transcoding`.

## Hygiene

- `flat_byte_size` element-wise variant JOIN (was `max`; no in-tree consumers, no LS-N).

## Tests / verification

- 266 lib tests (+34 from v0.9.0's 232)
- LS-N gate: **33/33** approved loss scenarios with regression tests
- mythos-auto delta-pass: clean per-file on parser.rs / fact.rs / resolver.rs
- Each finding clean-room-verified by an independent agent following `validate.md` before fix-or-dispute. One false positive (auto-runner disputed LS-P-8's spec-correct fix, directly contradicting `canonical-abi.py::record_size`) was disputed rather than fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)