### PR TITLE
chore(mythos): register dwarf.rs as Tier-5

### DIFF
--- a/.github/workflows/mythos-auto.yml
+++ b/.github/workflows/mythos-auto.yml
@@ -113,6 +113,7 @@ jobs:
             "meld-core/src/p3_async.rs"
             "meld-core/src/p3_stream.rs"
             "meld-core/src/provenance.rs"
+            "meld-core/src/dwarf.rs"
             "meld-core/src/adapter/"
             "meld-core/src/resource_graph.rs"
             "meld-core/src/segments.rs"


### PR DESCRIPTION
Adds `meld-core/src/dwarf.rs` to the Mythos auto-scan Tier-5 file list.

`dwarf.rs` holds the DWARF `AddressRemap` engine and the
`DwarfHandling::Remap` `.debug_*` rewrite (#143). A wrong remapped code
address silently de-grounds downstream coverage/breakpoints (LS-D-1), so
the file warrants the clean-room AI delta pass on every future diff.

Standalone workflow-only change: the `claude-code-action` identity check
requires the workflow file to be byte-identical to `main`, so this is
kept separate from the inc 3b code PR (#206) — same split as #197 for
`provenance.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)