### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-27
+
 ### Added
 
 - **`component-provenance` custom section** (#192, LS-M-6,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts v0.14.0. One landed PR since v0.13.0:

- **#194** \`feat(provenance): emit component-provenance custom section (#192 / LS-M-6)\` — closes the cross-repo dependency from \`pulseengine/scry\`'s DD-002. Every defined function in the fused module gets a JSON back-pointer entry under a new \`component-provenance\` Wasm custom section. Default on, opt-out via \`--no-component-provenance\`. 11 new tests (5 unit + 6 integration) + new approved LS-M-6 entry.

## Test plan

- [x] \`cargo check --workspace\` clean on 0.14.0
- [x] All 281 lib + 6 \`component_provenance\` integration tests pass
- [x] Pre-commit hooks pass
- [ ] CI green on this PR
- [ ] After merge: tag \`v0.14.0\` triggers the signed/attested release pipeline (third successful run of the synth-pattern flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)