### PR TITLE
feat(dwarf): DwarfHandling::Remap is the default (#143 closeout)

### DIFF
--- a/meld-cli/src/main.rs
+++ b/meld-cli/src/main.rs
@@ -85,13 +85,15 @@ enum Commands {
         #[arg(long)]
         no_component_provenance: bool,
 
-        /// DWARF debug-info handling: `strip` (default — drop all
-        /// `.debug_*`), `passthrough` (copy verbatim; addresses are
-        /// wrong against the fused code section), or `remap` (#143 —
-        /// translate code addresses to the fused code section). `remap`
-        /// currently supports a single DWARF-bearing input module and
-        /// falls back to `strip` for multi-source inputs.
-        #[arg(long, value_name = "MODE", default_value = "strip")]
+        /// DWARF debug-info handling: `remap` (default since v0.25.0 —
+        /// translate code addresses to the fused code section; meld-
+        /// generated code is attributed to per-class `<meld-adapter>`
+        /// lines), `strip` (drop all `.debug_*`), or `passthrough`
+        /// (copy verbatim; addresses are wrong against the fused code
+        /// section). With multiple DWARF-bearing input modules, `remap`
+        /// drops the source DWARF (never wrong addresses, #208) but
+        /// still emits the synthetic adapter unit.
+        #[arg(long, value_name = "MODE", default_value = "remap")]
         dwarf: String,
 
         /// Preserve debug names in output

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -105,16 +105,17 @@ pub struct FuserConfig {
 
     /// DWARF (`.debug_*`) section handling.
     ///
-    /// Default `Strip` because meld currently does NOT remap DWARF
-    /// addresses across the merged code section (issue #130 Phase 2).
-    /// Passing the input DWARF through verbatim produces *wrong*
-    /// source-line attribution for every fused address — strictly
-    /// worse than emitting no DWARF, since downstream tooling
-    /// (`pulseengine/witness` MC/DC) trusts what it reads.
-    ///
-    /// Once Phase 2 ships an address-remapping pass, the default may
-    /// flip to a remap-based mode. Until then, `Strip` is the only
-    /// non-corrupting setting; `PassThrough` is opt-in and lossy.
+    /// Default `Remap` since v0.25.0 (#143/#144 complete): single-source
+    /// input DWARF is address-remapped against the fused code section
+    /// (correct-or-tombstone per address, LS-D-1), meld-generated code
+    /// gets the synthetic `<meld-adapter>` per-class unit (LS-D-2), and
+    /// the multi-source case drops source DWARF rather than emit wrong
+    /// addresses (#208 lifts that). Witness-measured on hello_rust:
+    /// 75.9% of fused branch offsets resolve to source (83.0% unfused;
+    /// the unfused 17% is debug-info-less libc, the fusion delta is
+    /// tombstoned/dropped ranges — tracked under #208). `Strip` remains
+    /// available; `PassThrough` is opt-in and lossy (its addresses are
+    /// wrong against the fused code section).
     pub dwarf_handling: DwarfHandling,
 
     /// Output format: core module (default) or P2 component
@@ -145,7 +146,7 @@ impl Default for FuserConfig {
             address_rebasing: false,
             preserve_names: false,
             custom_sections: CustomSectionHandling::Merge,
-            dwarf_handling: DwarfHandling::Strip,
+            dwarf_handling: DwarfHandling::Remap,
             output_format: OutputFormat::CoreModule,
             opaque_resources: Vec::new(),
         }

--- a/meld-core/tests/dwarf_passthrough.rs
+++ b/meld-core/tests/dwarf_passthrough.rs
@@ -222,20 +222,26 @@ fn fuse_with_drop(input: &[u8]) -> Vec<u8> {
 
 #[test]
 fn current_default_is_strip_post_phase_1_5() {
-    // Pin: Phase 1.5 (#135, commit c7a2c0b) flipped the default DWARF
-    // handling from PassThrough (broken-but-present) to Strip
-    // (correct-but-lossy). The discovery oracle was originally
-    // authored against the pre-Phase-1.5 default and inverted in this
-    // commit to reflect shipped behaviour. Any future change to the
-    // default (e.g. Phase 2 making PassThrough correct + the new
-    // default) must be a deliberate edit to this test.
+    // Pin history: Phase 1.5 (#135) flipped PassThrough → Strip
+    // (correct-but-lossy). v0.25.0 (#143/#144 complete) flipped
+    // Strip → Remap (correct AND attributing: single-source addresses
+    // remapped, generated code on per-class `<meld-adapter>` lines,
+    // multi-source drops source DWARF rather than emit wrong
+    // addresses). The invariant carried through both flips: the
+    // default NEVER emits address-wrong DWARF — PassThrough stays a
+    // deliberate opt-in. Any future change to the default must be a
+    // deliberate edit to this test.
     assert_eq!(
         FuserConfig::default().dwarf_handling,
-        DwarfHandling::Strip,
-        "FuserConfig::default().dwarf_handling drifted from Strip. \
-         If this was intentional (Phase 2 making PassThrough address- \
-         correct etc.), update DWARF policy docs and the \
-         witness-integration discovery issue."
+        DwarfHandling::Remap,
+        "FuserConfig::default().dwarf_handling drifted from Remap. \
+         If intentional, update DWARF policy docs, dwarf_strip.rs \
+         pins, and the witness-integration discovery issue."
+    );
+    assert_ne!(
+        FuserConfig::default().dwarf_handling,
+        DwarfHandling::PassThrough,
+        "the default must never be the address-wrong PassThrough"
     );
     // The custom-sections default remains Merge — Phase 1.5 only
     // changed DWARF policy, not the wider custom-section default.

--- a/meld-core/tests/dwarf_strip.rs
+++ b/meld-core/tests/dwarf_strip.rs
@@ -8,14 +8,17 @@
 //! fused output points at the wrong instruction. Phase 1.5 makes the
 //! policy explicit:
 //!
-//! - `DwarfHandling::Strip` (default) drops every `.debug_*` section so
+//! - `DwarfHandling::Strip` drops every `.debug_*` section so
 //!   downstream consumers (e.g. `pulseengine/witness` MC/DC) see no
 //!   DWARF rather than corrupted DWARF.
 //! - `DwarfHandling::PassThrough` is opt-in for the rare case a caller
 //!   wants the lossy old behaviour for diagnostics.
-//!
-//! Phase 2 will add an actual address-remap pass; until then, "no
-//! DWARF" is strictly safer than "wrong DWARF".
+//! - `DwarfHandling::Remap` (default since v0.25.0, #143/#144 complete)
+//!   address-remaps single-source DWARF and attributes meld-generated
+//!   code to per-class `<meld-adapter>` lines; with multiple DWARF
+//!   sources it drops the source DWARF (#208) but keeps the synthetic
+//!   unit. The LS-CP-4 invariant is unchanged: the DEFAULT never emits
+//!   address-wrong DWARF — `PassThrough` stays a deliberate opt-in.
 
 use meld_core::{DwarfHandling, Fuser, FuserConfig};
 
@@ -78,15 +81,15 @@ fn fuse_with(handling: DwarfHandling) -> Vec<u8> {
 /// Default `FuserConfig` strips DWARF — the fused module carries zero
 /// `.debug_*` sections at the top level.
 #[test]
-fn default_strips_dwarf() {
+fn strip_strips_dwarf() {
     if !fixture_available() {
         return;
     }
-    let fused = fuse_with(FuserConfig::default().dwarf_handling);
+    let fused = fuse_with(DwarfHandling::Strip);
     assert_eq!(
         count_dwarf_sections(&fused),
         0,
-        "default DwarfHandling::Strip must produce zero DWARF sections"
+        "DwarfHandling::Strip must produce zero DWARF sections"
     );
 }
 
@@ -107,13 +110,14 @@ fn passthrough_preserves_dwarf() {
     );
 }
 
-/// Smoke check: `Default::default()` resolves to `DwarfHandling::Strip`,
-/// not `PassThrough`. If the default ever flips, this test must be
-/// updated together with the LS-CP-N entry.
+/// `Default::default()` resolves to `DwarfHandling::Remap` (v0.25.0),
+/// and — the actual LS-CP-4 invariant — NEVER to `PassThrough`, whose
+/// addresses are wrong against the fused code section.
 #[test]
-fn default_is_strip() {
+fn default_is_remap_never_passthrough() {
     let cfg = FuserConfig::default();
-    assert_eq!(cfg.dwarf_handling, DwarfHandling::Strip);
+    assert_eq!(cfg.dwarf_handling, DwarfHandling::Remap);
+    assert_ne!(cfg.dwarf_handling, DwarfHandling::PassThrough);
 }
 
 // LS-N verification gate convention aliases. These delegate to the
@@ -129,8 +133,8 @@ fn default_is_strip() {
 // pin that policy.
 
 #[test]
-fn ls_cp_4_default_strips_dwarf() {
-    default_strips_dwarf();
+fn ls_cp_4_strip_strips_dwarf() {
+    strip_strips_dwarf();
 }
 
 #[test]
@@ -139,6 +143,6 @@ fn ls_cp_4_passthrough_preserves_dwarf_explicitly() {
 }
 
 #[test]
-fn ls_cp_4_default_is_strip() {
-    default_is_strip();
+fn ls_cp_4_default_is_never_passthrough() {
+    default_is_remap_never_passthrough();
 }

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -797,7 +797,7 @@ artifacts:
       `.debug_str` / `.debug_abbrev` pass through with string-pool dedup /
       byte-equal merge. End-to-end verified by witness MC/DC integration:
       ≥ X% of `br_if` byte offsets in fused output resolve to source.
-    status: implemented
+    status: verified
     tags: [roadmap, dwarf, witness-mc-dc, v0.10.0]
     links:
       - type: derives-from

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -381,15 +381,19 @@ verification-status:
       - meld-core/tests/dwarf_strip.rs
       - meld-core/tests/dwarf_passthrough.rs
     proofs: []
-    status: implemented
+    status: verified
     note: >-
       v0.16.0–v0.18.0 (#143 inc 1–3b): provenance v2 code ranges,
       rewriter instruction-offset map, AddressRemap engine, gimli
       section rewrite behind DwarfHandling::Remap (landed in
       meld-core/src/dwarf.rs, not the originally-planned dwarf_remap.rs).
-      `verified` is gated on the cross-repo witness MC/DC attribution
-      run scheduled for v0.25.0 (docs/roadmap.md) — the Strip→Remap
-      default flip rides the same gate.
+      Verified v0.25.0: cross-repo witness runs on hello_rust —
+      line tables survive remap exactly (2011/2011 rows); 75.9% of
+      fused branch offsets resolve to source vs 83.0% unfused (the
+      unfused gap is debug-info-less libc; the fusion delta is
+      tombstoned/dropped ranges, tracked under #208 — never wrong
+      addresses, LS-D-1). Strip→Remap default flip shipped on the
+      same evidence; evidence trail on #143.
 
   SR-36:
     implementation-files: []


### PR DESCRIPTION
v0.25.0 scope: the Strip→Remap default flip, shipped on the witness evidence recorded on #143 (line tables byte-identical through remap; 75.9% fused branch attribution vs 83.0% unfused, with the decomposition: unfused gap = debug-info-less libc, fusion delta = tombstoned/dropped ranges → #208; LS-D-1 guarantees correct-or-tombstone, never wrong).

- `FuserConfig::default().dwarf_handling` and CLI `--dwarf` default: `strip` → `remap`.
- Policy pins updated: `default_is_remap_never_passthrough` (the LS-CP-4 invariant — the default is never address-wrong PassThrough — carried through both historical flips), `strip_strips_dwarf` (explicit Strip unchanged), `current_default…` pin extended with v0.25.0 history.
- SR-35 → **verified** with measurement anchors.

Non-Tier-5 (lib.rs, main.rs, tests, YAML). Closes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)