### PR TITLE
feat(component-wrap): internalise satisfied imports across separate inputs (#212.1)

### DIFF
--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -835,6 +835,18 @@ fn assemble_component(
         .flat_map(|m| m.imports.iter())
         .map(|imp| imp.module.as_str())
         .collect();
+    // INVARIANT (Mythos pass, PR #236): `instance_renum` keys are import
+    // ordinals but are consumed with component-instance indices from
+    // `component_instance_defs` — these coincide only while import
+    // instances occupy the contiguous LEADING slots of the component
+    // instance space, which every real producer (wit-component, wac,
+    // wit-bindgen) satisfies. Likewise the depth-0 replay only filters
+    // the Import section; a depth-0 Alias/Type section referencing an
+    // import instance by index would dangle after a drop — unreachable
+    // from real producers (their instance-referencing aliases come after
+    // the first core module and are not captured as depth-0). If either
+    // assumption breaks, the loud dropped-instance error below fires
+    // rather than emitting a wrong index.
     let mut dropped_import_names: std::collections::BTreeSet<String> = Default::default();
     let mut instance_renum: std::collections::HashMap<u32, u32> = Default::default();
     {

--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -814,15 +814,103 @@ fn assemble_component(
     let n = fused_info.func_imports.len();
 
     // -----------------------------------------------------------------------
+    // 0. Internalised-import elimination (#212.1). An instance import in
+    //    the wrapped component is needed IFF some import remaining in the
+    //    FUSED core module references it (module name == instance name).
+    //    An interface that an input module imported but the fused module
+    //    no longer does was satisfied internally by the resolver — its
+    //    component-level import declaration must be dropped, or the
+    //    wrapped component demands an implementation the linker cannot
+    //    have. Dropping shifts later instance indices, so a renumber map
+    //    is threaded to every consumer below.
+    // -----------------------------------------------------------------------
+    let remaining_modules: std::collections::BTreeSet<&str> = fused_info
+        .func_imports
+        .iter()
+        .map(|(m, _, _)| m.as_str())
+        .collect();
+    let original_modules: std::collections::BTreeSet<&str> = all_components
+        .iter()
+        .flat_map(|c| c.core_modules.iter())
+        .flat_map(|m| m.imports.iter())
+        .map(|imp| imp.module.as_str())
+        .collect();
+    let mut dropped_import_names: std::collections::BTreeSet<String> = Default::default();
+    let mut instance_renum: std::collections::HashMap<u32, u32> = Default::default();
+    {
+        let mut old_idx = 0u32;
+        let mut new_idx = 0u32;
+        for imp in &source.imports {
+            if !matches!(imp.ty, wasmparser::ComponentTypeRef::Instance(_)) {
+                continue;
+            }
+            let internalised = original_modules.contains(imp.name.as_str())
+                && !remaining_modules.contains(imp.name.as_str());
+            if internalised {
+                log::debug!(
+                    "component wrap: dropping internalised import `{}` (#212.1)",
+                    imp.name
+                );
+                dropped_import_names.insert(imp.name.clone());
+            } else {
+                instance_renum.insert(old_idx, new_idx);
+                new_idx += 1;
+            }
+            old_idx += 1;
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // 1. Replay depth-0 Type and Import sections from the original component.
     //    These define the component-level instance types and import declarations
-    //    that the runtime validates against.
+    //    that the runtime validates against. Import sections are filtered
+    //    through the internalised-import drop set (#212.1).
     // -----------------------------------------------------------------------
     for (section_id, data) in &source.depth_0_sections {
-        component.section(&RawSection {
-            id: *section_id,
-            data,
-        });
+        if *section_id == ComponentSectionId::Import as u8 && !dropped_import_names.is_empty() {
+            let reader = wasmparser::ComponentImportSectionReader::new(
+                wasmparser::BinaryReader::new(data, 0),
+            )
+            .map_err(|e| Error::EncodingError(format!("replay import section: {e}")))?;
+            let mut imports = ComponentImportSection::new();
+            for entry in reader {
+                let entry =
+                    entry.map_err(|e| Error::EncodingError(format!("import entry: {e}")))?;
+                if dropped_import_names.contains(entry.name.0) {
+                    continue;
+                }
+                let ty = match entry.ty {
+                    wasmparser::ComponentTypeRef::Module(i) => ComponentTypeRef::Module(i),
+                    wasmparser::ComponentTypeRef::Func(i) => ComponentTypeRef::Func(i),
+                    wasmparser::ComponentTypeRef::Value(_) => {
+                        return Err(Error::EncodingError(
+                            "value imports are not supported in wrap replay".into(),
+                        ));
+                    }
+                    wasmparser::ComponentTypeRef::Type(_) => {
+                        ComponentTypeRef::Type(TypeBounds::Eq(0))
+                    }
+                    wasmparser::ComponentTypeRef::Instance(i) => ComponentTypeRef::Instance(i),
+                    wasmparser::ComponentTypeRef::Component(i) => ComponentTypeRef::Component(i),
+                };
+                // Type imports carry bounds we must preserve precisely.
+                let ty = if let wasmparser::ComponentTypeRef::Type(bounds) = entry.ty {
+                    ComponentTypeRef::Type(match bounds {
+                        wasmparser::TypeBounds::Eq(i) => TypeBounds::Eq(i),
+                        wasmparser::TypeBounds::SubResource => TypeBounds::SubResource,
+                    })
+                } else {
+                    ty
+                };
+                imports.import(entry.name.0, ty);
+            }
+            component.section(&imports);
+        } else {
+            component.section(&RawSection {
+                id: *section_id,
+                data,
+            });
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -921,8 +1009,20 @@ fn assemble_component(
         if let Some((inst_idx, func_name)) =
             resolve_import_to_instance(source, module_name, field_name, &instance_map)
         {
+            // Source-numbered instance index → output numbering after the
+            // internalised-import drops (#212.1). A miss here would mean a
+            // resolution references a DROPPED instance — impossible by
+            // construction (drops require the module absent from the fused
+            // imports, and resolutions exist only for present ones), so
+            // surface it loudly rather than emit a wrong index.
+            let renumbered = *instance_renum.get(&inst_idx).ok_or_else(|| {
+                Error::EncodingError(format!(
+                    "import resolution references dropped instance {inst_idx} \
+                     ({module_name}::{field_name})"
+                ))
+            })?;
             import_resolutions.push(ImportResolution::Instance {
-                instance_idx: inst_idx,
+                instance_idx: renumbered,
                 func_name,
             });
             continue;
@@ -1739,12 +1839,9 @@ fn assemble_component(
         }
     }
 
-    // Track component instance index (starts after import instances)
-    let mut component_instance_idx = source
-        .imports
-        .iter()
-        .filter(|imp| matches!(imp.ty, wasmparser::ComponentTypeRef::Instance(_)))
-        .count() as u32;
+    // Track component instance index (starts after the KEPT import
+    // instances — internalised imports were dropped above, #212.1).
+    let mut component_instance_idx = instance_renum.len() as u32;
 
     for comp_export in &source.exports {
         if comp_export.kind != wasmparser::ComponentExternalKind::Instance {

--- a/meld-core/tests/golden_e2e.rs
+++ b/meld-core/tests/golden_e2e.rs
@@ -383,9 +383,11 @@ fn tier_b_fused_composed_matches_host_linked() {
 /// the call, and emit a self-contained component. Currently `#[ignore]`d:
 /// meld does not yet resolve a cross-component *interface* import/export
 /// across separate inputs (the fused output still imports
-/// `golden:math/lib`). Un-ignore when #212.1 lands.
+/// `golden:math/lib`). Un-ignored since #212.1 landed (v0.28.0):
+/// component_wrap drops internalised instance imports and renumbers
+/// the survivors, so the fused component is self-contained.
+/// (`ls_cp_6_` alias below: LS-CP-6 regression, run by the LS-N gate.)
 #[test]
-#[ignore = "meld#212.1: cross-component interface link not internalised across separate inputs"]
 fn tier_b_separate_inputs_internalise_link() {
     let (Ok(consumer), Ok(provider), Some((_, golden))) = (
         std::fs::read(format!("{COMPOSE_DIR}/consumer.wasm")),
@@ -404,4 +406,9 @@ fn tier_b_separate_inputs_internalise_link() {
     let got =
         call_runner(&fused).expect("fused separate-input composition should run runner standalone");
     assert_eq!(got, golden, "separate-input fusion must match host-linked");
+}
+
+#[test]
+fn ls_cp_6_separate_inputs_internalise_link() {
+    tier_b_separate_inputs_internalise_link();
 }

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -925,3 +925,36 @@ artifacts:
         (4 on single-source, 11 on multi) — variable-location data,
         explicitly out of #130 scope.
       milestone: v0.26.0
+
+  - id: SR-39
+    type: requirement
+    title: Separate-input cross-component linking (import internalisation)
+    description: >
+      `meld fuse a.wasm b.wasm --component` shall resolve one input's
+      instance imports against another input's matching exports and
+      internalise the calls, producing a self-contained component: the
+      wrapped output declares an instance import IFF the fused core
+      module still references it. Satisfied imports are dropped from
+      the component's import surface with the surviving instance
+      indices renumbered consistently at every consumer.
+    status: implemented
+    tags: [roadmap, composition, v0.28.0]
+    links:
+      - type: derives-from
+        target: "#94"
+      - type: tracked-by
+        target: "#212"
+      - type: mitigates
+        target: LS-CP-6
+    fields:
+      implementation:
+        - meld-core/src/component_wrap.rs
+      verification-method: test
+      verification-description: >
+        ls_cp_6_separate_inputs_internalise_link — the golden-e2e
+        acceptance authored with #212: fuse consumer.wasm+provider.wasm
+        --component, instantiate standalone in wasmtime with no linker
+        definitions, assert compute()==42 and greet()==7 (host-linked
+        golden equivalence). The full wit-bindgen runtime suite guards
+        the dual failure (WASI imports must remain declared).
+      milestone: v0.28.0

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -3061,3 +3061,53 @@ loss-scenarios:
       dwarf_passthrough multi-source policy test (real lists.wasm
       fixture: merged output parses coherently, >1 unit, file names
       from the input union only).
+
+  - id: LS-CP-6
+    title: wrapped component retains (or wrongly drops) instance imports after internalisation
+    uca: UCA-M-9
+    hazards: [H-1, H-5]
+    type: inadequate-control-algorithm
+    scenario: >
+      Fusing separate input components where A imports an interface B
+      exports internalises the call at the CORE level (resolver wires
+      it; the fused module carries no such import), but component_wrap
+      replayed the consumer's component-level import declarations
+      verbatim — the wrapped component still DEMANDED an implementation
+      of the satisfied interface, so it could not instantiate
+      standalone (#212.1, observed live: wasmtime "matching
+      implementation was not found in the linker"). The dual failure is
+      worse: dropping an import that is NOT satisfied (e.g. a WASI
+      interface still referenced by remaining core imports), or
+      mis-renumbering the surviving instance indices, silently rewires
+      every later alias to the wrong instance [H-1, H-5].
+    causal-factors:
+      - >-
+        replaying depth-0 import sections raw, with no knowledge of
+        which interfaces the resolver satisfied
+      - >-
+        dropping by name without checking the fused module's REMAINING
+        imports (would break WASI passthrough)
+      - >-
+        forgetting a consumer of the instance index space after
+        renumbering (resolution aliases; the component-instance base
+        that starts after import instances)
+    process-model-flaw: >
+      The wrap's model was "the source component's interface surface is
+      the output's interface surface" — true for exports, false for
+      imports once fusion satisfies some of them internally. The
+      output's import surface must be derived from the FUSED module's
+      remaining imports, not the source's declarations.
+    status: approved
+    priority: high
+    fix: >
+      component_wrap drops an instance import IFF its name was imported
+      by some input core module AND is absent from the fused module's
+      remaining imports (structurally: satisfied internally); survivors
+      are renumbered and the map applied at every consumer (resolution
+      aliases via a loud error on any impossible dropped-instance
+      reference; the component-instance base counts kept imports only).
+      Pinned by ls_cp_6_separate_inputs_internalise_link (the formerly
+      #[ignore]d golden-e2e acceptance: fused consumer+provider runs
+      standalone, compute()==42 ∧ greet()==7) and the full wit-bindgen
+      runtime suite (WASI imports stay declared — wrong-drop
+      regression).


### PR DESCRIPTION
v0.28.0 scope — meld's headline capability (closes #212).

## Diagnosis

The core level was already internalised (resolver wires consumer→provider; fused module carries no import of the satisfied interface; `imports_resolved: 1`, adapter generated). The failure was isolated to `component_wrap` replaying the consumer's component-level import declarations verbatim — the wrapped component still *demanded* `golden:math/lib@0.1.0` (observed live: wasmtime "matching implementation was not found in the linker").

## Fix

Derive the output's import surface from the **fused module's remaining imports**, not the source's declarations: drop an instance import IFF its name was imported by an input core module AND is absent from the fused module's remaining imports. WASI/external imports remain by construction. Survivors renumbered; the map applied at every instance-index consumer (resolution aliases — with a loud error on any impossible dropped-instance reference — and the component-instance base).

## Oracle

The acceptance test authored WITH the issue (`tier_b_separate_inputs_internalise_link`, `#[ignore]`d since #213) is **un-ignored and passes**: fused `consumer.wasm + provider.wasm --component` instantiates standalone with zero linker definitions; `compute()==42 ∧ greet()==7` equals the host-linked golden. Gate alias `ls_cp_6_separate_inputs_internalise_link` (LS-CP-6 approved, SR-39 implemented). Full suite: 531 passed / 0 failed (wit-bindgen WASI fixtures pin the dual failure — no wrong drops).

## Tier-5

`component_wrap.rs` changed. Mythos clean-room pass to follow as comment + label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)