### PR TITLE
release: v0.26.0 — multi-source DWARF merge (#208 inc 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-06-11
+
+### Added
+
+- **Multi-source DWARF merge** (#208 inc 1, SR-38, LS-D-3; PR #232).
+  `DwarfHandling::Remap` no longer drops source DWARF when more than
+  one input module carries it: each source is converted and
+  address-remapped independently, and the written section sets are
+  merged by a bounded relocator patching the closed cross-section
+  reference list (CU abbrev offset, `strp`, `stmt_list`/`ranges`/
+  location `sec_offset`s, `ref_addr`) on every set after the first.
+  Abort-don't-guess: inputs outside the DWARF32-v4 repertoire fall
+  back to synthetic-only emission; a source whose remap fails is
+  dropped individually. Real-fixture evidence: lists.wasm merges 287
+  compile units with >23k parseable line rows. Known carried
+  limitation (SR-38): pre-existing convert-path `DW_AT_location`
+  verifier warnings (variable-location data, out of #130 scope).
+
+### Pre-release Mythos note
+
+No Tier-5 files changed since v0.25.0 (dwarf.rs + tests + YAML only).
+
+### Falsification statement
+
+Claim: merging two independently remapped DWARF sources preserves
+every unit, file, line, and strp-referenced string at the correct
+relocated offsets. Refute via
+`ls_d_3_multi_source_merge_round_trips_both_units` or the
+dwarf_passthrough multi-source policy test — a single missed
+relocation fails the re-parse or resolves foreign data.
+
 ## [0.25.0] - 2026-06-11
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.25.0"
+version = "0.26.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
Release PR. Scope: #232 (bounded relocator; SR-38 implemented, LS-D-3 approved). No Tier-5 deltas since v0.25.0. Falsification statement in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)