### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-05-28
+
 ### Added
 
 - **`component-provenance` section v2: per-function code-byte ranges**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts v0.16.0. Landed since v0.15.0:

- **#200** DWARF Phase 2 increment 1 — `component-provenance` section **v2** with per-function code-byte ranges (`code_range { start, end }`), the anchor for DWARF address remapping. Additive v1→v2.
- **#199** LS-M-5 status correction — the multiply-instantiated-module silent-corruption hazard was already closed by detection-and-reject; flipped `open`→`fixed` with a gate-convention regression test.

DWARF Phase 2 increments 2 (rewriter instruction-offset map) + 3 (gimli `.debug_*` rewrite) follow in later releases.

## Test plan

- [x] `cargo check --workspace` clean on 0.16.0
- [x] 291 lib + provenance integration tests green (verified pre-bump on f6f36ee)
- [ ] CI green
- [ ] After merge: tag v0.16.0 → fifth run of the signed/attested release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)