### PR TITLE
ci(fuzz): force RUSTFLAGS=-C target-feature=-crt-static (#168 defense)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -39,6 +39,20 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Defensive belt: cargo-fuzz injects `-Z sanitizer=address` which is
+  # incompatible with statically-linked libc. Even though we never opt
+  # into musl as a build target (see the explanation on the `Install
+  # nightly Rust` step), a drifted smithy runner may still have
+  # `target-feature=+crt-static` configured via /etc/cargo/config.toml
+  # or an inherited environment variable. Setting RUSTFLAGS at the
+  # workflow level completely overrides any cargo-config rustflags
+  # (cargo gives env-RUSTFLAGS strict precedence), so we force-disable
+  # static-crt up-front. Defends against the recurring #168 pattern
+  # ("sanitizer is incompatible with statically linked libc, disable
+  # it using -C target-feature=-crt-static") landing on `-5`/`-6`-type
+  # drifted runners. Harmless no-op on clean runners (target feature
+  # was already off).
+  RUSTFLAGS: "-C target-feature=-crt-static"
 
 jobs:
   fuzz-smoke:


### PR DESCRIPTION
## Summary

Belt-and-suspenders defense against the #168 sanitizer/crt-static failure pattern that just recurred on PR #188 ([fuzz_resolver_terminates job 77662221327](https://github.com/pulseengine/meld/actions/runs/26385210560/job/77662221327) and [fuzz_fusion_roundtrip job 77662221339](https://github.com/pulseengine/meld/actions/runs/26385210560/job/77662221339)).

\`fuzz.yml\` already has a thoughtful "don't install musl as a target" mitigation, but that only addresses one failure mode. The underlying hazard surfaces whenever a drifted smithy runner has \`target-feature=+crt-static\` configured via \`/etc/cargo/config.toml\` or an inherited \`RUSTFLAGS\` env var — even on a gnu-host build, cargo-fuzz's \`-Z sanitizer=address\` then crashes with the canonical \"sanitizer is incompatible with statically linked libc\" error.

Setting \`RUSTFLAGS\` at the workflow env level overrides any cargo-config rustflags (cargo gives env-\`RUSTFLAGS\` strict precedence). On clean runners the feature was already off, so this is a harmless no-op; on drifted runners it force-disables static-crt up-front before cargo-fuzz ever calls into rustc.

## What this is not

Not a replacement for the upstream smithy ask in #168 — re-imaging the rust-cpu runner pool remains the durable fix. This stops the noise on every fuzz PR landing on a drifted runner until smithy gets to it.

## Test plan

- [x] YAML parses (\`check-yaml\` pre-commit passed)
- [ ] Fuzz workflow runs against this PR — expect all four targets green
- [ ] Confirm no behavior change on clean runners (target feature already off, flag is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)