### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,32 +4,68 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-25
+
 ### Added
 
-- **Static stream cycle detection at fusion time** (#142 (iii),
-  LS-R-12, `meld-core/src/p3_stream.rs`, `meld-core/src/resolver.rs`,
-  `meld-core/src/error.rs`). Tarjan-style strongly-connected-component
-  detection on the directed `producer → consumer` graph induced by
-  detected `StreamPair`s; strongly-connected components of size ≥ 3
-  are reported as deadlock candidates at fusion time. The legal
-  bidirectional-pipe pattern (size-2 SCCs from two independent streams
-  in opposite directions) is explicitly excluded. New
-  `Error::StreamValidation(String)` variant reports all issues from a
-  single fusion attempt at once so users can act on the whole punch
-  list. Validation logic factored into pure `validate_from_pairs` so
-  the four new regression tests
-  (`ls_r_12_stream_three_component_cycle_flagged`,
-  `bidirectional_pipe_is_not_flagged_as_cycle`,
-  `four_component_cycle_flagged`, `linear_pipeline_is_not_flagged`)
-  pin behavior without needing `ParsedComponent` fixtures.
-  Checks (i) "stream element-type compatibility", (ii) "bounded-channel
-  capacity", and (iv) "resource lifetime across async boundaries"
-  remain open. (i) needs per-import-edge type lookups — the role-list
-  heuristic that landed in an earlier draft of this PR raised a
-  false-positive on sync-connected components with unrelated streams,
-  as the Mythos delta-pass auto-scan caught; LS-R-11 stays open
-  tracking that follow-up. (ii) and (iv) need information beyond
-  `CanonicalEntry` / `ParsedComponent`.
+- **Static stream cycle detection at fusion time** (#142 (iii) / #188,
+  LS-R-12, LS-R-13, `meld-core/src/p3_stream.rs`,
+  `meld-core/src/resolver.rs`, `meld-core/src/error.rs`).
+  Strongly-connected-component detection on the directed
+  `producer → consumer` graph induced by detected `StreamPair`s;
+  multi-component SCCs of size ≥ 3 are reported as deadlock candidates
+  at fusion time. The legal bidirectional-pipe pattern (size-2 SCCs
+  from two independent streams in opposite directions) is explicitly
+  excluded. New `Error::StreamValidation(String)` variant batches every
+  issue from a single fusion attempt so users can act on the whole
+  punch list at once. Backed by an **iterative Tarjan implementation**
+  (LS-R-13) so deep linear chains can't overflow the call stack — the
+  Mythos delta-pass auto-scan on the PR identified that the original
+  recursive draft (and `petgraph 0.8`'s own `tarjan_scc`) overflows the
+  default 8 MB Rust thread stack at ~40 000 nodes. Pinned by a
+  50 000-node deep-chain regression test
+  (`deep_linear_chain_does_not_overflow_stack`). Checks (i) "stream
+  element-type compatibility", (ii) "bounded-channel capacity", and
+  (iv) "resource lifetime across async boundaries" from #142 remain
+  open. (i) needs per-import-edge type lookups — a role-list heuristic
+  attempted in an earlier draft of #188 produced false-positives on
+  sync-connected components with unrelated streams, as Mythos caught;
+  LS-R-11 stays open tracking that follow-up.
+
+- **Consumer verification recipe for signed releases** (#187, README).
+  Four-step `cosign verify-blob` + `gh attestation verify` recipe in
+  the Supply Chain Security section so consumers can independently
+  confirm a downloaded archive was produced by this repo's release
+  workflow. Closes the documentation gap from #186.
+
+### Changed
+
+- **Release pipeline shipped** (#186, `.github/workflows/release.yml`).
+  Re-implemented around the synth reference flow: per-target
+  `meld-${VERSION}-${TARGET}.tar.gz` archives, CycloneDX SBOM
+  (`meld-<bare>.cdx.json` via cargo-cyclonedx), Sigstore-keyless-signed
+  `SHA256SUMS.txt` (cosign v2.4.1; signature, certificate, and
+  Sigstore bundle alongside), SLSA v1 build-provenance attestation per
+  archive via `actions/attest-build-provenance@v2`, and a captured
+  `build-env.txt`. Per-file `.sha256` sidecars dropped. Workflow
+  permissions: `contents: write`, `id-token: write`,
+  `attestations: write`. Untrusted-input safety: all workflow-context
+  values (`matrix.target`, `inputs.tag`, etc.) flow through `env:`
+  bindings and dereference as `$VAR`. This is the first v0.12 release
+  to publish with the new format; v0.11.0's binaries were the last
+  built under the bare-asset flow.
+
+### Fixed
+
+- **Fuzz smoke job no longer collapses on drifted runner config**
+  (#168 / #189, `.github/workflows/fuzz.yml`). Set
+  `RUSTFLAGS: "-C target-feature=-crt-static"` at the workflow `env:`
+  level so cargo's env-RUSTFLAGS strict precedence overrides any
+  `+crt-static` setting cached in a drifted self-hosted runner's
+  `/etc/cargo/config.toml`. Defends against the recurring
+  "sanitizer is incompatible with statically linked libc" failure
+  pattern; harmless no-op on clean runners. Upstream re-imaging of
+  the rust-cpu runner pool remains the durable fix tracked in #168.
 
 ## [0.11.0] - 2026-05-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts v0.12.0 — four landed PRs since v0.11.0 (2026-05-24):

- **#186** Release pipeline standardization (synth flow: SBOM, sums, cosign, SLSA, build-env)
- **#187** README consumer verification recipe (\`cosign verify-blob\` + \`gh attestation verify\`)
- **#188** Static stream cycle detection at fusion time (#142 (iii), LS-R-12, iterative Tarjan via LS-R-13)
- **#189** Defensive RUSTFLAGS in fuzz workflow against #168 drifted-runner pattern

v0.12.0 is the **first release** published with the new artifact flow — per-target \`.tar.gz\` archives, CycloneDX SBOM, cosign-signed \`SHA256SUMS.txt\` + bundle, and SLSA v1 build provenance per archive. v0.11.0's binaries were the last bare-asset release.

## Test plan

- [x] \`cargo check --workspace\` clean on 0.12.0
- [x] Full \`cargo test -p meld-core --lib\` passes
- [x] Pre-commit hooks pass (\`cargo-fmt\`, \`cargo-clippy\`, \`cargo-test\`)
- [ ] CI green on this PR
- [ ] After merge: tag \`v0.12.0\` triggers \`release.yml\` end-to-end (first real test of the synth-pattern flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)