### PR TITLE
chore(mythos): register p3_bridge.rs as Tier-5 ahead of the #141 emitter

### DIFF
--- a/.github/workflows/mythos-auto.yml
+++ b/.github/workflows/mythos-auto.yml
@@ -112,6 +112,7 @@ jobs:
             "meld-core/src/component_wrap.rs"
             "meld-core/src/p3_async.rs"
             "meld-core/src/p3_stream.rs"
+            "meld-core/src/p3_bridge.rs"
             "meld-core/src/provenance.rs"
             "meld-core/src/dwarf.rs"
             "meld-core/src/adapter/"

--- a/.github/workflows/mythos-gate.yml
+++ b/.github/workflows/mythos-gate.yml
@@ -61,6 +61,7 @@ jobs:
             "meld-core/src/component_wrap.rs"
             "meld-core/src/p3_async.rs"
             "meld-core/src/p3_stream.rs"
+            "meld-core/src/p3_bridge.rs"
             "meld-core/src/adapter/"
             "meld-core/src/resource_graph.rs"
             "meld-core/src/segments.rs"


### PR DESCRIPTION
Workflow-only PR (byte-identical constraint: mythos workflow edits ship separately from code). Registers the upcoming stream-bridge emitter file in the Tier-5 lists of both the gate and the auto-pass, BEFORE the code lands, so the #141 emitter PR is gated from its first push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)