### PR TITLE
ci(mythos-auto): register provenance.rs as Tier-5

### DIFF
--- a/.github/workflows/mythos-auto.yml
+++ b/.github/workflows/mythos-auto.yml
@@ -112,6 +112,7 @@ jobs:
             "meld-core/src/component_wrap.rs"
             "meld-core/src/p3_async.rs"
             "meld-core/src/p3_stream.rs"
+            "meld-core/src/provenance.rs"
             "meld-core/src/adapter/"
             "meld-core/src/resource_graph.rs"
             "meld-core/src/segments.rs"


### PR DESCRIPTION
## Summary

Adds \`meld-core/src/provenance.rs\` to the Tier-5 pattern list in \`mythos-auto.yml\`. v0.14.0's component-provenance section emitter shipped but wasn't in the Mythos auto-scan registry; future changes to the section format / origin-tuple plumbing / fused_func_idx arithmetic now get the AI-driven delta-pass scan on PR.

Split from #196 (LS-R-11 layer-2) because \`anthropics/claude-code-action\` requires this workflow file to be byte-identical to main for PR runs — a workflow self-reference breaks the action's auth flow. This PR touches no Tier-5 *source*, so its own Mythos scan is a no-op and the identity check passes once merged.

## Test plan

- [x] One-line additive change to the pattern array; YAML still valid
- [ ] CI green (no Rust changes, so Test/Clippy are trivial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)