### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-26
+
 ### Added
 
 - **Stream type-mismatch detection on stream-carrying import edges**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts v0.13.0. One landed PR since v0.12.0:

- **#191** \`feat(p3_stream): LS-R-11 precise stream type-mismatch + fuzz layer-2 fix\` — closes #142 (i) follow-up that was withdrawn from v0.12.0 (PR #188) after the Mythos delta-pass auto-scan correctly identified a false-positive path in the role-list heuristic. The new check filters by stream-typed-import presence so sync-only connections with unrelated stream operations are correctly skipped. Bundles fuzz workflow layer-2 (CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu) for the second #168 drift mode.

## Test plan

- [x] \`cargo check --workspace\` clean on 0.13.0
- [x] All 276 \`cargo test -p meld-core --lib\` pass (includes 5 new LS-R-11 regression tests)
- [ ] CI green on this PR
- [ ] After merge: tag \`v0.13.0\` triggers \`release.yml\` (second run of the synth-pattern flow that landed in v0.12.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)