### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-24
+
 ### Changed
 
 - **`list<option-with-pointer>` / `list<result<…,…>>` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
Spec-compliant UTF transcoding + working `list<conditional-pointer>` adapters + diff-scoped mythos scan. 3 PRs since v0.10.0 — bumps `meld-core` and `meld-cli` 0.10.0 → 0.11.0.

## Headline

- **#181** mythos-auto diff-scoped scan — judges Tier-5 PRs on the diff, not the whole file. Closes the v0.9–v0.10 treadmill where every parser.rs PR re-triggered every latent bug.
- **#182** UTF transcoders emit U+FFFD on malformed input — converts v0.10's defensive trap (LS-P-16 + LS-P-19) to the Canonical-ABI-correct lossy replacement.
- **#183** LS-P-12 + LS-P-18 structural per-element conditional pointer fixup — `list<option<string>>`, `list<result<string, E>>`, `list<variant{…(string)…}>` and mixed-record shapes now generate correct cross-component adapters instead of panicking.

## Tests

- 266 lib tests
- LS-N verification gate **33/33**
- mythos-auto: clean diff-scoped per-file scans on parser.rs / fact.rs / resolver.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)