### PR TITLE
release: v0.22.0 — sound memory default + composed-export correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,76 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-11
+
+### Added
+
+- **`--memory auto` is the new default** for `meld fuse` and
+  `FuserConfig` (#172, SR-37, PR #220). Resolves to shared memory +
+  address rebasing **iff** no input core module contains `memory.grow`
+  (static probe, conservative on parse failure) and at least two
+  memories would be merged; multi-memory otherwise; a shared-plan
+  refusal retries as multi, so auto accepts every input multi accepts.
+  Out-of-the-box fused output now flows through `wasm-opt → synth`
+  with no extra flags whenever soundness permits (measured: the #172
+  repro passes `wasm-opt -Os` with no flags; explicit `--memory multi`
+  still reproduces the rejection). The PR's Mythos clean-room pass
+  found and fixed two real findings pre-merge: stale Auto resolution
+  on `Fuser` reuse (re-derived per fuse via `requested_memory`), and
+  a Merger split-brain on unresolved `Auto` (normalized at all three
+  public entry points). New UCA-M-11 + approved LS-M-7 with
+  gate-runnable `ls_m_7_*` regression tests.
+
+### Fixed
+
+- **Composed multi-component exports survive wrapping** (#212 items
+  2+3, LS-CP-5, PR #216). `wac`-composed inputs no longer come out as
+  an empty `world root {}`: canonical lifts are resolved by core-export
+  NAME (immune to the module-local vs component-level index-space
+  divergence that core imports cause), and the wrap source is ranked by
+  (depth-0 sections, instance-export count, prefer-original). Pinned by
+  an adversarial divergent-type two-export fixture and golden-e2e
+  Tier B (`fused composed runner == host-linked (42, 7)`).
+- **`CustomSectionHandling::Merge` actually merges** (#222, PR #223).
+  `producers` sections are merged field-wise per tool-conventions
+  (value names unique within a field — first-seen version wins);
+  `target_features` set-unioned; both emitted last in the canonical
+  order LLVM's wasm reader enforces. `llvm-dwarfdump` now reads the
+  fused `.debug_line` untouched (previously: hard `out of order
+  section type: 0` error on every fused module with duplicated
+  `producers`).
+
+### Infrastructure
+
+- **The merge gate is now real**: `main` requires `Test`, `Clippy`,
+  `Format`, `LS-N verification gate`, and `Mythos delta-pass gate`
+  (`strict` up-to-date, admins bound). The campaign-invariants audit
+  found `required_status_checks` had been EMPTY — every prior "CI-gated"
+  merge was gated by convention only. A companion docs-only stub
+  workflow (PR #224) reports the three code contexts instantly for
+  `paths-ignore`d changes so docs/safety PRs stay mergeable.
+- Roadmap v0.22.0 → v0.31.0 in `docs/roadmap.md` (PR #221), mirrored
+  to GitHub milestones; SR-33 honesty correction (detection shipped,
+  emitter did NOT — reverted to `planned`, rebuilt as v0.29.0 scope)
+  and SR-34/SR-35 traceability sync.
+
+### Pre-release Mythos note
+
+Tier-5 files changed since v0.21.0: `component_wrap.rs` (#216),
+`resolver.rs` + `merger.rs` (#220). Both PRs carried clean-room
+delta passes with findings comments and the `mythos-pass-done` label;
+#220's pass produced two provable findings, both fixed and
+regression-pinned in the same PR.
+
+### Falsification statement
+
+Claim: default `meld fuse a.component.wasm b.component.wasm -o fused.wasm`
+on grow-free inputs produces a single-memory module accepted by
+`wasm-opt -Os` with no feature flags. Refute by producing grow-free
+inputs (≥2 memories) whose default fusion emits >1 memory or is
+rejected by a standards-default validator — `tests/auto_memory.rs`
+encodes the oracle.
+
 ## [0.21.0] - 2026-05-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -862,7 +862,7 @@ artifacts:
       `wasm-opt → synth` chain with no extra flags (#172) without ever
       selecting the shared form where `memory.grow` makes it unsound
       (merger Bug #7, LS-M-7).
-    status: implemented
+    status: verified
     tags: [usability, memory-strategy, v0.22.0]
     links:
       - type: tracked-by

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -398,6 +398,25 @@ verification-status:
     status: planned
     note: "v0.11.0 — DWARF Phase 3 adapter DIEs (#144). Depends on SR-35."
 
+  SR-37:
+    implementation-files:
+      - meld-core/src/memory_probe.rs
+      - meld-core/src/lib.rs
+    tests:
+      - meld-core/tests/auto_memory.rs::auto_selects_shared_for_growfree_inputs
+      - meld-core/tests/auto_memory.rs::ls_m_7_auto_keeps_multi_when_input_grows
+      - meld-core/tests/auto_memory.rs::ls_m_7_auto_reprobes_after_add_component
+      - meld-core/tests/auto_memory.rs::auto_keeps_multi_for_single_memory_input
+      - meld-core/tests/auto_memory.rs::explicit_multi_is_not_overridden
+      - meld-core/src/memory_probe.rs::tests::ls_m_7_malformed_input_counts_as_grow
+    proofs: []
+    status: verified
+    note: >-
+      v0.22.0 (#172, PR #220). Verified: full oracle suite green on the
+      merged main commit through the required-checks gate (Test, Clippy,
+      LS-N gate incl. ls_m_7_*, Mythos delta-pass); manual wasm-opt 116
+      evidence on the issue repro recorded on #172 and in the PR body.
+
 # wit-bindgen fixture coverage (14 fixtures × 3 levels = 42 integration tests)
 wit-bindgen-fixtures:
   passing-all-3-levels:


### PR DESCRIPTION
Release PR per the standard process. Scope (all merged through the now-required gate):

- #220 — `--memory auto` default (#172, SR-37 → **verified** in this PR with traceability anchors)
- #216 — composed multi-component export fix (#212 items 2+3, LS-CP-5)
- #223 — producers/target_features coalescing (#222)
- #221 — roadmap v0.22→v0.31 + SR-33/34/35 honesty sync
- #224 — docs-only stub contexts (gate machinery)

**Pre-release Mythos:** Tier-5 deltas since v0.21.0 are `component_wrap.rs` (#216) and `resolver.rs`/`merger.rs` (#220); both PRs carried clean-room passes + `mythos-pass-done` (the #220 pass produced 2 provable findings, fixed in-PR).

**Falsification statement:** default fuse of grow-free inputs (≥2 memories) produces a single-memory module accepted by `wasm-opt -Os` with no flags — refute via `tests/auto_memory.rs`'s oracle.

After merge: tag `v0.22.0` once main CI is green; release verified only on a `success` release.yml run + #185 asset standard spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)