### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-28
+
 ### Added
 
 - **LS-R-11 layer-2 per-edge precise stream type-mismatch**
@@ -25,6 +27,17 @@ All notable changes to this project will be documented in this file.
   4 new regression tests pin the new behavior. Layer-1 only fires
   for connections not precisely checked, so the v0.13.0 heuristic
   stays in place as a safety net.
+
+### Changed
+
+- **`provenance.rs` registered as Tier-5** in
+  `.github/workflows/mythos-auto.yml` (#197). Future changes to the
+  component-provenance section emitter now get the AI-driven Mythos
+  delta-pass scan on PR. Shipped as a standalone PR because the
+  `anthropics/claude-code-action` requires the workflow file to be
+  byte-identical to main for PR runs — bundling the registry edit
+  with a Tier-5 source change would break the action's auth flow on
+  that PR.
 
 ## [0.14.0] - 2026-05-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts v0.15.0. Two landed PRs since v0.14.0:

- **#196** \`feat(p3_stream): LS-R-11 layer-2 per-edge precise type-mismatch\` — promotes the v0.13.0 stream-typed-import heuristic to a per-edge precise check. New \`export_stream_elements\` resolves Func exports through \`component_func_defs\` (Import + Lift paths) and compares stream element types directly per resolved edge. 4 new regression tests.
- **#197** \`ci(mythos-auto): register provenance.rs as Tier-5\` — the v0.14.0 component-provenance emitter now gets the AI delta-pass scan on future changes.

## Test plan

- [x] \`cargo check --workspace\` clean on 0.15.0
- [x] 285 lib + 22 p3_stream tests pass
- [ ] CI green
- [ ] After merge: tag v0.15.0 triggers the signed/attested release pipeline (fourth run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)