### PR TITLE
release: v0.28.0 — separate-input cross-component linking (#212 complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-06-11
+
+### Added
+
+- **Separate-input cross-component linking** (#212.1, closes #212;
+  SR-39, LS-CP-6; PR #236). `meld fuse consumer.wasm provider.wasm
+  --component` now produces a SELF-CONTAINED component: the wrapped
+  output's import surface is derived from the fused core module's
+  REMAINING imports, so interfaces the resolver satisfied internally
+  are dropped from the component-level declarations (with surviving
+  instance indices renumbered consistently); WASI and other external
+  imports remain by construction. The formerly `#[ignore]`d golden-e2e
+  acceptance (`tier_b_separate_inputs_internalise_link`) is un-ignored
+  and passing: the fused composition instantiates standalone with zero
+  linker definitions, `compute()==42 ∧ greet()==7` equal to the
+  host-linked golden.
+
+### Pre-release Mythos note
+
+Tier-5 file changed since v0.27.0: `component_wrap.rs` (PR #236).
+Clean-room pass: NO PROVABLE FINDING; the pass additionally verified
+the drop-one-keep-one renumber path with its own 2-import fixture, and
+its two latent-fragility observations are pinned as an INVARIANT
+comment in code. `mythos-pass-done` applied.
+
+### Falsification statement
+
+Claim: fusing two separate components where one's instance import
+matches the other's export yields a component that instantiates with
+NO linker definitions and behaves identically to the host-linked
+composition. Refute via `ls_cp_6_separate_inputs_internalise_link`.
+
 ## [0.27.0] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
Release PR. Scope: #236 (#212.1; SR-39 implemented, LS-CP-6 approved; Mythos pass clean). Falsification statement in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)