### PR TITLE
feat(dwarf): per-class <meld-adapter> lines + FACT-adapter coverage (#144 inc 4)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -15,7 +15,9 @@
 //! For static fusion, we generate similar adapters but inline them directly
 //! into the fused module rather than keeping them as separate adapter modules.
 
-use super::{AdapterConfig, AdapterFunction, AdapterGenerator, AdapterOptions, StringEncoding};
+use super::{
+    AdapterClass, AdapterConfig, AdapterFunction, AdapterGenerator, AdapterOptions, StringEncoding,
+};
 use crate::Result;
 use crate::merger::MergedModule;
 use crate::parser::CanonStringEncoding;
@@ -611,12 +613,16 @@ impl FactStyleGenerator {
             self.analyze_call_site(site, merged, resource_rep_imports, resource_new_imports);
 
         // Generate the adapter function body
-        let (type_idx, body) = if site.crosses_memory && options.needs_transcoding() {
-            self.generate_transcoding_adapter(site, merged, &options)?
+        let (type_idx, body, class) = if site.crosses_memory && options.needs_transcoding() {
+            let (t, b) = self.generate_transcoding_adapter(site, merged, &options)?;
+            (t, b, AdapterClass::Transcode)
         } else if site.crosses_memory {
-            self.generate_memory_copy_adapter(site, merged, &options, resource_rep_imports)?
+            let (t, b) =
+                self.generate_memory_copy_adapter(site, merged, &options, resource_rep_imports)?;
+            (t, b, AdapterClass::MemoryCopy)
         } else {
-            self.generate_direct_adapter(site, merged, &options)?
+            let (t, b) = self.generate_direct_adapter(site, merged, &options)?;
+            (t, b, AdapterClass::Direct)
         };
 
         Ok(AdapterFunction {
@@ -628,6 +634,7 @@ impl FactStyleGenerator {
             target_component: site.to_component,
             target_module: site.to_module,
             target_function: self.resolve_target_function(site, merged)?,
+            class,
         })
     }
 
@@ -4486,6 +4493,7 @@ impl FactStyleGenerator {
             target_component: site.to_component,
             target_module: site.to_module,
             target_function: target_func,
+            class: AdapterClass::Async,
         })
     }
 
@@ -5047,6 +5055,7 @@ impl FactStyleGenerator {
             target_component: site.to_component,
             target_module: site.to_module,
             target_function: target_func,
+            class: AdapterClass::Async,
         })
     }
 }
@@ -5702,6 +5711,7 @@ mod tests {
             type_idx: 0,
             body: wasm_encoder::Function::new([]),
             origin: (1, 0, 0),
+            synthetic_kind: None,
         });
         merged.types.push(crate::merger::MergedFuncType {
             params: Vec::new(),
@@ -5748,6 +5758,7 @@ mod tests {
             type_idx: 0,
             body: wasm_encoder::Function::new([]),
             origin: (1, 0, 0),
+            synthetic_kind: None,
         });
         merged.function_index_map.insert((1, 0, 0), 0);
 
@@ -5862,6 +5873,7 @@ mod tests {
             type_idx: 1,
             body: wasm_encoder::Function::new([]),
             origin: (1, 0, 0),
+            synthetic_kind: None,
         });
         merged.function_index_map.insert((1, 0, 0), 0);
 
@@ -5870,6 +5882,7 @@ mod tests {
             type_idx: 1,
             body: wasm_encoder::Function::new([]),
             origin: (0, 0, 0),
+            synthetic_kind: None,
         });
         merged.realloc_map.insert((0, 0), 1);
 
@@ -5987,6 +6000,7 @@ mod tests {
             type_idx: 1,
             body: wasm_encoder::Function::new([]),
             origin: (1, 0, 0),
+            synthetic_kind: None,
         });
         merged.function_index_map.insert((1, 0, 0), 0);
 
@@ -6092,6 +6106,7 @@ mod tests {
             type_idx: 0,
             body: wasm_encoder::Function::new([]),
             origin: (1, 0, 0),
+            synthetic_kind: None,
         });
         merged.function_index_map.insert((1, 0, 0), 0);
 

--- a/meld-core/src/adapter/mod.rs
+++ b/meld-core/src/adapter/mod.rs
@@ -47,6 +47,31 @@ impl Default for AdapterConfig {
     }
 }
 
