### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-29
+
 ### Added
 
 - **DWARF `AddressRemap` engine** (#143 DWARF Phase 2 increment 3a,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Cuts v0.18.0. Landed since v0.17.0:

- **#204** DWARF Phase 2 increment 3a — the `AddressRemap` engine. Composes the per-function base (component-provenance v2 `code_range`, v0.16.0) and the intra-function `InstrOffsetMap` (v0.17.0) into input→output code-address translation. The mathematical core of DWARF address remapping; 6 unit tests pin all three offset-space reconciliations.

Increment 3b (gimli `write::Dwarf::from` section rewrite + `DwarfHandling::Remap` mode) follows in a later release.

## Test plan

- [x] `cargo check --workspace` clean on 0.18.0
- [x] 301 lib tests green
- [ ] CI green
- [ ] After merge: tag v0.18.0 → seventh signed/attested release run

🤖 Generated with [Claude Code](https://claude.com/claude-code)