### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-28
+
 ### Added
 
 - **Rewriter instruction-level offset map** (#143 DWARF Phase 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts v0.17.0. Landed since v0.16.0:

- **#202** DWARF Phase 2 increment 2 — rewriter instruction-level offset map (`rewrite_function_body_with_offsets` + `InstrOffsetMap`). Captures the intra-function byte drift from LEB128 operand-length changes during index remapping. The second of two anchors DWARF address remapping needs; increment 1 (v0.16.0) supplied the per-function base via component-provenance v2 code ranges.

Increment 3 (gimli `.debug_line`/`.debug_info` rewrite composing both maps) is queued for its own release.

## Test plan

- [x] `cargo check --workspace` clean on 0.17.0
- [x] 295 lib tests green (4 new offset-map tests)
- [ ] CI green
- [ ] After merge: tag v0.17.0 → sixth signed/attested release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)