+/// Class of a generated adapter, at the granularity meld actually emits
+/// (#144 inc 4 / #130 §Phase 3).
+///
+/// #130 sketched per-class attribution as "transcode / cabi_realloc /
+/// lift / lower", assuming wasmtime-FACT-style separate functions. meld
+/// emits ONE fused trampoline per call site, with lowering, allocation
+/// (a call to the callee's own `cabi_realloc`, not a meld-emitted one),
+/// copying, and lifting inline in that body — so the honest class
+/// granularity is per-trampoline-kind, matching the generator's actual
+/// dispatch. Consumed by `dwarf::adapter_spans` to assign per-class
+/// `<meld-adapter>` line numbers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdapterClass {
+    /// Thin call shim — same memory, no transcoding (direct adapter).
+    Direct,
+    /// Cross-memory `(ptr, len)` copy chain: lower → `cabi_realloc`
+    /// call → `memory.copy` → lift, fused in one body.
+    MemoryCopy,
+    /// Cross-memory + string-encoding conversion (UTF-8/UTF-16/Latin-1
+    /// transcode loop) fused in one body.
+    Transcode,
+    /// P3 async adapter (callback-driving or stackful trampoline).
+    Async,
+}
+
 /// A generated adapter function
 #[derive(Debug, Clone)]
 pub struct AdapterFunction {
@@ -67,6 +92,9 @@ pub struct AdapterFunction {
     pub target_component: usize,
     pub target_module: usize,
     pub target_function: u32,
+
+    /// Emitter class, for synthetic DWARF attribution (#144 inc 4).
+    pub class: AdapterClass,
 }
 
 /// Trait for adapter generators

--- a/meld-core/src/dwarf.rs
+++ b/meld-core/src/dwarf.rs
@@ -552,6 +552,7 @@ fn rewrite_debug_sections(
 pub fn remap_for_output(
     components: &[crate::parser::ParsedComponent],
     merged: &crate::merger::MergedModule,
+    adapter_classes: &[crate::adapter::AdapterClass],
     output_bytes: &[u8],
 ) -> Option<Vec<(String, Vec<u8>)>> {
     // Find every (comp_idx, mod_idx) whose module carries DWARF.
@@ -570,7 +571,7 @@ pub fn remap_for_output(
 
     // #144: which fused-output ranges are meld-generated. Computed once;
     // attributed to `<meld-adapter>` in every branch below.
-    let spans = adapter_spans(merged, output_bytes);
+    let spans = adapter_spans(merged, adapter_classes, output_bytes);
 
     match dwarf_sources.as_slice() {
         [] => {
@@ -649,16 +650,71 @@ pub fn remap_for_output(
 /// time and land in a follow-up increment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AdapterRole {
-    /// meld-generated, role not yet classified (placeholder line 0).
+    /// meld-generated, class not determinable (fallback).
     Generated,
+    /// FACT direct call shim — same memory, no transcoding.
+    Direct,
+    /// FACT cross-memory `(ptr, len)` copy chain (lower → callee
+    /// `cabi_realloc` → `memory.copy` → lift, fused in one body).
+    MemoryCopy,
+    /// FACT cross-memory + string-encoding transcode loop.
+    Transcode,
+    /// P3 async adapter (callback-driving or stackful trampoline).
+    Async,
+    /// Merger handle-table helper (`ht_new` / `ht_rep` / `ht_drop`).
+    HandleTable,
+    /// Merger multi-`start` wrapper.
+    StartWrapper,
+    /// Type-coercion shim wrapping a FACT adapter call (i32/i64 glue).
+    AdapterShim,
+    /// P3 async `task.return` result-global shim.
+    TaskReturnShim,
 }
 
 impl AdapterRole {
     /// Line number in the synthetic `<meld-adapter>` file encoding this
-    /// role, per #130 §"Phase 3".
+    /// role (#144 inc 4). Line 0 means "no source line" in DWARF, so the
+    /// mapping starts at 1; the assignment is a stable contract consumed
+    /// by witness's adapter-branch classification.
+    ///
+    /// Note on granularity vs #130's sketch ("transcode / cabi_realloc /
+    /// lift / lower"): meld emits ONE fused trampoline per call site —
+    /// lowering, allocation (a call to the callee's own `cabi_realloc`),
+    /// copying and lifting live inline in a single body — so the honest
+    /// class unit is the trampoline kind, not sub-function stages.
     pub fn adapter_line(self) -> u32 {
         match self {
-            AdapterRole::Generated => 0,
+            AdapterRole::Generated => 1,
+            AdapterRole::Direct => 2,
+            AdapterRole::MemoryCopy => 3,
+            AdapterRole::Transcode => 4,
+            AdapterRole::Async => 5,
+            AdapterRole::HandleTable => 6,
+            AdapterRole::StartWrapper => 7,
+            AdapterRole::AdapterShim => 8,
+            AdapterRole::TaskReturnShim => 9,
+        }
+    }
+}
+
+impl From<crate::adapter::AdapterClass> for AdapterRole {
+    fn from(class: crate::adapter::AdapterClass) -> Self {
+        match class {
+            crate::adapter::AdapterClass::Direct => AdapterRole::Direct,
+            crate::adapter::AdapterClass::MemoryCopy => AdapterRole::MemoryCopy,
+            crate::adapter::AdapterClass::Transcode => AdapterRole::Transcode,
+            crate::adapter::AdapterClass::Async => AdapterRole::Async,
+        }
+    }
+}
+
+impl From<crate::merger::SyntheticKind> for AdapterRole {
+    fn from(kind: crate::merger::SyntheticKind) -> Self {
+        match kind {
+            crate::merger::SyntheticKind::HandleTable => AdapterRole::HandleTable,
+            crate::merger::SyntheticKind::StartWrapper => AdapterRole::StartWrapper,
+            crate::merger::SyntheticKind::AdapterShim => AdapterRole::AdapterShim,
+            crate::merger::SyntheticKind::TaskReturnShim => AdapterRole::TaskReturnShim,
         }
     }
 }
@@ -709,32 +765,48 @@ fn is_generated_origin(origin: (usize, usize, u32)) -> bool {
 /// functions.
 pub fn adapter_spans(
     merged: &crate::merger::MergedModule,
+    adapter_classes: &[crate::adapter::AdapterClass],
     output_bytes: &[u8],
 ) -> Vec<AdapterSpan> {
-    let origins: Vec<(usize, usize, u32)> = merged.functions.iter().map(|f| f.origin).collect();
-    adapter_spans_from_parts(&origins, output_bytes)
+    // Roles for merged.functions (None = real source function), followed
+    // by the FACT adapters the encoder appends AFTER merged.functions in
+    // the output code section — previously un-enumerated (#144 inc 4),
+    // which left every FACT trampoline unattributed.
+    let mut roles: Vec<Option<AdapterRole>> = merged
+        .functions
+        .iter()
+        .map(|f| {
+            f.synthetic_kind.map(AdapterRole::from).or_else(|| {
+                // Sentinel origin without a kind tag (future generator
+                // paths): still attribute, as the unclassified fallback.
+                is_generated_origin(f.origin).then_some(AdapterRole::Generated)
+            })
+        })
+        .collect();
+    roles.extend(adapter_classes.iter().map(|c| Some(AdapterRole::from(*c))));
+    adapter_spans_from_parts(&roles, output_bytes)
 }
 
-/// Testable core of [`adapter_spans`]: `origins[i]` is the origin tuple of
-/// fused-output defined-function `i`.
+/// Testable core of [`adapter_spans`]: `roles[i]` is `Some(role)` when
+/// fused-output defined-function `i` is meld-generated.
 fn adapter_spans_from_parts(
-    origins: &[(usize, usize, u32)],
+    roles: &[Option<AdapterRole>],
     output_bytes: &[u8],
 ) -> Vec<AdapterSpan> {
     let Some(layouts) = module_function_layouts(output_bytes) else {
         return Vec::new();
     };
-    origins
+    roles
         .iter()
         .enumerate()
-        .filter(|(_, origin)| is_generated_origin(**origin))
-        .filter_map(|(out_idx, _)| {
+        .filter_map(|(out_idx, role)| {
+            let role = (*role)?;
             let l = layouts.get(out_idx)?;
             Some(AdapterSpan {
                 output_defined_idx: out_idx,
                 output_body_start: l.body_start,
                 output_body_end: l.body_end,
-                role: AdapterRole::Generated,
+                role,
             })
         })
         .collect()
@@ -752,9 +824,7 @@ fn adapter_spans_from_parts(
 /// enum and [`AdapterRole::adapter_line`] are the seam that refinement
 /// will populate.
 fn emitted_adapter_line(role: AdapterRole) -> u64 {
-    match role {
-        AdapterRole::Generated => 1,
-    }
+    u64::from(role.adapter_line())
 }
 
 /// Build a fresh, synthetic DWARF unit attributing each adapter span's
@@ -1218,17 +1288,13 @@ mod tests {
             (func (result i32) i32.const 3))"#;
         let bytes = wat::parse_str(wat).expect("assemble wat");
         // func 1 is meld-generated; 0 and 2 are original source.
-        let origins = [
-            (0usize, 0usize, 0u32),
-            (0usize, 0usize, u32::MAX),
-            (0usize, 0usize, 2u32),
-        ];
+        let roles = [None, Some(AdapterRole::Generated), None];
 
-        let spans = adapter_spans_from_parts(&origins, &bytes);
+        let spans = adapter_spans_from_parts(&roles, &bytes);
         assert_eq!(spans.len(), 1, "exactly one generated function");
         assert_eq!(spans[0].output_defined_idx, 1);
         assert_eq!(spans[0].role, AdapterRole::Generated);
-        assert_eq!(spans[0].role.adapter_line(), 0);
+        assert_eq!(spans[0].role.adapter_line(), 1);
 
         // The span must match func 1's real layout in the output.
         let layouts = module_function_layouts(&bytes).expect("layouts");
@@ -1246,11 +1312,12 @@ mod tests {
     fn adapter_spans_recognises_fully_synthetic_sentinel() {
         let wat = r#"(module (func (result i32) i32.const 7))"#;
         let bytes = wat::parse_str(wat).expect("assemble wat");
-        let origins = [(usize::MAX, usize::MAX, 0u32)];
+        let roles = [Some(AdapterRole::StartWrapper)];
 
-        let spans = adapter_spans_from_parts(&origins, &bytes);
+        let spans = adapter_spans_from_parts(&roles, &bytes);
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].output_defined_idx, 0);
+        assert_eq!(spans[0].role.adapter_line(), 7);
     }
 
     /// An all-original module produces no adapter spans.
@@ -1260,8 +1327,8 @@ mod tests {
             (func (result i32) i32.const 1)
             (func (result i32) i32.const 2))"#;
         let bytes = wat::parse_str(wat).expect("assemble wat");
-        let origins = [(0usize, 0usize, 0u32), (0usize, 1usize, 1u32)];
-        assert!(adapter_spans_from_parts(&origins, &bytes).is_empty());
+        let roles = [None, None];
+        assert!(adapter_spans_from_parts(&roles, &bytes).is_empty());
     }
 
     /// Adapter ranges must be disjoint from every source-function range —
@@ -1274,17 +1341,13 @@ mod tests {
             (func (result i32) i32.const 2)
             (func (result i32) i32.const 3))"#;
         let bytes = wat::parse_str(wat).expect("assemble wat");
-        let origins = [
-            (0usize, 0usize, 0u32),
-            (0usize, 0usize, u32::MAX), // generated
-            (0usize, 0usize, 2u32),
-        ];
+        let roles = [None, Some(AdapterRole::MemoryCopy), None];
 
-        let adapters = adapter_spans_from_parts(&origins, &bytes);
+        let adapters = adapter_spans_from_parts(&roles, &bytes);
         let layouts = module_function_layouts(&bytes).expect("layouts");
         for a in &adapters {
             for (i, l) in layouts.iter().enumerate() {
-                if is_generated_origin(origins[i]) {
+                if roles[i].is_some() {
                     continue;
                 }
                 let disjoint =
@@ -1377,6 +1440,94 @@ mod tests {
     #[test]
     fn build_adapter_dwarf_none_when_no_spans() {
         assert!(build_adapter_dwarf(&[]).is_none());
+    }
+
+    /// #144 inc 4: every adapter class maps to a distinct, non-zero
+    /// `<meld-adapter>` line — the stable contract witness consumes.
+    /// Line 0 means "no source line" in DWARF and would read back as
+    /// `unknown`; two classes sharing a line would be indistinguishable.
+    #[test]
+    fn adapter_lines_are_distinct_and_nonzero() {
+        let all = [
+            AdapterRole::Generated,
+            AdapterRole::Direct,
+            AdapterRole::MemoryCopy,
+            AdapterRole::Transcode,
+            AdapterRole::Async,
+            AdapterRole::HandleTable,
+            AdapterRole::StartWrapper,
+            AdapterRole::AdapterShim,
+            AdapterRole::TaskReturnShim,
+        ];
+        let mut seen = std::collections::BTreeSet::new();
+        for role in all {
+            let line = role.adapter_line();
+            assert!(line > 0, "{role:?} must not use DWARF line 0");
+            assert!(seen.insert(line), "{role:?} reuses line {line}");
+        }
+    }
+
+    /// #144 inc 4: spans carry per-class roles and the indices stay
+    /// aligned with output layout — including entries appended AFTER the
+    /// merged functions (the FACT-adapter positions that were previously
+    /// un-enumerated). Round-trip through `build_adapter_dwarf` and
+    /// assert each address resolves to its class's line.
+    #[test]
+    fn per_class_spans_round_trip_to_distinct_lines() {
+        use gimli::{EndianSlice, LittleEndian};
+
+        let wat = r#"(module
+            (func (result i32) i32.const 1)
+            (func (result i32) i32.const 2)
+            (func (result i32) i32.const 3))"#;
+        let bytes = wat::parse_str(wat).expect("assemble wat");
+        // func 0 = real source; func 1 = merger handle-table helper;
+        // func 2 = appended FACT transcode adapter.
+        let roles = [
+            None,
+            Some(AdapterRole::HandleTable),
+            Some(AdapterRole::Transcode),
+        ];
+        let spans = adapter_spans_from_parts(&roles, &bytes);
+        assert_eq!(spans.len(), 2);
+
+        let sections = build_adapter_dwarf(&spans).expect("build");
+        let section_data = |name: &str| -> &[u8] {
+            sections
+                .iter()
+                .find(|(n, _)| n == name)
+                .map(|(_, d)| d.as_slice())
+                .unwrap_or(&[])
+        };
+        let load = |id: gimli::SectionId| -> Result<EndianSlice<'_, LittleEndian>, gimli::Error> {
+            Ok(EndianSlice::new(section_data(id.name()), LittleEndian))
+        };
+        let dwarf = gimli::Dwarf::load(load).expect("load");
+        let mut by_addr = std::collections::BTreeMap::new();
+        let mut units = dwarf.units();
+        while let Some(header) = units.next().expect("units") {
+            let unit = dwarf.unit(header).expect("unit");
+            let Some(program) = unit.line_program.clone() else {
+                continue;
+            };
+            let mut rows = program.rows();
+            while let Some((_, row)) = rows.next_row().expect("row") {
+                if !row.end_sequence() {
+                    by_addr.insert(row.address(), row.line().map_or(0, |l| l.get()));
+                }
+            }
+        }
+        for span in &spans {
+            assert_eq!(
+                by_addr.get(&u64::from(span.output_body_start)).copied(),
+                Some(u64::from(span.role.adapter_line())),
+                "span at {:#x} must resolve to its class line",
+                span.output_body_start
+            );
+        }
+        // And the two classes resolved to DIFFERENT lines.
+        let lines: std::collections::BTreeSet<u64> = by_addr.values().copied().collect();
+        assert_eq!(lines.len(), 2, "two classes, two distinct lines");
     }
 
     /// Inc 3 oracle: source DWARF and the synthetic `<meld-adapter>` unit

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -579,13 +579,22 @@ impl Fuser {
 
         // Build the remapped `.debug_*` sections (only under Remap; a
         // miss or unsupported shape returns no sections → DWARF stripped).
-        let dwarf_sections: Vec<(String, Vec<u8>)> = if self.config.dwarf_handling
-            == DwarfHandling::Remap
-        {
-            dwarf::remap_for_output(&self.components, &merged, &bytes_for_remap).unwrap_or_default()
-        } else {
-            Vec::new()
-        };
+        let dwarf_sections: Vec<(String, Vec<u8>)> =
+            if self.config.dwarf_handling == DwarfHandling::Remap {
+                {
+                    let adapter_classes: Vec<adapter::AdapterClass> =
+                        adapters.iter().map(|a| a.class).collect();
+                    dwarf::remap_for_output(
+                        &self.components,
+                        &merged,
+                        &adapter_classes,
+                        &bytes_for_remap,
+                    )
+                    .unwrap_or_default()
+                }
+            } else {
+                Vec::new()
+            };
 
         // Pass B: re-encode with the remapped DWARF embedded. These are
         // the bytes the attestation/provenance hashes cover.
@@ -806,6 +815,7 @@ impl Fuser {
                 type_idx: info.caller_type_idx,
                 body,
                 origin: (info.comp_idx, info.mod_idx, u32::MAX),
+                synthetic_kind: Some(merger::SyntheticKind::AdapterShim),
             });
             affected_modules.insert((info.comp_idx, info.mod_idx));
         }
@@ -1224,6 +1234,7 @@ impl Fuser {
                 type_idx: shim_type,
                 body,
                 origin: (comp_idx, 0, u32::MAX),
+                synthetic_kind: Some(merger::SyntheticKind::TaskReturnShim),
             });
 
             // Export the shim so the component wrapper can alias it

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -218,6 +218,25 @@ pub struct MergedFunction {
     pub body: Function,
     /// Original location (component_idx, module_idx, function_idx)
     pub origin: (usize, usize, u32),
+    /// What kind of meld-generated helper this is, when the function is
+    /// synthetic (`origin` carries a sentinel). `None` for functions
+    /// copied from input modules. Consumed by `dwarf::adapter_spans`
+    /// for per-class `<meld-adapter>` attribution (#144 inc 4).
+    pub synthetic_kind: Option<SyntheticKind>,
+}
+
+/// Kind of merger-emitted synthetic function (#144 inc 4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyntheticKind {
+    /// Per-resource handle-table helper (`ht_new` / `ht_rep` / `ht_drop`).
+    HandleTable,
+    /// Wrapper calling every input module's `start` function in order.
+    StartWrapper,
+    /// Type-coercion shim wrapping a call to a FACT adapter (i32/i64
+    /// widening glue between the caller's import type and the adapter).
+    AdapterShim,
+    /// P3 async `task.return` shim storing results into result globals.
+    TaskReturnShim,
 }
 
 /// Global in merged module
@@ -737,6 +756,7 @@ impl Merger {
                     type_idx: type_i32_to_i32,
                     body,
                     origin: (comp_idx, 0, u32::MAX), // synthetic
+                    synthetic_kind: Some(SyntheticKind::HandleTable),
                 });
             }
 
@@ -751,6 +771,7 @@ impl Merger {
                     type_idx: type_i32_to_i32,
                     body,
                     origin: (comp_idx, 0, u32::MAX),
+                    synthetic_kind: Some(SyntheticKind::HandleTable),
                 });
             }
 
@@ -840,6 +861,7 @@ impl Merger {
                     type_idx: type_i32_to_void,
                     body,
                     origin: (comp_idx, 0, u32::MAX),
+                    synthetic_kind: Some(SyntheticKind::HandleTable),
                 });
             }
 
@@ -1843,6 +1865,7 @@ impl Merger {
                 type_idx: new_type_idx,
                 body,
                 origin: (comp_idx, mod_idx, old_func_idx),
+                synthetic_kind: None,
             });
         }
 
