### PR TITLE
release: v0.27.0 — multi-source DWARF dedup (#208 complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-06-11
+
+### Added
+
+- **Multi-source DWARF merge: string-pool dedup + abbrev reuse**
+  (#208 inc 2, closes #208; SR-38 → verified; PR #234). The merged
+  `.debug_str` is a deduped content-addressed pool (per-string `strp`
+  relocation map), and byte-identical `.debug_abbrev` tables are
+  reused rather than appended. `.debug_ranges`/`.debug_loc` need no
+  dedup (address-pair contents, already converted per source).
+
+### Pre-release Mythos note
+
+No Tier-5 files changed since v0.26.0 (dwarf.rs only).
+
+### Falsification statement
+
+Claim: the deduped merge preserves the full unit/file/line/strp
+round-trip while making merged abbrev strictly smaller than naive
+concatenation and pooling shared strings. Refute via the extended
+`ls_d_3_multi_source_merge_round_trips_both_units`.
+
 ## [0.26.0] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -899,7 +899,7 @@ artifacts:
       abort the merge and fall back to synthetic-only emission —
       never a guessed offset. A source whose remap fails is dropped
       individually; the others proceed.
-    status: implemented
+    status: verified
     tags: [roadmap, dwarf, witness-mc-dc, v0.26.0]
     links:
       - type: derives-from


### PR DESCRIPTION
Release PR. Scope: #234 (#208 inc 2; SR-38 → verified). Closes the #208 epic's meld-side deliverables. No Tier-5 deltas since v0.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)