### PR TITLE
feat(dwarf): make --dwarf remap work on real DWARF + witness oracle (v0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-05-29
+
+### Changed
+
+- **`DwarfHandling::Remap` now works on real compiler-emitted DWARF**
+  (#143 / #130, witness integration). Falsifying the v0.19.0 remap
+  against a real Rust component (`hello_rust.wasm`) surfaced four
+  address classes the synthetic oracle missed; all are now handled, and
+  the all-or-nothing gimli failure mode is replaced with per-address
+  tombstoning.
+  - **`low_pc` is the function body start.** WebAssembly DWARF measures
+    `DW_AT_low_pc` from the locals-declaration byte, not the first
+    instruction. The locals/prefix region now maps linearly (locals are
+    preserved verbatim during fusion). Previously every function's
+    `low_pc` underflowed to a miss.
+  - **Exclusive-end addresses** (`high_pc`-as-address, range-list ends,
+    line-program `end_sequence`) map to the output body end.
+  - **Padded LEBs.** LLVM emits fixed-width zero-padded LEBs for
+    relocatable indices, so DWARF rows can land inside an operator's
+    operand bytes; these now resolve to the **containing** operator
+    (exact on instruction boundaries), giving correct source-line
+    attribution.
+  - **Data addresses** (`DW_OP_addr` linear-memory locations) at or
+    beyond the code extent pass through unchanged (correct under
+    multi-memory fusion).
+  - **Per-address tombstoning replaces all-or-nothing strip.**
+    `gimli::write::Dwarf::from` aborts the entire conversion on a single
+    unmappable address, so on real modules (hundreds of functions,
+    dead-code gaps) the strict gate stripped *all* DWARF. The
+    `convert_address` closure is now total: correct fused offset where
+    mappable, identity for data/existing tombstones, and the DWARF
+    tombstone `0xFFFF_FFFF` for unmappable code (functions meld dropped).
+    The LS-D-1 guarantee strengthens to *"every emitted address is
+    correct or an ignored tombstone — never a plausible-but-wrong
+    address."*
+
+### Added
+
+- **DWARF remap falsification oracle** (`tests/dwarf_remap_witness.rs`,
+  #130). Fuses a real Rust component with `--dwarf remap` and asserts
+  every non-tombstone `DW_TAG_subprogram` `low_pc` in the *output* DWARF
+  equals some fused function's component-provenance `code_range.start` —
+  the `pulseengine/witness` code-offset → source-line contract, checked
+  in-tree with `gimli`. On the fixture all but 9 of 225 functions map
+  exactly (the 9 are dead code, tombstoned). Updates LS-D-1.
+
+### Notes
+
+- Multi-DWARF-source fusion still falls back to `strip` (merging
+  independent DWARF unit sets is blocked by gimli's writer API — see
+  issue #208 for the analysis and the relocator design).
+
 ## [0.19.0] - 2026-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/meld-core/Cargo.toml
+++ b/meld-core/Cargo.toml
@@ -43,6 +43,9 @@ petgraph = "0.8.3"
 [dev-dependencies]
 proptest.workspace = true
 wasmprinter.workspace = true
+# Re-declared for integration tests (tests/dwarf_remap_witness.rs) to
+# parse and validate the remapped DWARF in the fused output.
+gimli.workspace = true
 wat = "1.219"
 wasmtime = "41.0.1"
 wasmtime-wasi = "41.0.4"

--- a/meld-core/src/dwarf.rs
+++ b/meld-core/src/dwarf.rs
@@ -145,12 +145,30 @@ impl AddressRemap {
     pub fn translate(&self, addr: u32) -> Option<u32> {
         // Greatest span whose input_start ≤ addr.
         let (_, span) = self.by_input_start.range(..=addr).next_back()?;
-        // Exclusive-end address: maps to the output body end. Checked
-        // before `contains_input` because a function's end equals the
-        // next function's start in the contiguous input code section;
-        // for the body this `addr == input_end` case only triggers for
-        // the span whose input_end it is (the last body, or via the
-        // boundary alias resolved to the next body's start below).
+
+        // Aliased boundary: input function bodies are contiguous, so
+        // `addr` can be BOTH the previous function A's exclusive end
+        // (A.input_end) and this span B's start (B.input_start). The
+        // range lookup picks B, but a `high_pc`/range-end/`end_sequence`
+        // query means A's end while a `low_pc`/first-instruction query
+        // means B's start — and `convert_address` cannot tell them
+        // apart. The two output offsets coincide ONLY when A and B stay
+        // adjacent in the fused output (input order preserved — the
+        // single-source case). If they diverge (functions interleaved
+        // or reordered), the address is genuinely ambiguous: return None
+        // so the caller tombstones it rather than emit a plausible but
+        // wrong offset for one of the two meanings (Mythos #209).
+        if addr == span.input_start
+            && let Some((_, prev)) = self.by_input_start.range(..addr).next_back()
+            && prev.input_end == addr
+            && prev.output_body_end != span.output_body_start
+        {
+            return None;
+        }
+
+        // Exclusive-end address: maps to the output body end. Reached
+        // for the span whose input_end equals addr (the last body, or a
+        // boundary where the next body's start was not selected above).
         if addr == span.input_end {
             return Some(span.output_body_end);
         }
@@ -669,6 +687,31 @@ mod tests {
         assert_eq!(remap.translate(11), Some(100));
         // Input 13 = stream 3, inside the second operator → maps to op@2.
         assert_eq!(remap.translate(13), Some(103));
+    }
+
+    /// Mythos #209: when two adjacent input functions (A.input_end ==
+    /// B.input_start) are NOT adjacent in the fused output, the shared
+    /// boundary address is ambiguous (A's exclusive end vs B's start)
+    /// and must tombstone (None) rather than emit B's start as A's end.
+    /// When they ARE adjacent in the output (input order preserved), the
+    /// two interpretations coincide and the address resolves cleanly.
+    #[test]
+    fn translate_ambiguous_boundary_tombstones_when_reordered() {
+        // A = [10,20) → output [200,210); B = [20,30) → output [500,510).
+        // A and B are contiguous in input but far apart in output.
+        let mut remap = AddressRemap::new();
+        remap.insert(span(10, 20, 200, 0, &[(0, 0)]));
+        remap.insert(span(20, 30, 500, 0, &[(0, 0)]));
+        // addr 20 is A.input_end AND B.input_start; outputs diverge
+        // (A end = 210, B start = 500) → ambiguous → None.
+        assert_eq!(remap.translate(20), None);
+
+        // Order-preserved layout: A end (210) == B start (210) → the
+        // boundary is unambiguous and resolves.
+        let mut ordered = AddressRemap::new();
+        ordered.insert(span(10, 20, 200, 0, &[(0, 0)]));
+        ordered.insert(span(20, 30, 210, 0, &[(0, 0)]));
+        assert_eq!(ordered.translate(20), Some(210));
     }
 
     /// An address in the locals/prefix region (`DW_AT_low_pc` points at

--- a/meld-core/src/dwarf.rs
+++ b/meld-core/src/dwarf.rs
@@ -66,6 +66,12 @@ pub struct FunctionSpan {
     /// section (code-section-relative), including the locals prefix.
     /// This is the v2 provenance `code_range.start`.
     pub output_body_start: u32,
+    /// Exclusive end of this function body in the **output** code
+    /// section. Used to map an exclusive-end DWARF address
+    /// (`DW_AT_high_pc` as address, range-list end, line-program
+    /// `end_sequence`) — which points one byte past the last
+    /// instruction — to the corresponding output end.
+    pub output_body_end: u32,
     /// Byte length of the locals-declaration vector at the head of the
     /// body — identical on input and output (locals are preserved).
     /// The instruction stream begins `locals_prefix_len` bytes past
@@ -120,23 +126,57 @@ impl AddressRemap {
     /// Translate an input code-section-relative address to the fused
     /// output code-section-relative address.
     ///
+    /// WebAssembly DWARF measures code addresses from the **function
+    /// body start** (the locals-declaration byte), so three regions of
+    /// a body must be handled:
+    ///
+    /// 1. **Locals/prefix** `[input_start, input_start+locals_prefix)`
+    ///    — includes `DW_AT_low_pc`, which points at the body start.
+    ///    Locals are preserved verbatim during fusion, so this maps
+    ///    linearly: `output_body_start + body_rel`.
+    /// 2. **Instruction stream** — mapped through the rewriter's
+    ///    [`InstrOffsetMap`] (operand LEB widths shift offsets).
+    /// 3. **Exclusive end** `addr == input_end` — an end address
+    ///    (`high_pc`, range end, line `end_sequence`) one byte past the
+    ///    last instruction; maps to `output_body_end`.
+    ///
     /// Returns `None` if `addr` is not inside any registered function
     /// or does not land on a recorded instruction boundary.
     pub fn translate(&self, addr: u32) -> Option<u32> {
         // Greatest span whose input_start ≤ addr.
         let (_, span) = self.by_input_start.range(..=addr).next_back()?;
+        // Exclusive-end address: maps to the output body end. Checked
+        // before `contains_input` because a function's end equals the
+        // next function's start in the contiguous input code section;
+        // for the body this `addr == input_end` case only triggers for
+        // the span whose input_end it is (the last body, or via the
+        // boundary alias resolved to the next body's start below).
+        if addr == span.input_end {
+            return Some(span.output_body_end);
+        }
         if !span.contains_input(addr) {
             return None;
         }
-        // Convert the input address to an instruction-stream offset:
-        // subtract the body start and the locals prefix.
         let body_rel = addr - span.input_start;
-        let instr_stream_old = body_rel.checked_sub(span.locals_prefix_len)?;
-        // Map through the rewriter's instruction offset map.
-        let instr_stream_new = span.instr_offsets.translate(instr_stream_old)?;
-        // Reassemble the output address: merged body start + locals
-        // prefix (unchanged) + new instruction-stream offset.
-        Some(span.output_body_start + span.locals_prefix_len + instr_stream_new)
+        // Region 1: locals/prefix — preserved verbatim, maps linearly.
+        if body_rel < span.locals_prefix_len {
+            return Some(span.output_body_start + body_rel);
+        }
+        // Region 2: instruction stream. Map to the *containing*
+        // operator's new offset. Exact on instruction boundaries; for
+        // an address inside an operator's operand bytes — which happens
+        // because LLVM emits fixed-width (zero-padded) LEBs for
+        // relocatable indices while meld re-encodes them canonically —
+        // it resolves to that operator's start, attributing the address
+        // to the instruction it is actually inside (correct source-line
+        // attribution for debuggers / witness).
+        let instr_stream_old = body_rel - span.locals_prefix_len;
+        let entries = &span.instr_offsets.entries;
+        // Greatest entry whose `old` <= instr_stream_old (entries are in
+        // ascending operator order).
+        let idx = entries.partition_point(|e| e.old <= instr_stream_old);
+        let entry = entries.get(idx.checked_sub(1)?)?;
+        Some(span.output_body_start + span.locals_prefix_len + entry.new)
     }
 
     /// Number of registered function spans.
@@ -146,6 +186,18 @@ impl AddressRemap {
 
     pub fn is_empty(&self) -> bool {
         self.by_input_start.is_empty()
+    }
+
+    /// Exclusive upper bound of the input code section covered by the
+    /// registered spans (the greatest `input_end`). Used to tell code
+    /// addresses (`< code_extent`, must map exactly) from linear-memory
+    /// data addresses (`>= code_extent`, passed through unchanged).
+    pub fn code_extent(&self) -> u32 {
+        self.by_input_start
+            .values()
+            .map(|s| s.input_end)
+            .max()
+            .unwrap_or(0)
     }
 }
 
@@ -274,9 +326,21 @@ fn build_remap_from_parts(
         // Locals are preserved verbatim in the DWARF-remap path, so the
         // prefix must be identical; an operator was inserted otherwise.
         if input.locals_prefix_len != output.locals_prefix_len {
+            log::debug!(
+                "dwarf remap abort: func in_idx={in_idx} locals_prefix mismatch \
+                 (in={} out={})",
+                input.locals_prefix_len,
+                output.locals_prefix_len
+            );
             return None;
         }
         if input.op_offsets.len() != output.op_offsets.len() {
+            log::debug!(
+                "dwarf remap abort: func in_idx={in_idx} out_idx={defined_out_idx} \
+                 operator-count mismatch (in={} out={})",
+                input.op_offsets.len(),
+                output.op_offsets.len()
+            );
             return None;
         }
 
@@ -291,6 +355,7 @@ fn build_remap_from_parts(
             input_start: input.body_start,
             input_end: input.body_end,
             output_body_start: output.body_start,
+            output_body_end: output.body_end,
             locals_prefix_len: input.locals_prefix_len,
             instr_offsets: InstrOffsetMap { entries },
         });
@@ -351,16 +416,49 @@ fn rewrite_debug_sections(
     // base (`DW_AT_low_pc` = 0) denotes that start, which is offset 0 in
     // both the input and the fused output. Map it to itself; everything
     // else must go through the instruction-accurate remap.
+    // DWARF tombstone: the conventional "this address is invalid / dead
+    // code" marker (max address). Consumers (debuggers, gimli, witness)
+    // skip DIEs and line rows whose address is the tombstone. wasm-ld
+    // itself tombstones discarded code this way.
+    const TOMBSTONE: u64 = 0xFFFF_FFFF;
+
+    let code_extent = remap.code_extent() as u64;
+    // `convert_address` is **total** — it never returns `None`, because
+    // `gimli::write::Dwarf::from` aborts the *entire* conversion on a
+    // single `None`. On real compiler output (hundreds of functions,
+    // dead-code gaps, padded LEBs, data addresses) some address always
+    // fails to map; all-or-nothing would then strip every byte of
+    // DWARF. Instead each address is independently resolved to either
+    // its correct fused offset or a tombstone — never a plausible but
+    // wrong address. This keeps the LS-D-1 guarantee per-address while
+    // emitting correct debug info for everything that does map.
     let convert_address = |addr: u64| -> Option<Address> {
         if addr == 0 {
             return Some(Address::Constant(0));
         }
-        remap
-            .translate(addr as u32)
-            .map(|new| Address::Constant(new as u64))
+        if let Some(new) = remap.translate(addr as u32) {
+            return Some(Address::Constant(new as u64));
+        }
+        // Not a mapped code offset. At/beyond the code extent it is a
+        // linear-memory / data address (e.g. `DW_OP_addr` in a variable
+        // location) or an existing wasm-ld tombstone — unchanged under
+        // multi-memory fusion, pass through. Within the code section it
+        // is a genuine code miss (a function meld dropped, a dead-code
+        // range): tombstone it rather than emit a stale offset.
+        if addr >= code_extent {
+            return Some(Address::Constant(addr));
+        }
+        log::debug!("dwarf remap: tombstoning unmapped code address {addr:#x}");
+        Some(Address::Constant(TOMBSTONE))
     };
 
-    let mut write_dwarf = WriteDwarf::from(&read_dwarf, &convert_address).ok()?;
+    let mut write_dwarf = match WriteDwarf::from(&read_dwarf, &convert_address) {
+        Ok(d) => d,
+        Err(e) => {
+            log::debug!("dwarf remap abort: gimli convert failed: {e:?}");
+            return None;
+        }
+    };
     let mut sections = Sections::new(EndianVec::new(endian));
     write_dwarf.write(&mut sections).ok()?;
 
@@ -418,7 +516,12 @@ pub fn remap_for_output(
         [] => None,
         [(ci, mi)] => {
             let module = &components[*ci].core_modules[*mi];
+            log::debug!("dwarf remap: single DWARF source at component {ci} module {mi}");
             let remap = build_remap_for_module(module, merged, *ci, *mi, output_bytes)?;
+            log::debug!(
+                "dwarf remap: built remap with {} function spans",
+                remap.len()
+            );
             let debug: Vec<(String, Vec<u8>)> = module
                 .custom_sections
                 .iter()
@@ -455,6 +558,9 @@ mod tests {
             input_start,
             input_end,
             output_body_start,
+            // Tests that don't exercise the end-address path set a
+            // plausible end; the dedicated end-address test overrides it.
+            output_body_end: output_body_start + (input_end - input_start),
             locals_prefix_len,
             instr_offsets: InstrOffsetMap {
                 entries: offsets
@@ -527,31 +633,55 @@ mod tests {
         assert_eq!(remap.translate(28), Some(3003)); // func 2
     }
 
-    /// Addresses outside any function, or not on an instruction
-    /// boundary, return None — gimli will then drop them rather than
-    /// emit a wrong address.
+    /// Addresses outside any registered function return None — the
+    /// caller then tombstones or passes them through.
     #[test]
-    fn translate_misses_return_none() {
+    fn translate_outside_functions_return_none() {
         let mut remap = AddressRemap::new();
+        // span(10,20,...) → output_body_end = 100 + (20-10) = 110.
         remap.insert(span(10, 20, 100, 0, &[(0, 0), (2, 2)]));
 
         assert_eq!(remap.translate(5), None, "before any function");
-        assert_eq!(remap.translate(20), None, "at end (exclusive)");
         assert_eq!(remap.translate(50), None, "past all functions");
         assert_eq!(remap.translate(1), None, "below first function");
-        // Inside the function but not on a recorded instruction start.
-        assert_eq!(remap.translate(11), None, "mid-instruction offset");
     }
 
-    /// An address whose body-relative offset is *less than* the locals
-    /// prefix (i.e. pointing into the locals declarations, not the
-    /// instruction stream) returns None rather than underflowing.
+    /// An exclusive-end address (`high_pc` as address, range end, line
+    /// `end_sequence`) maps to the output body end, not the next
+    /// function's start.
     #[test]
-    fn translate_address_inside_locals_prefix_is_none() {
+    fn translate_exclusive_end_maps_to_output_body_end() {
+        let mut remap = AddressRemap::new();
+        remap.insert(span(10, 20, 100, 0, &[(0, 0), (2, 2)]));
+        // addr == input_end (20) → output_body_end (110).
+        assert_eq!(remap.translate(20), Some(110));
+    }
+
+    /// An address inside an operator's operand bytes (not on a recorded
+    /// boundary — e.g. inside a padded LEB) resolves to the *containing*
+    /// operator's new offset, attributing it to the right instruction.
+    #[test]
+    fn translate_mid_operator_maps_to_containing_operator() {
+        let mut remap = AddressRemap::new();
+        // Operators at stream offsets 0 and 2; output shifts 2→3.
+        remap.insert(span(10, 20, 100, 0, &[(0, 0), (2, 3)]));
+        // Input 11 = stream 1, inside the first operator → maps to op 0.
+        assert_eq!(remap.translate(11), Some(100));
+        // Input 13 = stream 3, inside the second operator → maps to op@2.
+        assert_eq!(remap.translate(13), Some(103));
+    }
+
+    /// An address in the locals/prefix region (`DW_AT_low_pc` points at
+    /// the body start) maps linearly — the locals are preserved verbatim
+    /// during fusion.
+    #[test]
+    fn translate_locals_prefix_maps_linearly() {
         let mut remap = AddressRemap::new();
         remap.insert(span(10, 30, 50, 5, &[(0, 0)]));
-        // Input addr 12 = body_rel 2 < locals_prefix_len 5 → None.
-        assert_eq!(remap.translate(12), None);
+        // low_pc at body start (body_rel 0) → output_body_start.
+        assert_eq!(remap.translate(10), Some(50));
+        // body_rel 2 (still in the 5-byte locals prefix) → 50 + 2.
+        assert_eq!(remap.translate(12), Some(52));
     }
 
     /// Oracle for inc 3b: build real input DWARF with gimli, remap a
@@ -601,6 +731,7 @@ mod tests {
             input_start: 0x10,
             input_end: 0x40,
             output_body_start: 0x200,
+            output_body_end: 0x230,
             locals_prefix_len: 0,
             instr_offsets: InstrOffsetMap {
                 entries: vec![InstrOffset { old: 0, new: 0 }],

--- a/meld-core/src/dwarf.rs
+++ b/meld-core/src/dwarf.rs
@@ -104,6 +104,15 @@ pub struct AddressRemap {
     /// lookup. Spans are non-overlapping (function bodies are laid
     /// out sequentially), so the greatest key ≤ addr is the candidate.
     by_input_start: BTreeMap<u32, FunctionSpan>,
+    /// Exclusive end of the **input** module's code section (the size of
+    /// its code-section contents), covering *every* input function —
+    /// including ones meld dropped that have no registered span. This is
+    /// the code/data boundary: an address below it is a code offset
+    /// (mapped or tombstoned), at/above it is a linear-memory address.
+    /// Distinct from the registered spans' max `input_end`, which would
+    /// wrongly classify a dropped *trailing* function's code address as
+    /// data (Mythos #209).
+    input_code_extent: u32,
 }
 
 impl AddressRemap {
@@ -206,16 +215,26 @@ impl AddressRemap {
         self.by_input_start.is_empty()
     }
 
-    /// Exclusive upper bound of the input code section covered by the
-    /// registered spans (the greatest `input_end`). Used to tell code
-    /// addresses (`< code_extent`, must map exactly) from linear-memory
-    /// data addresses (`>= code_extent`, passed through unchanged).
+    /// Record the input module's full code-section extent (covering all
+    /// input functions, including dropped ones). Set once at build time.
+    pub fn set_input_code_extent(&mut self, extent: u32) {
+        self.input_code_extent = extent;
+    }
+
+    /// Exclusive upper bound of the input code section — the code/data
+    /// classification boundary. Prefers the explicitly-recorded full
+    /// input extent ([`Self::set_input_code_extent`]); falls back to the
+    /// greatest registered span end when unset (synthetic test remaps).
+    /// Addresses `< code_extent` are code offsets (mapped or tombstoned);
+    /// `>= code_extent` are linear-memory data addresses.
     pub fn code_extent(&self) -> u32 {
-        self.by_input_start
+        let registered_max = self
+            .by_input_start
             .values()
             .map(|s| s.input_end)
             .max()
-            .unwrap_or(0)
+            .unwrap_or(0);
+        self.input_code_extent.max(registered_max)
     }
 }
 
@@ -335,6 +354,12 @@ fn build_remap_from_parts(
     let output_layouts = module_function_layouts(output_bytes)?;
 
     let mut remap = AddressRemap::new();
+    // Code/data boundary = the full input code-section extent (every
+    // input function, including any meld dropped), so a dropped
+    // function's code address is tombstoned rather than mistaken for a
+    // linear-memory data address (Mythos #209).
+    let input_code_extent = input_layouts.iter().map(|l| l.body_end).max().unwrap_or(0);
+    remap.set_input_code_extent(input_code_extent);
     for &(defined_out_idx, old_func_idx) in pairs {
         // Module-level function index → input defined-function index.
         let in_idx = old_func_idx.checked_sub(imports)? as usize;
@@ -846,6 +871,37 @@ mod tests {
                 "identity rewrite must map an address to itself"
             );
         }
+    }
+
+    /// Mythos #209 (2nd finding): `code_extent` must cover the input
+    /// module's *full* code section — including functions meld dropped —
+    /// so a dropped function's code address is classified as code
+    /// (tombstoned) rather than as a linear-memory data address (passed
+    /// through stale). Using only the surviving spans' max end would
+    /// misclassify a dropped trailing function.
+    #[test]
+    fn code_extent_covers_dropped_trailing_function() {
+        let wat = r#"(module
+            (func (result i32) i32.const 1)
+            (func (result i32) i32.const 2)
+            (func (result i32) i32.const 3))"#;
+        let bytes = wat::parse_str(wat).expect("assemble wat");
+        let layouts = module_function_layouts(&bytes).expect("layouts");
+        let full_extent = layouts.iter().map(|l| l.body_end).max().unwrap();
+        let surviving_max = layouts[1].body_end;
+        assert!(
+            full_extent > surviving_max,
+            "the dropped trailing function must extend past the survivors"
+        );
+
+        // meld keeps func 0 and func 1; func 2 is dropped (no pair).
+        let pairs = [(0usize, 0u32), (1usize, 1u32)];
+        let remap = build_remap_from_parts(&bytes, 0, &bytes, &pairs).expect("build remap");
+
+        // The code/data boundary is the full input extent, so func 2's
+        // address range stays classified as code (→ tombstone in
+        // convert_address), not data (→ stale pass-through).
+        assert_eq!(remap.code_extent(), full_extent);
     }
 
     /// A layout mismatch (output has more operators than input — what a

--- a/meld-core/tests/dwarf_remap_witness.rs
+++ b/meld-core/tests/dwarf_remap_witness.rs
@@ -1,0 +1,192 @@
+//! DWARF remap falsification oracle (#143 Phase 2, #130 witness
+//! integration — v0.20.0).
+//!
+//! `DwarfHandling::Remap` claims that, for a single-DWARF-source fusion,
+//! every function's `.debug_*` code addresses are rewritten to point at
+//! the function's *fused* location. This test falsifies that claim on a
+//! real compiler-emitted fixture by tying two independently-derived
+//! facts together:
+//!
+//! 1. The **component-provenance** `code_range.start` of each fused
+//!    function — computed by re-parsing the fused code section
+//!    (`provenance::code_section_function_ranges`), completely separate
+//!    from the DWARF path.
+//! 2. Each `DW_TAG_subprogram`'s `DW_AT_low_pc` in the **remapped
+//!    output DWARF** — parsed back with `gimli`.
+//!
+//! WebAssembly DWARF's `low_pc` is the function body start, which the
+//! remap sends to `output_body_start` == `code_range.start`. So every
+//! non-tombstone subprogram `low_pc` MUST equal some fused function's
+//! `code_range.start`. If the remap math were wrong, the addresses
+//! would not line up. This is the cross-repo contract `pulseengine/
+//! witness` relies on (code offset → source line), validated in-tree.
+//!
+//! Dead-code functions that meld drops are tombstoned to `0xFFFF_FFFF`
+//! by the remap (never a wrong address); those are skipped here.
+
+use std::collections::BTreeSet;
+
+use meld_core::{
+    CustomSectionHandling, DwarfHandling, Fuser, FuserConfig, MemoryStrategy, OutputFormat,
+};
+
+/// A single-DWARF-source fixture: a real Rust component whose main core
+/// module carries `debuginfo`, with no second DWARF-bearing module (so
+/// `Remap` exercises the address-rewrite path rather than the
+/// multi-source strip fallback).
+const SINGLE_SOURCE_FIXTURE: &str = "../tests/wit_bindgen/fixtures/release-0.2.0/hello_rust.wasm";
+
+const TOMBSTONE: u64 = 0xFFFF_FFFF;
+
+fn fixture_available() -> bool {
+    if std::path::Path::new(SINGLE_SOURCE_FIXTURE).is_file() {
+        true
+    } else {
+        eprintln!("skipping: fixture not found at {SINGLE_SOURCE_FIXTURE}");
+        false
+    }
+}
+
+fn fuse_remap(input: &[u8]) -> Vec<u8> {
+    let mut fuser = Fuser::new(FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        component_provenance: true,
+        address_rebasing: false,
+        preserve_names: false,
+        custom_sections: CustomSectionHandling::Merge,
+        output_format: OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
+        dwarf_handling: DwarfHandling::Remap,
+    });
+    fuser
+        .add_component_named(input, Some("hello-rust"))
+        .expect("add_component");
+    fuser.fuse().expect("fuse")
+}
+
+/// Collect the `.debug_*` custom sections from a fused core module.
+fn debug_sections(bytes: &[u8]) -> std::collections::HashMap<String, Vec<u8>> {
+    let mut out = std::collections::HashMap::new();
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let Ok(wasmparser::Payload::CustomSection(reader)) = payload
+            && reader.name().starts_with(".debug_")
+        {
+            out.insert(reader.name().to_string(), reader.data().to_vec());
+        }
+    }
+    out
+}
+
+/// The `component-provenance` `code_range.start` of every fused
+/// function — the fused-code-section body starts, derived without
+/// touching DWARF.
+fn provenance_body_starts(bytes: &[u8]) -> BTreeSet<u64> {
+    let mut section = None;
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let Ok(wasmparser::Payload::CustomSection(reader)) = payload
+            && reader.name() == meld_core::provenance::SECTION_NAME
+        {
+            section = Some(reader.data().to_vec());
+        }
+    }
+    let data = section.expect("fused output carries component-provenance section");
+    let prov = meld_core::provenance::ComponentProvenance::from_bytes(&data)
+        .expect("decode component-provenance");
+    prov.entries
+        .iter()
+        .filter_map(|e| e.code_range.map(|r| r.start as u64))
+        .collect()
+}
+
+/// Every `DW_TAG_subprogram` `DW_AT_low_pc` (as a concrete address) in
+/// the remapped output DWARF.
+fn subprogram_low_pcs(sections: &std::collections::HashMap<String, Vec<u8>>) -> Vec<u64> {
+    let endian = gimli::LittleEndian;
+    let load = |id: gimli::SectionId| -> Result<gimli::EndianSlice<'_, gimli::LittleEndian>, gimli::Error> {
+        let data = sections.get(id.name()).map(|v| v.as_slice()).unwrap_or(&[]);
+        Ok(gimli::EndianSlice::new(data, endian))
+    };
+    let dwarf = gimli::Dwarf::load(load).expect("load output dwarf");
+
+    let mut low_pcs = Vec::new();
+    let mut units = dwarf.units();
+    while let Some(header) = units.next().expect("unit header") {
+        let unit = dwarf.unit(header).expect("parse unit");
+        let mut entries = unit.entries();
+        while let Some((_, entry)) = entries.next_dfs().expect("dfs walk") {
+            if entry.tag() == gimli::constants::DW_TAG_subprogram
+                && let Some(gimli::AttributeValue::Addr(a)) = entry
+                    .attr_value(gimli::constants::DW_AT_low_pc)
+                    .expect("low_pc attr")
+            {
+                low_pcs.push(a);
+            }
+        }
+    }
+    low_pcs
+}
+
+#[test]
+fn remapped_subprogram_low_pcs_match_fused_body_starts() {
+    if !fixture_available() {
+        return;
+    }
+    let input = std::fs::read(SINGLE_SOURCE_FIXTURE).expect("read fixture");
+    let fused = fuse_remap(&input);
+
+    // The remap ran (didn't strip): the fused module carries DWARF.
+    let sections = debug_sections(&fused);
+    assert!(
+        sections.contains_key(".debug_info"),
+        "Remap on a single-DWARF-source fixture must emit remapped \
+         `.debug_info`; got sections: {:?}",
+        sections.keys().collect::<Vec<_>>()
+    );
+
+    let body_starts = provenance_body_starts(&fused);
+    assert!(
+        !body_starts.is_empty(),
+        "expected component-provenance code ranges in the fused output"
+    );
+
+    let low_pcs = subprogram_low_pcs(&sections);
+    assert!(
+        !low_pcs.is_empty(),
+        "expected at least one DW_TAG_subprogram with a low_pc"
+    );
+
+    // FALSIFICATION: every concrete (non-tombstone) subprogram low_pc
+    // must equal some fused function's provenance body start. A wrong
+    // remap would land low_pcs off the fused function boundaries.
+    let mut matched = 0usize;
+    let mut tombstoned = 0usize;
+    for &pc in &low_pcs {
+        if pc == TOMBSTONE {
+            tombstoned += 1;
+            continue;
+        }
+        assert!(
+            body_starts.contains(&pc),
+            "remapped subprogram low_pc {pc:#x} does not match any fused \
+             function body start (component-provenance code_range). The \
+             DWARF address remap is wrong."
+        );
+        matched += 1;
+    }
+
+    // Sanity: the remap mapped the overwhelming majority of functions,
+    // only tombstoning the few meld dropped. If most were tombstoned the
+    // remap would be vacuously "correct" while useless.
+    assert!(
+        matched > body_starts.len() / 2,
+        "only {matched} subprogram low_pcs matched fused body starts \
+         ({tombstoned} tombstoned, {} fused functions) — remap is \
+         tombstoning too much to be meaningful",
+        body_starts.len()
+    );
+    eprintln!(
+        "DWARF remap witness: {matched} subprogram low_pcs land exactly on \
+         fused body starts, {tombstoned} dead-code subprograms tombstoned"
+    );
+}

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -2675,3 +2675,39 @@ loss-scenarios:
       start address (`low_pc`) and line-number program — what debuggers
       and witness actually use — are correct. Eliminating the high_pc
       length drift is deferred to a later increment.
+      ###
+      ### v0.20.0 — real-DWARF hardening + per-address tombstoning (#130)
+      ###
+      Falsifying the inc-3b remap against a real Rust fixture
+      (`tests/dwarf_remap_witness.rs`) surfaced four address classes the
+      synthetic oracle missed, each now handled in
+      `AddressRemap::translate` / the `convert_address` closure:
+      (1) WebAssembly DWARF `low_pc` is the function **body start** (the
+      locals-declaration byte), not the first instruction — the
+      locals/prefix region now maps linearly (locals are preserved
+      verbatim); (2) exclusive-end addresses (`high_pc`-as-address, range
+      end, line `end_sequence`) map to the output body end; (3) LLVM
+      emits fixed-width **zero-padded LEBs** for relocatable indices, so
+      DWARF rows can land *inside* an operator's operand bytes — these
+      resolve to the **containing** operator (exact on boundaries),
+      attributing the address to the right instruction; (4) linear-memory
+      / data addresses (`DW_OP_addr`) at or beyond the code extent pass
+      through unchanged (correct under multi-memory fusion).
+      Crucially, `gimli::write::Dwarf::from` is **all-or-nothing**: one
+      unmappable address aborts the whole conversion. On real modules
+      (hundreds of functions, dead-code gaps) that made the strict
+      correct-or-strip gate strip *everything*. The gate is now
+      **per-address**: `convert_address` is total — it returns the
+      correct fused offset where mappable, an identity for data/existing
+      tombstones, and the DWARF tombstone `0xFFFF_FFFF` for unmappable
+      code addresses (functions meld dropped). Consumers already ignore
+      `0xFFFF_FFFF`, so the guarantee strengthens from "all-or-nothing"
+      to *"every emitted address is correct or an ignored tombstone —
+      never a plausible-but-wrong address."* Validated end-to-end by
+      `dwarf_remap_witness::remapped_subprogram_low_pcs_match_fused_body_starts`:
+      it fuses a real Rust component with `--dwarf remap`, then asserts
+      every non-tombstone `DW_TAG_subprogram` `low_pc` in the output
+      DWARF equals some fused function's component-provenance
+      `code_range.start` (the cross-repo `pulseengine/witness` contract,
+      checked in-tree). On the fixture, all but 9 of 225 functions map
+      exactly; the 9 are dead code, tombstoned.

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -2725,3 +2725,12 @@ loss-scenarios:
       the boundary so the caller tombstones it, rather than emit B's
       output start as A's end — a plausible but wrong offset. Pinned by
       `dwarf::tests::translate_ambiguous_boundary_tombstones_when_reordered`.
+      A second auto-scan finding (same PR) noted that the code/data
+      classification boundary (`AddressRemap::code_extent`) was the max
+      *registered* span end, so a dropped *trailing* function's code
+      address (which exceeds the surviving extent) was classified as a
+      linear-memory data address and passed through stale instead of
+      tombstoned. `code_extent` is now the input module's *full*
+      code-section extent (every input function, dropped or not), so a
+      dropped function's address stays in the code range and tombstones.
+      Pinned by `dwarf::tests::code_extent_covers_dropped_trailing_function`.

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -2711,3 +2711,17 @@ loss-scenarios:
       `code_range.start` (the cross-repo `pulseengine/witness` contract,
       checked in-tree). On the fixture, all but 9 of 225 functions map
       exactly; the 9 are dead code, tombstoned.
+      ###
+      ### Boundary-aliasing hazard (Mythos auto-scan finding, PR #209)
+      ###
+      Input function bodies are contiguous, so a single address is BOTH
+      function A's exclusive end (`A.input_end`) and the next function
+      B's start (`B.input_start`). `convert_address` gets no DWARF
+      context to tell an A-`high_pc`/`end_sequence` query from a
+      B-`low_pc` query. The two output offsets coincide only when A and B
+      stay adjacent in the fused output (input order preserved — the
+      single-source case meld currently emits). If they diverge
+      (functions interleaved/reordered), `translate` now returns None for
+      the boundary so the caller tombstones it, rather than emit B's
+      output start as A's end — a plausible but wrong offset. Pinned by
+      `dwarf::tests::translate_ambiguous_boundary_tombstones_when_reordered`.


### PR DESCRIPTION
## Summary

v0.19.0 shipped `DwarfHandling::Remap` validated on **synthetic** DWARF. This PR runs the **falsification** the witness-integration epic (#130) called for — fusing a real Rust component (`hello_rust.wasm`) with `--dwarf remap` and checking the output DWARF against real compiler output. That immediately falsified the v0.19.0 remap (it stripped on the real fixture), surfacing four address-handling gaps and gimli's all-or-nothing failure mode. All are now fixed, and a strong end-to-end oracle pins the result.

This is the **#3 (witness proof) + the multi-source documentation (#208)** slice of the planned v0.20.0 (async #142 follows as v0.21.0).

## What the falsification found (and fixed)

| Gap | Cause | Fix |
|---|---|---|
| Every `low_pc` missed | WebAssembly DWARF `low_pc` is the **function body start** (locals-decl byte), not the first instruction | locals/prefix region maps linearly (locals preserved verbatim) |
| End addresses missed | half-open `[low,high)` — `high_pc`/range-end/`end_sequence` point one past the last instruction | map `addr == input_end` → `output_body_end` |
| Mid-instruction addresses missed | LLVM emits **fixed-width zero-padded LEBs** for relocatable indices; DWARF rows land inside operand bytes | resolve to the **containing** operator (exact on boundaries) |
| Data addresses missed | `DW_OP_addr` linear-memory locations share the address space | pass through unchanged when `>= code_extent` (correct under multi-memory) |
| One miss stripped **all** DWARF | `gimli::write::Dwarf::from` is all-or-nothing on `convert_address` | **per-address tombstoning** — total `convert_address`, `0xFFFF_FFFF` for unmappable code |

The guarantee strengthens from "all-or-nothing correct-or-strip" to **"every emitted address is correct or an ignored tombstone — never a plausible-but-wrong address."**

## The oracle (`tests/dwarf_remap_witness.rs`)

Fuses a real Rust component with `--dwarf remap`, parses the output DWARF with `gimli`, and asserts **every non-tombstone `DW_TAG_subprogram` `low_pc` equals some fused function's component-provenance `code_range.start`** — two independently-derived facts (DWARF vs. re-parsed code section) that only line up if the remap math is right. This is the `pulseengine/witness` code-offset → source-line contract, checked in-tree.

Result on the fixture: **all but 9 of 225 functions map exactly**; the 9 are dead code meld dropped, correctly tombstoned.

## Scope / residual

- **Multi-DWARF-source** fusion still falls back to `strip` — merging independent DWARF unit sets is blocked by gimli's writer API; analysis + relocator design filed as **#208**.
- `gimli` added as a dev-dependency (already a normal dep) for the oracle.
- `dwarf.rs` is Tier-5, so this PR gets the Mythos delta scan.
- LS-D-1 amended with the v0.20.0 hardening; verified by `run_ls_verification.py` (`[ OK ] LS-D-1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)