@@ -2474,6 +2497,7 @@ impl Merger {
                 type_idx: empty_type_idx,
                 body: wrapper,
                 origin: (usize::MAX, usize::MAX, 0), // synthetic function
+                synthetic_kind: Some(SyntheticKind::StartWrapper),
             });
 
             log::info!(

--- a/meld-core/tests/adapter_dwarf_e2e.rs
+++ b/meld-core/tests/adapter_dwarf_e2e.rs
@@ -157,9 +157,12 @@ fn debug_line_rows(wasm: &[u8]) -> Vec<(u64, String, u64)> {
 
 /// The pipeline contract: dwarf-less inputs whose fusion generates code
 /// produce a fused output whose `.debug_line` attributes the generated
-/// range to `<meld-adapter>:1`, at an address that is a real function
-/// body start (independently derived). (`ls_d_2_` prefix: LS-D-2
-/// regression, run by the LS-N verification gate.)
+/// range to `<meld-adapter>:<class-line>`, at an address that is a real
+/// function body start (independently derived). Since #144 inc 4 the
+/// line encodes the adapter CLASS — the only generated function in this
+/// fixture is the merger's multi-`start` wrapper, so every adapter row
+/// must carry [`AdapterRole::StartWrapper`]'s line. (`ls_d_2_` prefix:
+/// LS-D-2 regression, run by the LS-N verification gate.)
 #[test]
 fn ls_d_2_generated_start_wrapper_is_attributed_to_meld_adapter() {
     let fused = fuse_remap();
@@ -174,8 +177,13 @@ fn ls_d_2_generated_start_wrapper_is_attributed_to_meld_adapter() {
         "fusion generated a start wrapper; output .debug_line must carry \
          <meld-adapter> attribution (rows: {rows:?})"
     );
+    let start_wrapper_line = u64::from(meld_core::dwarf::AdapterRole::StartWrapper.adapter_line());
+    assert!(start_wrapper_line > 0, "line 0 means 'no line' in DWARF");
     for (_, _, line) in &adapter_rows {
-        assert_eq!(*line, 1, "adapter line must be 1 (0 means 'no line')");
+        assert_eq!(
+            *line, start_wrapper_line,
+            "the start wrapper must attribute to its CLASS line (#144 inc 4)"
+        );
     }
 
     let ranges = function_body_ranges(&fused);

--- a/meld-core/tests/dwarf_passthrough.rs
+++ b/meld-core/tests/dwarf_passthrough.rs
@@ -400,17 +400,17 @@ fn remap_policy_falls_back_to_strip_on_multi_dwarf_source() {
     // `lists.wasm` embeds more than one core module carrying DWARF (two
     // `.debug_info` sections — verified at fixture-selection time).
     // Merging independent DWARF unit sets into one consistent
-    // `.debug_info` against the fused code section is deferred to a
-    // later increment; the honest behaviour is to strip rather than
-    // emit one source's addresses (wrong for the other). This pins that
-    // fallback: Remap on a multi-source fixture yields NO `.debug_*`.
+    // `.debug_info` against the fused code section is deferred (#208);
+    // the honest behaviour is to drop the SOURCE DWARF rather than emit
+    // one source's addresses (wrong for the other).
     //
-    // The single-source happy path (addresses actually remapped) is
-    // covered mechanically by the `dwarf` module unit tests:
-    // `rewrite_debug_sections_translates_low_pc` (full gimli
-    // read→convert→write→read round-trip) and
-    // `build_remap_from_parts_identity_walk` (remap built from real
-    // wasm bytes).
+    // Since #144 inc 3/4 the multi-source case still emits the
+    // synthetic `<meld-adapter>` unit when the fusion generated code —
+    // it references only meld-generated ranges, so no wrong source
+    // addresses are involved. The invariant this test pins is therefore
+    // "no SOURCE DWARF leaks": any emitted `.debug_*` must form exactly
+    // one compilation unit whose every line row attributes to
+    // `<meld-adapter>` — never to a real source file.
     if !fixture_available() {
         return;
     }
@@ -426,11 +426,68 @@ fn remap_policy_falls_back_to_strip_on_multi_dwarf_source() {
     );
 
     let fused = fuse_remap(&bytes);
-    let counts = count_dwarf_sections_at_top_level(&fused);
-    assert!(
-        counts.is_empty(),
-        "Remap must fall back to stripping when >1 source module carries \
-         DWARF (never emit wrong addresses). Saw: {counts:?}"
+
+    // Collect emitted .debug_* and parse them with gimli.
+    let mut sections: Vec<(String, Vec<u8>)> = Vec::new();
+    for payload in wasmparser::Parser::new(0).parse_all(&fused) {
+        if let Ok(wasmparser::Payload::CustomSection(r)) = payload
+            && r.name().starts_with(".debug_")
+        {
+            sections.push((r.name().to_string(), r.data().to_vec()));
+        }
+    }
+    if sections.is_empty() {
+        // Also a valid outcome: the fusion generated no code to
+        // attribute, so nothing is emitted at all.
+        return;
+    }
+
+    use gimli::{EndianSlice, LittleEndian};
+    let section_data = |name: &str| -> &[u8] {
+        sections
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, d)| d.as_slice())
+            .unwrap_or(&[])
+    };
+    let load = |id: gimli::SectionId| -> Result<EndianSlice<'_, LittleEndian>, gimli::Error> {
+        Ok(EndianSlice::new(section_data(id.name()), LittleEndian))
+    };
+    let dwarf = gimli::Dwarf::load(load).expect("emitted DWARF must parse");
+
+    let mut unit_count = 0usize;
+    let mut units = dwarf.units();
+    while let Some(header) = units.next().expect("units") {
+        unit_count += 1;
+        let unit = dwarf.unit(header).expect("unit");
+        let Some(program) = unit.line_program.clone() else {
+            continue;
+        };
+        let mut rows = program.rows();
+        while let Some((hdr, row)) = rows.next_row().expect("row") {
+            if row.end_sequence() {
+                continue;
+            }
+            let fname = row
+                .file(hdr)
+                .map(|f| match f.path_name() {
+                    gimli::AttributeValue::String(s) => {
+                        String::from_utf8_lossy(s.slice()).into_owned()
+                    }
+                    _ => String::new(),
+                })
+                .unwrap_or_default();
+            assert_eq!(
+                fname, "<meld-adapter>",
+                "multi-DWARF-source fusion must never leak SOURCE \
+                 attribution (wrong addresses for at least one source); \
+                 only the synthetic adapter unit is allowed"
+            );
+        }
+    }
+    assert_eq!(
+        unit_count, 1,
+        "multi-source fusion may emit exactly the one synthetic unit"
     );
 }
 

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -837,12 +837,23 @@ artifacts:
       source units (one shared offset space; concatenating separately
       serialised `.debug_*` bytes would collide), and is emitted even
       when no input carries DWARF, so adapter attribution never depends
-      on debug-built inputs. Increment 4 (pending, v0.24.0): per-class
-      `<meld-adapter>` line numbers (requires the merger to tag each
-      synthetic function's adapter class at generation time). All
-      generated code currently attributes to line 1.
+      on debug-built inputs. Increment 4 (v0.24.0): per-class
+      `<meld-adapter>` lines. The merger tags synthetic functions
+      (`MergedFunction::synthetic_kind`: handle-table, start wrapper,
+      adapter shim, task-return shim) and the FACT generator tags each
+      `AdapterFunction` (`AdapterClass`: direct, memory-copy, transcode,
+      async); `dwarf::adapter_spans` additionally enumerates the FACT
+      trampolines appended after the merged functions — previously a
+      coverage gap leaving every FACT adapter unattributed. Stable line
+      contract (`AdapterRole::adapter_line`): 1 unclassified, 2 direct,
+      3 memory-copy, 4 transcode, 5 async, 6 handle-table, 7 start
+      wrapper, 8 adapter shim, 9 task-return shim. Granularity
+      correction vs #130's sketch ("transcode/cabi_realloc/lift/lower"):
+      meld emits ONE fused trampoline per call site with lowering,
+      allocation (a call to the callee's own cabi_realloc) and lifting
+      inline, so the honest class unit is the trampoline kind.
     status: implemented
-    tags: [roadmap, dwarf, witness-mc-dc, v0.23.0]
+    tags: [roadmap, dwarf, witness-mc-dc, v0.23.0, v0.24.0]
     links:
       - type: derives-from
         target: "#130"


### PR DESCRIPTION
Final increment of #144 (v0.24.0 scope). Closes #144.

## What

- **Classification at generation time** (Tier-5): `MergedFunction::synthetic_kind` (handle-table / start-wrapper / adapter-shim / task-return-shim, set at all four emission sites) and `AdapterFunction::class` (direct / memory-copy / transcode from the FACT generator's real dispatch; async for callback/stackful trampolines).
- **Coverage fix**: `dwarf::adapter_spans` now also enumerates the FACT trampolines appended AFTER `merged.functions` in the output code section — previously un-enumerated, so every FACT adapter (the bulk of generated code in real fusions) was unattributed.
- **Stable line contract** (`AdapterRole::adapter_line`): 1 unclassified · 2 direct · 3 memory-copy · 4 transcode · 5 async · 6 handle-table · 7 start-wrapper · 8 adapter-shim · 9 task-return-shim.
- **Granularity correction vs #130** recorded in SR-36: meld emits ONE fused trampoline per call site (lower + callee-`cabi_realloc` call + copy + lift inline), so the honest class unit is the trampoline kind — not the per-stage "transcode/cabi_realloc/lift/lower" split #130 sketched assuming wasmtime-FACT-style separate functions.

## Oracles

- `adapter_lines_are_distinct_and_nonzero` — contract pin (no DWARF line 0, no collisions).
- `per_class_spans_round_trip_to_distinct_lines` — write→read: each span resolves to its class's line, including appended-position indices (the coverage-gap shape).
- `ls_d_2_generated_start_wrapper_is_attributed_to_meld_adapter` upgraded: the start wrapper must attribute to its CLASS line end-to-end through the full pipeline.

## Tier-5 note

`merger.rs`, `adapter/mod.rs`, `adapter/fact.rs` changed (field additions + tagging at existing emission sites; no decision-logic changes). Mythos clean-room pass to follow as comment + `mythos-pass-done` label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)