### PR TITLE
feat(p3-bridge): cross-component stream-bridge emitter (#141, SR-33)

### DIFF
--- a/meld-core/src/dwarf.rs
+++ b/meld-core/src/dwarf.rs
@@ -952,6 +952,8 @@ pub enum AdapterRole {
     AdapterShim,
     /// P3 async `task.return` result-global shim.
     TaskReturnShim,
+    /// Cross-component stream-bridge dispatch shim (#141, `p3_bridge`).
+    StreamBridge,
 }
 
 impl AdapterRole {
@@ -976,6 +978,7 @@ impl AdapterRole {
             AdapterRole::StartWrapper => 7,
             AdapterRole::AdapterShim => 8,
             AdapterRole::TaskReturnShim => 9,
+            AdapterRole::StreamBridge => 10,
         }
     }
 }
@@ -998,6 +1001,7 @@ impl From<crate::merger::SyntheticKind> for AdapterRole {
             crate::merger::SyntheticKind::StartWrapper => AdapterRole::StartWrapper,
             crate::merger::SyntheticKind::AdapterShim => AdapterRole::AdapterShim,
             crate::merger::SyntheticKind::TaskReturnShim => AdapterRole::TaskReturnShim,
+            crate::merger::SyntheticKind::StreamBridge => AdapterRole::StreamBridge,
         }
     }
 }
@@ -1741,6 +1745,7 @@ mod tests {
             AdapterRole::StartWrapper,
             AdapterRole::AdapterShim,
             AdapterRole::TaskReturnShim,
+            AdapterRole::StreamBridge,
         ];
         let mut seen = std::collections::BTreeSet::new();
         for role in all {

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -55,6 +55,7 @@ mod error;
 pub mod memory_probe;
 pub mod merger;
 pub mod p3_async;
+pub mod p3_bridge;
 pub mod p3_stream;
 pub mod parser;
 pub mod provenance;
@@ -540,6 +541,30 @@ impl Fuser {
         // after EXIT. Must run BEFORE adapter generation so shim info
         // is available to the async adapter.
         self.generate_task_return_shims(&mut merged, &graph)?;
+
+        // Step 2.6: Cross-component stream-bridge emitter (#141, SR-33).
+        //
+        // When the resolver detected cross-component stream pairs
+        // (graph.stream_pair_graph, ADR-3 detection foundation), emit the
+        // bridge memory + per-component dispatch shims and rewire every
+        // stream-intrinsic call site to its component's shim. This MUST
+        // run before adapter generation/wiring: adapters are encoded
+        // after merged.functions, so wire_adapter_indices bakes adapter
+        // indices derived from functions.len() into call sites —
+        // appending shim functions any later would shift those indices
+        // off-target. Running here, the shims are plain merged functions
+        // that every later index computation already accounts for.
+        if let Some(stream_pairs) = graph.stream_pair_graph.as_ref()
+            && !stream_pairs.is_empty()
+        {
+            p3_bridge::emit_stream_bridge(
+                &mut merged,
+                &self.components,
+                stream_pairs,
+                self.config.memory_strategy,
+                self.config.address_rebasing,
+            )?;
+        }
 
         // Step 3: Generate adapters
         log::info!("Generating adapters");

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -237,6 +237,12 @@ pub enum SyntheticKind {
     AdapterShim,
     /// P3 async `task.return` shim storing results into result globals.
     TaskReturnShim,
+    /// Cross-component stream-bridge shim (#141): per-component
+    /// `stream_*` dispatch function emitted by `crate::p3_bridge` that
+    /// routes locally-minted (bit-31-tagged) handles to the in-module
+    /// bridge ring memory and forwards host handles to the retained
+    /// `pulseengine:async` imports.
+    StreamBridge,
 }
 
 /// Global in merged module

--- a/meld-core/src/p3_bridge.rs
+++ b/meld-core/src/p3_bridge.rs
@@ -1,0 +1,801 @@
+//! # Cross-component stream-bridge emitter (#141, SR-33, ADR-3 follow-up)
+//!
+//! When two fused components share a `stream<T>` end-to-end (one holds the
+//! writable end, the other the readable end), both sides previously lowered
+//! to `pulseengine:async` **host** imports — every byte crossed the host
+//! boundary twice even though both ends live in the same merged module.
+//! This module emits the in-module bridge that removes the double host
+//! round-trip.
+//!
+//! ## Design (issue #141, "shim-dispatch bridge")
+//!
+//! The pairing is static ([`crate::p3_stream::StreamPairGraph`]) but handle
+//! identity is runtime — `stream_new` mints handles at run time. So the
+//! bridge takes over the stream plane for handles minted **in-module** and
+//! forwards everything else to the retained host intrinsics:
+//!
+//! * A **bridge memory** is appended to the merged module: a slot header
+//!   table plus ring storage (layout constants below).
+//! * Per component that imports any of the five stream intrinsics
+//!   (`stream_new` / `stream_read` / `stream_write` /
+//!   `stream_drop_readable` / `stream_drop_writable`), meld emits **shim
+//!   functions** with that component's merged memory index hardwired as an
+//!   instruction immediate (wasm memory indices are immediates, so the
+//!   host ABI's dynamic `mem_idx` parameter cannot be honoured in-module —
+//!   the caller always passes its own memory by construction). Same-memory
+//!   fusion is the identical codegen with all caller-memory immediates 0.
+//! * **Handle tagging**: the shim `stream_new` allocates a bridge slot and
+//!   returns handles with bit 31 set ([`LOCAL_TAG`]). Host handles are
+//!   assumed `< 2^31` (recorded invariant from ADR-2's small-int handle
+//!   convention). Each shim dispatches on the tag: tagged → ring ops
+//!   against the bridge memory; untagged → call the original host import
+//!   (which stays imported as the foreign-handle fallback path).
+//! * **Slot exhaustion** falls back to host `stream_new` — graceful,
+//!   never an error.
+//! * Call sites are **rewired**: every call to a component's
+//!   `pulseengine:async` `stream_*` import is redirected to that
+//!   component's shim (same body-re-rewrite mechanism as
+//!   `wire_adapter_indices` in `lib.rs`).
+//!
+//! ## Ring protocol (single-threaded interleaved semantics)
+//!
+//! Per-slot header at `HEADER_BASE + slot * SLOT_HEADER_STRIDE`:
+//!
+//! | offset | field | meaning |
+//! |---|---|---|
+//! | +0 | `state: u32` | 0 free, 1 open, 2 writer-dropped, 3 fully-closed |
+//! | +4 | `rd: u32` | monotonic read cursor (wrapping) |
+//! | +8 | `wr: u32` | monotonic write cursor (wrapping) |
+//! | +12 | reserved | — |
+//!
+//! Ring data for slot `s` lives at `RINGS_BASE + s * RING_CAP`. Cursors
+//! are **u32 wrapping monotonic counters**: `wr - rd` is the fill level
+//! and `cursor & (RING_CAP - 1)` the ring offset (`RING_CAP` is a power
+//! of two), so full ([`RING_CAP`]) and empty (0) are distinguishable
+//! without a spare byte.
+//!
+//! * **write**: `avail = RING_CAP - (wr - rd)`; `n = min(len, avail)`;
+//!   two-part wrapping `memory.copy` caller-mem → bridge; `wr += n`;
+//!   return `n`. `n == 0` is backpressure per ADR-2 (never an error).
+//! * **read**: if `wr == rd`, return `0` iff `state == 2`
+//!   (writer-dropped ⇒ EOF after drain) else `-5`
+//!   ([`crate::p3_async::AbiError::Pending`] — open and empty). Otherwise
+//!   `n = min(len, wr - rd)`; two-part wrapping copy bridge → caller-mem;
+//!   `rd += n`; return `n`.
+//! * **drop_writable** (local): `state = 2`. The reader drains remaining
+//!   bytes and then observes EOF — the ADR-2 "EOF only after writer
+//!   dropped AND drained" contract.
+//! * **drop_readable** (local): `state = 3`. The slot is **not reused**
+//!   in v0.29.0 — reclamation would require proving no live writable end
+//!   remains, which the single-pass emitter does not track. With
+//!   [`SLOT_COUNT`] slots exhausted, `stream_new` falls back to the host,
+//!   so the failure mode is "loses the optimisation", never "loses data".
+//! * **stream_new**: scan for a `state == 0` slot; none → call host
+//!   `stream_new` and return its `i64` unchanged. Otherwise `state = 1`,
+//!   `rd = wr = 0`, and return an `i64` whose low half (readable end) and
+//!   high half (writable end) are both `slot | LOCAL_TAG` — the same slot
+//!   id for both ends; the ops distinguish ends by which function is
+//!   called, exactly like the host ABI.
+//!
+//! ## ADR-3 amendment (recorded on landing, falsification-driven)
+//!
+//! The original "zero-copy same-memory ring" sketch drops to "**no host
+//! crossing, single copy**": the ABI's caller-buffer contract
+//! (`stream_read(handle, buf_ptr, …)`) requires a copy into the caller's
+//! buffer regardless; what fusion removes is the double host round-trip
+//! per chunk.
+//!
+//! ## Pipeline placement
+//!
+//! [`emit_stream_bridge`] runs after merging, P3 intrinsic lowering and
+//! task-return shims, but **before** FACT adapter generation/wiring:
+//! adapters are encoded *after* `merged.functions`, so their merged
+//! indices are `import_count + functions.len() + offset` — appending shim
+//! functions after `wire_adapter_indices` had baked those indices into
+//! call sites would shift every adapter call off-target. Emitting the
+//! shims first keeps every later index computation correct, and the
+//! shared `function_index_map` carries the rewires through the later
+//! re-extractions.
+
+use std::collections::{BTreeMap, HashMap};
+
+use wasm_encoder::{BlockType, EntityType, Function, Instruction, MemArg, MemoryType, ValType};
+
+use crate::merger::{MergedFuncType, MergedFunction, MergedModule, SyntheticKind};
+use crate::p3_async::{self, HOST_INTRINSIC_MODULE};
+use crate::p3_stream::StreamPairGraph;
+use crate::parser::{ImportKind, ParsedComponent};
+use crate::{MemoryStrategy, Result};
+
+// ─── Bridge memory layout ──────────────────────────────────────────────
+//
+// Page 0: slot header table (SLOT_COUNT * SLOT_HEADER_STRIDE bytes used,
+//         rest reserved). Page 1: ring storage, SLOT_COUNT rings of
+//         RING_CAP bytes each (8 * 4096 = 32 KiB, within one 64 KiB page).
+// Total: 2 pages, fixed (min == max — the bridge never grows).
+
+/// Number of bridge stream slots. Exhaustion falls back to the host.
+pub const SLOT_COUNT: u32 = 8;
+/// Ring capacity in bytes per slot. MUST be a power of two (cursor
+/// arithmetic uses `& (RING_CAP - 1)` masking).
+pub const RING_CAP: u32 = 4096;
+/// Byte offset of the slot header table in the bridge memory.
+pub const HEADER_BASE: u32 = 0;
+/// Bytes per slot header entry: `{state u32, rd u32, wr u32, reserved}`.
+pub const SLOT_HEADER_STRIDE: u32 = 16;
+/// Byte offset of the ring storage (start of page 1).
+pub const RINGS_BASE: u32 = 65536;
+/// Fixed size of the bridge memory in 64 KiB wasm pages.
+pub const BRIDGE_MEMORY_PAGES: u64 = 2;
+
+/// Bit 31 marks a handle as bridge-local. Host handles are `< 2^31`
+/// (ADR-2 small-int handle convention), so the tag is unambiguous.
+pub const LOCAL_TAG: u32 = 0x8000_0000;
+
+/// Slot state: unallocated.
+pub const STATE_FREE: i32 = 0;
+/// Slot state: both ends live.
+pub const STATE_OPEN: i32 = 1;
+/// Slot state: writable end dropped — reader drains, then sees EOF.
+pub const STATE_WRITER_DROPPED: i32 = 2;
+/// Slot state: readable end dropped. Slot is retired, not reused.
+pub const STATE_CLOSED: i32 = 3;
+
+/// The five stream intrinsics the bridge takes over. Cancel ops are NOT
+/// bridged: a bridged op never blocks (it returns Pending / a partial
+/// count immediately), so there is never a pending op to cancel; cancel
+/// calls keep routing to the host import untouched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum StreamOp {
+    /// `stream_new() -> i64`
+    New,
+    /// `stream_read(handle, buf_ptr, buf_len, mem_idx) -> i32`
+    Read,
+    /// `stream_write(handle, data_ptr, data_len, mem_idx) -> i32`
+    Write,
+    /// `stream_drop_readable(handle)`
+    DropReadable,
+    /// `stream_drop_writable(handle)`
+    DropWritable,
+}
+
+impl StreamOp {
+    /// Map a `pulseengine:async` import field name to the op, if it is
+    /// one of the five bridged intrinsics.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            n if n == p3_async::stream::NEW => Some(Self::New),
+            n if n == p3_async::stream::READ => Some(Self::Read),
+            n if n == p3_async::stream::WRITE => Some(Self::Write),
+            n if n == p3_async::stream::DROP_READABLE => Some(Self::DropReadable),
+            n if n == p3_async::stream::DROP_WRITABLE => Some(Self::DropWritable),
+            _ => None,
+        }
+    }
+}
+
+/// One emitted bridge shim.
+#[derive(Debug, Clone)]
+pub struct BridgeShim {
+    /// Source component the shim belongs to (memory immediate origin).
+    pub component: usize,
+    /// Source core module within the component.
+    pub module: usize,
+    /// Which intrinsic this shim replaces at the component's call sites.
+    pub op: StreamOp,
+    /// Merged function index of the shim.
+    pub merged_index: u32,
+}
+
+/// Result of [`emit_stream_bridge`]: what was added to the module.
+#[derive(Debug, Clone, Default)]
+pub struct BridgePlan {
+    /// Merged memory index of the appended bridge memory.
+    pub bridge_memory: u32,
+    /// All emitted shims.
+    pub shims: Vec<BridgeShim>,
+}
+
+/// `MemArg` against the bridge memory (i32 alignment).
+fn bridge_arg(offset: u64, bridge_mem: u32) -> MemArg {
+    MemArg {
+        offset,
+        align: 2,
+        memory_index: bridge_mem,
+    }
+}
+
+/// Emit the cross-component stream bridge into `merged`.
+///
+/// Gated by the caller on a non-empty [`StreamPairGraph`] — the
+/// detection foundation (ADR-3 path N) is the authority on *whether* the
+/// fused module contains a cross-component stream pairing; this emitter
+/// then takes over the stream plane module-wide (every component that
+/// imports a stream intrinsic gets shims, because handles minted by one
+/// participant may be observed by any other).
+///
+/// Returns `Ok(None)` when no component actually imports any of the
+/// five intrinsics (pairs detected from canonical entries alone, with
+/// no core-level call surface to rewire — nothing to do).
+pub fn emit_stream_bridge(
+    merged: &mut MergedModule,
+    components: &[ParsedComponent],
+    stream_pairs: &StreamPairGraph,
+    memory_strategy: MemoryStrategy,
+    address_rebasing: bool,
+) -> Result<Option<BridgePlan>> {
+    if stream_pairs.is_empty() {
+        return Ok(None);
+    }
+
+    // ── 1. Locate the host intrinsic imports in the merged module. ────
+    //
+    // `intrinsic_imports` maps EVERY merged function-import index that is
+    // a bridged stream intrinsic to its op (the merger's dedup and the
+    // lowering pass can each contribute an import of the same name);
+    // `host_idx` records one canonical index per op — the shims' foreign-
+    // handle fallback target.
+    let mut intrinsic_imports: HashMap<u32, StreamOp> = HashMap::new();
+    let mut host_idx: BTreeMap<StreamOp, u32> = BTreeMap::new();
+    let mut func_import_pos = 0u32;
+    for imp in &merged.imports {
+        if let EntityType::Function(_) = imp.entity_type {
+            if imp.module == HOST_INTRINSIC_MODULE
+                && let Some(op) = StreamOp::from_name(&imp.name)
+            {
+                intrinsic_imports.insert(func_import_pos, op);
+                host_idx.entry(op).or_insert(func_import_pos);
+            }
+            func_import_pos += 1;
+        }
+    }
+    if intrinsic_imports.is_empty() {
+        return Ok(None);
+    }
+
+    // ── 2. Which (component, module) calls which intrinsic? ───────────
+    //
+    // A module "uses" an op when one of its function-import positions is
+    // mapped (via function_index_map) to an intrinsic import index. This
+    // covers both direct `pulseengine:async` core imports and canonical-
+    // entry imports that earlier passes pointed at the lowered imports.
+    type Usage = BTreeMap<(usize, usize), BTreeMap<StreamOp, Vec<u32>>>;
+    let mut usage: Usage = BTreeMap::new();
+    for (c, comp) in components.iter().enumerate() {
+        for (m, module) in comp.core_modules.iter().enumerate() {
+            let mut pos = 0u32;
+            for imp in &module.imports {
+                if matches!(imp.kind, ImportKind::Function(_)) {
+                    if let Some(&merged_idx) = merged.function_index_map.get(&(c, m, pos))
+                        && let Some(&op) = intrinsic_imports.get(&merged_idx)
+                    {
+                        usage
+                            .entry((c, m))
+                            .or_default()
+                            .entry(op)
+                            .or_default()
+                            .push(pos);
+                    }
+                    pos += 1;
+                }
+            }
+        }
+    }
+    if usage.is_empty() {
+        return Ok(None);
+    }
+
+    // ── 3. Append the bridge memory (fixed 2 pages, never grows). ─────
+    merged.memories.push(MemoryType {
+        minimum: BRIDGE_MEMORY_PAGES,
+        maximum: Some(BRIDGE_MEMORY_PAGES),
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+    let bridge_mem = merged.import_counts.memory + merged.memories.len() as u32 - 1;
+
+    // ── 4. Shim function types (find-or-append, indices are stable). ──
+    let type_for =
+        |merged: &mut MergedModule, params: Vec<ValType>, results: Vec<ValType>| match merged
+            .types
+            .iter()
+            .position(|t| t.params == params && t.results == results)
+        {
+            Some(idx) => idx as u32,
+            None => {
+                merged.types.push(MergedFuncType { params, results });
+                merged.types.len() as u32 - 1
+            }
+        };
+    let ty_new = type_for(merged, vec![], vec![ValType::I64]);
+    let ty_rw = type_for(merged, vec![ValType::I32; 4], vec![ValType::I32]);
+    let ty_drop = type_for(merged, vec![ValType::I32], vec![]);
+
+    // ── 5. Emit one shim per (component module, used op). ─────────────
+    let mut plan = BridgePlan {
+        bridge_memory: bridge_mem,
+        shims: Vec::new(),
+    };
+    let mut shim_index: HashMap<(usize, usize, StreamOp), u32> = HashMap::new();
+
+    for (&(c, m), ops) in &usage {
+        // The component's own memory, as a hardwired immediate. Local
+        // memory index 0 is the module's first memory (imported or
+        // defined); modules with no memory at all cannot pass buffers,
+        // so 0 is a safe default for their (drop/new-only) shims.
+        let caller_mem = merged
+            .memory_index_map
+            .get(&(c, m, 0))
+            .copied()
+            .unwrap_or(0);
+
+        for &op in ops.keys() {
+            let host = host_idx[&op];
+            let (type_idx, body) = match op {
+                StreamOp::New => (ty_new, emit_new_shim(bridge_mem, host)),
+                StreamOp::Read => (ty_rw, emit_read_shim(bridge_mem, caller_mem, host)),
+                StreamOp::Write => (ty_rw, emit_write_shim(bridge_mem, caller_mem, host)),
+                StreamOp::DropReadable => (ty_drop, emit_drop_shim(bridge_mem, STATE_CLOSED, host)),
+                StreamOp::DropWritable => (
+                    ty_drop,
+                    emit_drop_shim(bridge_mem, STATE_WRITER_DROPPED, host),
+                ),
+            };
+            let merged_index = merged.import_counts.func + merged.functions.len() as u32;
+            merged.functions.push(MergedFunction {
+                type_idx,
+                body,
+                origin: (c, m, u32::MAX),
+                synthetic_kind: Some(SyntheticKind::StreamBridge),
+            });
+            shim_index.insert((c, m, op), merged_index);
+            plan.shims.push(BridgeShim {
+                component: c,
+                module: m,
+                op,
+                merged_index,
+            });
+        }
+    }
+
+    // ── 6. Rewire call sites: import position → shim. ─────────────────
+    for (&(c, m), ops) in &usage {
+        for (&op, positions) in ops {
+            let shim = shim_index[&(c, m, op)];
+            for &pos in positions {
+                merged.function_index_map.insert((c, m, pos), shim);
+            }
+        }
+    }
+
+    // ── 7. Re-extract function bodies of affected modules so already-
+    //       encoded `call` instructions pick up the shim indices (same
+    //       mechanism as `wire_adapter_indices`). ──────────────────────
+    for &(c, m) in usage.keys() {
+        let module = &components[c].core_modules[m];
+
+        let module_memory = if address_rebasing {
+            crate::merger::module_memory_type(module)?
+        } else {
+            None
+        };
+        let memory64 = module_memory
+            .as_ref()
+            .map(|mem| mem.memory64)
+            .unwrap_or(false);
+        let memory_initial_pages = module_memory.as_ref().map(|mem| mem.initial);
+
+        let index_maps = crate::merger::build_index_maps_for_module(
+            c,
+            m,
+            module,
+            merged,
+            memory_strategy,
+            address_rebasing,
+            0, // memory_base_offset — matches wire_adapter_indices
+            memory64,
+            memory_initial_pages,
+        );
+
+        let import_func_count = module
+            .imports
+            .iter()
+            .filter(|i| matches!(i.kind, ImportKind::Function(_)))
+            .count() as u32;
+
+        for (old_idx, &type_idx) in module.functions.iter().enumerate() {
+            let old_func_idx = import_func_count + old_idx as u32;
+            let param_count = module
+                .types
+                .get(type_idx as usize)
+                .map(|ty| ty.params.len() as u32)
+                .unwrap_or(0);
+
+            let body =
+                crate::merger::extract_function_body(module, old_idx, param_count, &index_maps)?;
+
+            if let Some(mf) = merged
+                .functions
+                .iter_mut()
+                .find(|f| f.origin == (c, m, old_func_idx))
+            {
+                mf.body = body;
+            }
+        }
+    }
+
+    log::info!(
+        "Stream bridge (#141): memory {} ({} slots × {} B rings) + {} shim(s) across {} module(s)",
+        bridge_mem,
+        SLOT_COUNT,
+        RING_CAP,
+        plan.shims.len(),
+        usage.len(),
+    );
+
+    Ok(Some(plan))
+}
+
+// ─── Shim codegen ───────────────────────────────────────────────────────
+//
+// Locals layout convention for read/write shims (params l0..l3 =
+// handle, ptr, len, mem_idx — mem_idx is accepted for ABI compatibility
+// and forwarded on the host path, but the local path uses the hardwired
+// memory immediates):
+//   l4 = slot, then header address  (slot * SLOT_HEADER_STRIDE)
+//   l5 = ring base address          (RINGS_BASE + slot * RING_CAP)
+//   l6 = rd cursor   l7 = wr cursor
+//   l8 = scratch → avail/fill → n   l9 = ring offset   l10 = first-part len
+
+/// Dispatch prologue shared by read/write/drop shims: if the handle is
+/// NOT bit-31-tagged, forward all params to the host import and return
+/// its results (the host call's results are exactly the shim's results).
+fn emit_host_fallback(f: &mut Function, host: u32, param_count: u32) {
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(LOCAL_TAG as i32));
+    f.instruction(&Instruction::I32And);
+    f.instruction(&Instruction::I32Eqz);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    for i in 0..param_count {
+        f.instruction(&Instruction::LocalGet(i));
+    }
+    f.instruction(&Instruction::Call(host));
+    f.instruction(&Instruction::Return);
+    f.instruction(&Instruction::End);
+}
+
+/// Decode `l0 = handle` into `l4 = header address`, `l5 = ring base`.
+fn emit_slot_decode(f: &mut Function) {
+    // l4 = handle & !LOCAL_TAG  (the slot id)
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(0x7FFF_FFFF));
+    f.instruction(&Instruction::I32And);
+    f.instruction(&Instruction::LocalSet(4));
+    // l5 = RINGS_BASE + slot * RING_CAP
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Const(RING_CAP as i32));
+    f.instruction(&Instruction::I32Mul);
+    f.instruction(&Instruction::I32Const(RINGS_BASE as i32));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(5));
+    // l4 = HEADER_BASE + slot * SLOT_HEADER_STRIDE (overwrites the slot id)
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Const(SLOT_HEADER_STRIDE as i32));
+    f.instruction(&Instruction::I32Mul);
+    f.instruction(&Instruction::I32Const(HEADER_BASE as i32));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(4));
+}
+
+/// `min(a_local, b_local)` (unsigned) left on the stack via `select`.
+fn emit_min_u(f: &mut Function, a: u32, b: u32) {
+    f.instruction(&Instruction::LocalGet(a));
+    f.instruction(&Instruction::LocalGet(b));
+    f.instruction(&Instruction::LocalGet(a));
+    f.instruction(&Instruction::LocalGet(b));
+    f.instruction(&Instruction::I32LtU);
+    f.instruction(&Instruction::Select);
+}
+
+/// `stream_new() -> i64` shim: claim a free slot (state=1, rd=wr=0) and
+/// return `(slot|LOCAL_TAG)` in both i64 halves; on exhaustion fall back
+/// to the host `stream_new` and return its result unchanged.
+fn emit_new_shim(bridge_mem: u32, host_new: u32) -> Function {
+    // locals: l0 = slot scan cursor, l1 = header address
+    let mut f = Function::new([(2, ValType::I32)]);
+
+    f.instruction(&Instruction::Block(BlockType::Empty)); // $exhausted (depth 2 from loop)
+    f.instruction(&Instruction::Block(BlockType::Empty)); // $have (depth 1 from loop)
+    f.instruction(&Instruction::Loop(BlockType::Empty)); // $scan (depth 0)
+    // if slot >= SLOT_COUNT → exhausted
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(SLOT_COUNT as i32));
+    f.instruction(&Instruction::I32GeU);
+    f.instruction(&Instruction::BrIf(2));
+    // if state[slot] == FREE → have
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(SLOT_HEADER_STRIDE as i32));
+    f.instruction(&Instruction::I32Mul);
+    f.instruction(&Instruction::I32Load(bridge_arg(
+        HEADER_BASE as u64,
+        bridge_mem,
+    )));
+    f.instruction(&Instruction::I32Eqz);
+    f.instruction(&Instruction::BrIf(1));
+    // slot += 1; continue scan
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(0));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End); // loop
+    f.instruction(&Instruction::End); // $have lands here
+
+    // claim: l1 = header address
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(SLOT_HEADER_STRIDE as i32));
+    f.instruction(&Instruction::I32Mul);
+    f.instruction(&Instruction::LocalSet(1));
+    // state = OPEN
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32Const(STATE_OPEN));
+    f.instruction(&Instruction::I32Store(bridge_arg(0, bridge_mem)));
+    // rd = 0
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::I32Store(bridge_arg(4, bridge_mem)));
+    // wr = 0
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::I32Store(bridge_arg(8, bridge_mem)));
+    // tagged = slot | LOCAL_TAG; result = tagged | (tagged << 32)
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(LOCAL_TAG as i32));
+    f.instruction(&Instruction::I32Or);
+    f.instruction(&Instruction::LocalSet(0));
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I64ExtendI32U);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I64ExtendI32U);
+    f.instruction(&Instruction::I64Const(32));
+    f.instruction(&Instruction::I64Shl);
+    f.instruction(&Instruction::I64Or);
+    f.instruction(&Instruction::Return);
+
+    f.instruction(&Instruction::End); // $exhausted lands here
+    f.instruction(&Instruction::Call(host_new));
+    f.instruction(&Instruction::End);
+    f
+}
+
+/// `stream_write(handle, ptr, len, mem_idx) -> i32` shim.
+fn emit_write_shim(bridge_mem: u32, caller_mem: u32, host_write: u32) -> Function {
+    let mut f = Function::new([(7, ValType::I32)]);
+    emit_host_fallback(&mut f, host_write, 4);
+    emit_slot_decode(&mut f);
+
+    // l6 = rd, l7 = wr
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Load(bridge_arg(4, bridge_mem)));
+    f.instruction(&Instruction::LocalSet(6));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Load(bridge_arg(8, bridge_mem)));
+    f.instruction(&Instruction::LocalSet(7));
+
+    // l8 = avail = RING_CAP - (wr - rd)   (wrapping u32 arithmetic)
+    f.instruction(&Instruction::I32Const(RING_CAP as i32));
+    f.instruction(&Instruction::LocalGet(7));
+    f.instruction(&Instruction::LocalGet(6));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::LocalSet(8));
+    // l8 = n = min(len, avail)
+    emit_min_u(&mut f, 2, 8);
+    f.instruction(&Instruction::LocalSet(8));
+    // n == 0 → backpressure: return 0 (ADR-2: 0 is Partial, never EOF)
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::I32Eqz);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::Return);
+    f.instruction(&Instruction::End);
+
+    // l9 = off = wr & (RING_CAP - 1)
+    f.instruction(&Instruction::LocalGet(7));
+    f.instruction(&Instruction::I32Const((RING_CAP - 1) as i32));
+    f.instruction(&Instruction::I32And);
+    f.instruction(&Instruction::LocalSet(9));
+    // l10 = first = min(n, RING_CAP - off)
+    f.instruction(&Instruction::I32Const(RING_CAP as i32));
+    f.instruction(&Instruction::LocalGet(9));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::LocalSet(10));
+    emit_min_u(&mut f, 8, 10);
+    f.instruction(&Instruction::LocalSet(10));
+
+    // copy 1: bridge[ring + off] ← caller[ptr], first bytes
+    f.instruction(&Instruction::LocalGet(5));
+    f.instruction(&Instruction::LocalGet(9));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::LocalGet(10));
+    f.instruction(&Instruction::MemoryCopy {
+        src_mem: caller_mem,
+        dst_mem: bridge_mem,
+    });
+    // copy 2 (wrap): bridge[ring] ← caller[ptr + first], n - first bytes
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::LocalGet(10));
+    f.instruction(&Instruction::I32GtU);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(5));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::LocalGet(10));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::LocalGet(10));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::MemoryCopy {
+        src_mem: caller_mem,
+        dst_mem: bridge_mem,
+    });
+    f.instruction(&Instruction::End);
+
+    // wr += n
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::LocalGet(7));
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::I32Store(bridge_arg(8, bridge_mem)));
+    // return n (accepted count)
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::End);
+    f
+}
+
+/// `stream_read(handle, ptr, len, mem_idx) -> i32` shim.
+fn emit_read_shim(bridge_mem: u32, caller_mem: u32, host_read: u32) -> Function {
+    let mut f = Function::new([(7, ValType::I32)]);
+    emit_host_fallback(&mut f, host_read, 4);
+    emit_slot_decode(&mut f);
+
+    // l6 = rd, l7 = wr
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Load(bridge_arg(4, bridge_mem)));
+    f.instruction(&Instruction::LocalSet(6));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Load(bridge_arg(8, bridge_mem)));
+    f.instruction(&Instruction::LocalSet(7));
+
+    // empty (wr == rd): EOF (0) iff writer dropped, else Pending (-5)
+    f.instruction(&Instruction::LocalGet(7));
+    f.instruction(&Instruction::LocalGet(6));
+    f.instruction(&Instruction::I32Eq);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Load(bridge_arg(0, bridge_mem)));
+    f.instruction(&Instruction::I32Const(STATE_WRITER_DROPPED));
+    f.instruction(&Instruction::I32Eq);
+    f.instruction(&Instruction::If(BlockType::Result(ValType::I32)));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::Else);
+    f.instruction(&Instruction::I32Const(p3_async::AbiError::Pending.as_i32()));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::Return);
+    f.instruction(&Instruction::End);
+
+    // l8 = fill = wr - rd; n = min(len, fill)
+    f.instruction(&Instruction::LocalGet(7));
+    f.instruction(&Instruction::LocalGet(6));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::LocalSet(8));
+    emit_min_u(&mut f, 2, 8);
+    f.instruction(&Instruction::LocalSet(8));
+
+    // l9 = off = rd & (RING_CAP - 1)
+    f.instruction(&Instruction::LocalGet(6));
+    f.instruction(&Instruction::I32Const((RING_CAP - 1) as i32));
+    f.instruction(&Instruction::I32And);
+    f.instruction(&Instruction::LocalSet(9));
+    // l10 = first = min(n, RING_CAP - off)
+    f.instruction(&Instruction::I32Const(RING_CAP as i32));
+    f.instruction(&Instruction::LocalGet(9));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::LocalSet(10));
+    emit_min_u(&mut f, 8, 10);
+    f.instruction(&Instruction::LocalSet(10));
+
+    // copy 1: caller[ptr] ← bridge[ring + off], first bytes
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::LocalGet(5));
+    f.instruction(&Instruction::LocalGet(9));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalGet(10));
+    f.instruction(&Instruction::MemoryCopy {
+        src_mem: bridge_mem,
+        dst_mem: caller_mem,
+    });
+    // copy 2 (wrap): caller[ptr + first] ← bridge[ring], n - first bytes
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::LocalGet(10));
+    f.instruction(&Instruction::I32GtU);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::LocalGet(10));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalGet(5));
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::LocalGet(10));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::MemoryCopy {
+        src_mem: bridge_mem,
+        dst_mem: caller_mem,
+    });
+    f.instruction(&Instruction::End);
+
+    // rd += n
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::LocalGet(6));
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::I32Store(bridge_arg(4, bridge_mem)));
+    // return n (bytes read)
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::End);
+    f
+}
+
+/// `stream_drop_readable` / `stream_drop_writable` shim: tagged handle →
+/// set the slot state; host handle → forward to the host import.
+fn emit_drop_shim(bridge_mem: u32, new_state: i32, host_drop: u32) -> Function {
+    let mut f = Function::new([]);
+    emit_host_fallback(&mut f, host_drop, 1);
+    // header address = (handle & !LOCAL_TAG) * SLOT_HEADER_STRIDE
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(0x7FFF_FFFF));
+    f.instruction(&Instruction::I32And);
+    f.instruction(&Instruction::I32Const(SLOT_HEADER_STRIDE as i32));
+    f.instruction(&Instruction::I32Mul);
+    f.instruction(&Instruction::I32Const(new_state));
+    f.instruction(&Instruction::I32Store(bridge_arg(0, bridge_mem)));
+    f.instruction(&Instruction::End);
+    f
+}
+
+// Layout invariants the codegen masks/offsets rely on, checked at
+// compile time: RING_CAP must be a power of two (mask arithmetic), the
+// header table must fit below the ring storage, the rings must fit in
+// the fixed bridge memory, and LOCAL_TAG must be exactly bit 31 (so
+// `handle as i32 >= 0` means "host handle").
+const _: () = {
+    assert!(RING_CAP.is_power_of_two());
+    assert!(SLOT_COUNT * SLOT_HEADER_STRIDE <= RINGS_BASE - HEADER_BASE);
+    assert!(
+        (RINGS_BASE as u64) + (SLOT_COUNT as u64) * (RING_CAP as u64)
+            <= BRIDGE_MEMORY_PAGES * 65536
+    );
+    assert!(LOCAL_TAG == 1 << 31);
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_op_name_round_trip() {
+        for (name, op) in [
+            ("stream_new", StreamOp::New),
+            ("stream_read", StreamOp::Read),
+            ("stream_write", StreamOp::Write),
+            ("stream_drop_readable", StreamOp::DropReadable),
+            ("stream_drop_writable", StreamOp::DropWritable),
+        ] {
+            assert_eq!(StreamOp::from_name(name), Some(op));
+        }
+        // Cancel ops are deliberately NOT bridged.
+        assert_eq!(StreamOp::from_name("stream_cancel_read"), None);
+        assert_eq!(StreamOp::from_name("stream_cancel_write"), None);
+        assert_eq!(StreamOp::from_name("future_read"), None);
+    }
+}

--- a/meld-core/src/p3_bridge.rs
+++ b/meld-core/src/p3_bridge.rs
@@ -575,6 +575,18 @@ fn emit_write_shim(bridge_mem: u32, caller_mem: u32, host_write: u32) -> Functio
     emit_host_fallback(&mut f, host_write, 4);
     emit_slot_decode(&mut f);
 
+    // Mythos S2 hardening: a write to a slot whose reader (or writer)
+    // end was dropped must signal Closed, not silently fill the ring
+    // (ADR-2: "subsequent writes return Closed").
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Load(bridge_arg(0, bridge_mem)));
+    f.instruction(&Instruction::I32Const(STATE_WRITER_DROPPED));
+    f.instruction(&Instruction::I32GeU);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    f.instruction(&Instruction::I32Const(p3_async::AbiError::Closed.as_i32()));
+    f.instruction(&Instruction::Return);
+    f.instruction(&Instruction::End);
+
     // l6 = rd, l7 = wr
     f.instruction(&Instruction::LocalGet(4));
     f.instruction(&Instruction::I32Load(bridge_arg(4, bridge_mem)));
@@ -692,6 +704,16 @@ fn emit_read_shim(bridge_mem: u32, caller_mem: u32, host_read: u32) -> Function 
     f.instruction(&Instruction::LocalSet(8));
     emit_min_u(&mut f, 2, 8);
     f.instruction(&Instruction::LocalSet(8));
+
+    // Mythos S1 hardening: n==0 here means len==0 while data exists
+    // (the empty case returned above). 0 is the EOF sentinel — a
+    // zero-length probe must report Pending, never EOF.
+    f.instruction(&Instruction::LocalGet(8));
+    f.instruction(&Instruction::I32Eqz);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    f.instruction(&Instruction::I32Const(p3_async::AbiError::Pending.as_i32()));
+    f.instruction(&Instruction::Return);
+    f.instruction(&Instruction::End);
 
     // l9 = off = rd & (RING_CAP - 1)
     f.instruction(&Instruction::LocalGet(6));

--- a/meld-core/tests/p3_bridge_runtime.rs
+++ b/meld-core/tests/p3_bridge_runtime.rs
@@ -1,0 +1,728 @@
+//! Runtime oracles for the cross-component stream-bridge emitter
+//! (#141, SR-33, LS-ST-1).
+//!
+//! Two hand-built components are fused through the REAL pipeline and the
+//! fused core module is executed under wasmtime:
+//!
+//! * **producer** — core module importing `pulseengine:async`
+//!   `stream_new` / `stream_write` / `stream_drop_writable`, with driver
+//!   exports (`p_new`, `p_write`, `p_drop`) and its own memory.
+//! * **consumer** — core module importing `stream_read` /
+//!   `stream_drop_readable`, with driver exports (`c_read`, `c_get`,
+//!   `c_drop`) and its own (distinct) memory.
+//!
+//! ## How the pair detector is triggered (honest construction note)
+//!
+//! `p3_stream::build_stream_pair_graph` needs two things that a bare
+//! module-in-component wrapper does not have:
+//!
+//! 1. **Stream roles** — `CanonicalEntry::StreamWrite` / `StreamRead`
+//!    entries whose type resolves to a `stream`. We attach a component
+//!    type section defining an UNTYPED `stream` (payload `None`) plus a
+//!    canonical section with `stream.write` / `stream.read` against it.
+//!    The untyped stream is deliberate: the component-model validator
+//!    only demands a `memory` canonical option when the element type is
+//!    concrete, and a memory option would require instantiating a core
+//!    module inside the component (which would internalise the very
+//!    host imports this test must keep). `StreamElement::Untyped`
+//!    matches `Untyped`, so the detector pairs them.
+//! 2. **Fusion connection** — `resolved_imports` is keyed on
+//!    *component-level* import/export names. The producer component
+//!    exports its core module as `"link"` and the consumer component
+//!    imports a core module named `"link"`; the resolver matches them,
+//!    making the two components fusion-connected without disturbing the
+//!    core-level stream imports.
+//!
+//! This drives the emitter through `Fuser::fuse()` itself — no test-only
+//! entry point — so these tests cover detection→emission→rewiring→runtime
+//! end to end. (The fallback sanctioned by the #141 plan — driving the
+//! emitter directly with a constructed `StreamPairGraph` — was NOT
+//! needed.)
+//!
+//! ## The host-crossing proof
+//!
+//! The wasmtime host stubs for every `pulseengine:async` intrinsic TRAP
+//! when invoked with a bit-31-tagged (bridge-local) handle, and the
+//! tests additionally assert the stubs' call counters stay zero on the
+//! bridged paths. Any mis-dispatch of a local stream op to the host
+//! fails loudly.
+
+use meld_core::p3_bridge::{LOCAL_TAG, RING_CAP, SLOT_COUNT};
+use meld_core::{Fuser, FuserConfig, MemoryStrategy};
+use wasm_encoder::{
+    CanonicalFunctionSection, CodeSection, Component, ComponentExportKind, ComponentExportSection,
+    ComponentImportSection, ComponentTypeRef, ComponentTypeSection, CoreTypeSection, ExportKind,
+    ExportSection, Function, FunctionSection, ImportSection, Instruction, MemArg, MemorySection,
+    MemoryType, Module, ModuleSection, ModuleType, TypeSection, ValType,
+};
+use wasmtime::{Caller, Config, Engine, Instance, Linker, Module as RuntimeModule, Store};
+
+const ASYNC_MOD: &str = "pulseengine:async";
+
+/// Producer buffer base address (in producer memory).
+const P_BUF: i32 = 16;
+/// Consumer buffer base address (in consumer memory).
+const C_BUF: i32 = 32;
+
+fn mem8(memory_index: u32) -> MemArg {
+    MemArg {
+        offset: 0,
+        align: 0,
+        memory_index,
+    }
+}
+
+/// Producer core module.
+///
+/// imports: f0 `stream_new` `()->i64`, f1 `stream_write`
+/// `(i32,i32,i32,i32)->i32`, f2 `stream_drop_writable` `(i32)->()`.
+///
+/// exports:
+/// * `p_new() -> i64` — mint a stream pair.
+/// * `p_write(handle, count) -> i32` — fill its OWN memory at `P_BUF`
+///   with bytes `(i+1) & 0xff` for `i in 0..count`, then
+///   `stream_write(handle, P_BUF, count, 0)`.
+/// * `p_drop(handle)` — drop the writable end.
+fn build_producer_module() -> Module {
+    let mut types = TypeSection::new();
+    types.ty().function([], [ValType::I64]); // t0: stream_new / p_new
+    types.ty().function([ValType::I32; 4], [ValType::I32]); // t1: stream_write
+    types.ty().function([ValType::I32], []); // t2: drop / p_drop
+    types
+        .ty()
+        .function([ValType::I32, ValType::I32], [ValType::I32]); // t3: p_write
+
+    let mut imports = ImportSection::new();
+    imports.import(
+        ASYNC_MOD,
+        "stream_new",
+        wasm_encoder::EntityType::Function(0),
+    );
+    imports.import(
+        ASYNC_MOD,
+        "stream_write",
+        wasm_encoder::EntityType::Function(1),
+    );
+    imports.import(
+        ASYNC_MOD,
+        "stream_drop_writable",
+        wasm_encoder::EntityType::Function(2),
+    );
+
+    let mut functions = FunctionSection::new();
+    functions.function(0); // f3: p_new
+    functions.function(3); // f4: p_write
+    functions.function(2); // f5: p_drop
+
+    let mut memory = MemorySection::new();
+    memory.memory(MemoryType {
+        minimum: 1,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+
+    let mut exports = ExportSection::new();
+    exports.export("p_new", ExportKind::Func, 3);
+    exports.export("p_write", ExportKind::Func, 4);
+    exports.export("p_drop", ExportKind::Func, 5);
+
+    let mut code = CodeSection::new();
+
+    // p_new: call stream_new
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::Call(0));
+    f.instruction(&Instruction::End);
+    code.function(&f);
+
+    // p_write(handle l0, count l1), local l2 = i
+    let mut f = Function::new([(1, ValType::I32)]);
+    f.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+    f.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32GeU);
+    f.instruction(&Instruction::BrIf(1));
+    // mem[P_BUF + i] = (i + 1) (store8 truncates to & 0xff)
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Const(P_BUF));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::I32Store8(mem8(0)));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I32Const(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::Br(0));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::End);
+    // stream_write(handle, P_BUF, count, 0)
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(P_BUF));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::Call(1));
+    f.instruction(&Instruction::End);
+    code.function(&f);
+
+    // p_drop(handle)
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::Call(2));
+    f.instruction(&Instruction::End);
+    code.function(&f);
+
+    let mut module = Module::new();
+    module
+        .section(&types)
+        .section(&imports)
+        .section(&functions)
+        .section(&memory)
+        .section(&exports)
+        .section(&code);
+    module
+}
+
+/// Consumer core module.
+///
+/// imports: f0 `stream_read` `(i32,i32,i32,i32)->i32`,
+/// f1 `stream_drop_readable` `(i32)->()`.
+///
+/// exports:
+/// * `c_read(handle, count) -> i32` — `stream_read(handle, C_BUF, count, 0)`
+///   into its OWN memory.
+/// * `c_get(i) -> i32` — `mem[C_BUF + i]` (u8 load) to verify integrity.
+/// * `c_drop(handle)` — drop the readable end.
+fn build_consumer_module() -> Module {
+    let mut types = TypeSection::new();
+    types.ty().function([ValType::I32; 4], [ValType::I32]); // t0: stream_read
+    types.ty().function([ValType::I32], []); // t1: drop / c_drop
+    types
+        .ty()
+        .function([ValType::I32, ValType::I32], [ValType::I32]); // t2: c_read
+    types.ty().function([ValType::I32], [ValType::I32]); // t3: c_get
+
+    let mut imports = ImportSection::new();
+    imports.import(
+        ASYNC_MOD,
+        "stream_read",
+        wasm_encoder::EntityType::Function(0),
+    );
+    imports.import(
+        ASYNC_MOD,
+        "stream_drop_readable",
+        wasm_encoder::EntityType::Function(1),
+    );
+
+    let mut functions = FunctionSection::new();
+    functions.function(2); // f2: c_read
+    functions.function(3); // f3: c_get
+    functions.function(1); // f4: c_drop
+
+    let mut memory = MemorySection::new();
+    memory.memory(MemoryType {
+        minimum: 1,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+
+    let mut exports = ExportSection::new();
+    exports.export("c_read", ExportKind::Func, 2);
+    exports.export("c_get", ExportKind::Func, 3);
+    exports.export("c_drop", ExportKind::Func, 4);
+
+    let mut code = CodeSection::new();
+
+    // c_read(handle l0, count l1)
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(C_BUF));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::Call(0));
+    f.instruction(&Instruction::End);
+    code.function(&f);
+
+    // c_get(i)
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(C_BUF));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::I32Load8U(mem8(0)));
+    f.instruction(&Instruction::End);
+    code.function(&f);
+
+    // c_drop(handle)
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::Call(1));
+    f.instruction(&Instruction::End);
+    code.function(&f);
+
+    let mut module = Module::new();
+    module
+        .section(&types)
+        .section(&imports)
+        .section(&functions)
+        .section(&memory)
+        .section(&exports)
+        .section(&code);
+    module
+}
+
+/// Producer component: untyped `stream` type + `canon stream.write`
+/// (StreamWrite role for the pair detector), the core module, and a
+/// component-level export of that module as `"link"` (the fusion
+/// connection anchor).
+fn producer_component() -> Vec<u8> {
+    let mut component = Component::new();
+
+    let mut ctypes = ComponentTypeSection::new();
+    ctypes.defined_type().stream(None); // component type 0: stream (untyped)
+    component.section(&ctypes);
+
+    let mut canon = CanonicalFunctionSection::new();
+    canon.stream_write(0, []);
+    component.section(&canon);
+
+    component.section(&ModuleSection(&build_producer_module()));
+
+    let mut exports = ComponentExportSection::new();
+    exports.export("link", ComponentExportKind::Module, 0, None);
+    component.section(&exports);
+
+    component.finish()
+}
+
+/// Consumer component: a core-module-typed import named `"link"` (the
+/// fusion connection anchor), untyped `stream` type + `canon
+/// stream.read` (StreamRead role), and the core module.
+fn consumer_component() -> Vec<u8> {
+    let mut component = Component::new();
+
+    let mut core_types = CoreTypeSection::new();
+    core_types.ty().module(&ModuleType::new()); // core type 0: (module)
+    component.section(&core_types);
+
+    let mut imports = ComponentImportSection::new();
+    imports.import("link", ComponentTypeRef::Module(0));
+    component.section(&imports);
+
+    let mut ctypes = ComponentTypeSection::new();
+    ctypes.defined_type().stream(None); // component type 0: stream (untyped)
+    component.section(&ctypes);
+
+    let mut canon = CanonicalFunctionSection::new();
+    canon.stream_read(0, []);
+    component.section(&canon);
+
+    component.section(&ModuleSection(&build_consumer_module()));
+
+    component.finish()
+}
+
+/// Fuse producer + consumer through the real pipeline (multi-memory —
+/// the cross-memory bridge shape; same-memory is the identical codegen
+/// with caller-memory immediates 0).
+fn fuse_pair() -> Vec<u8> {
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        component_provenance: false,
+        address_rebasing: false,
+        preserve_names: false,
+        custom_sections: meld_core::CustomSectionHandling::Drop,
+        dwarf_handling: meld_core::DwarfHandling::Strip,
+        output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
+    };
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&producer_component(), Some("producer"))
+        .expect("add producer");
+    fuser
+        .add_component_named(&consumer_component(), Some("consumer"))
+        .expect("add consumer");
+    fuser.fuse().expect("fuse")
+}
+
+/// Host-stub call counters — the "no host crossing" witness.
+#[derive(Default)]
+struct HostCounters {
+    new: u32,
+    read: u32,
+    write: u32,
+    drops: u32,
+}
+
+/// `Err` (→ wasm trap) on any bit-31-tagged handle reaching the host.
+fn guard(handle: i32, op: &str) -> wasmtime::Result<()> {
+    if (handle as u32) & LOCAL_TAG != 0 {
+        anyhow::bail!("bridge-local handle {handle:#x} crossed the host boundary via {op}");
+    }
+    Ok(())
+}
+
+/// Instantiate the fused core module with trapping host stubs.
+///
+/// Host `stream_new` mints untagged handles (readable = 1, writable = 2;
+/// then 3/4, …) — exercised only by the slot-exhaustion fallback test.
+/// Host `stream_write` accepts everything; host `stream_read` returns 0.
+fn instantiate(fused: &[u8]) -> (Store<HostCounters>, Instance) {
+    let mut cfg = Config::new();
+    cfg.wasm_multi_memory(true);
+    let engine = Engine::new(&cfg).expect("engine");
+    let module = RuntimeModule::new(&engine, fused).expect("fused module must validate");
+    let mut store = Store::new(&engine, HostCounters::default());
+
+    let mut linker: Linker<HostCounters> = Linker::new(&engine);
+    linker
+        .func_wrap(
+            ASYNC_MOD,
+            "stream_new",
+            |mut caller: Caller<'_, HostCounters>| -> wasmtime::Result<i64> {
+                let n = caller.data().new;
+                caller.data_mut().new = n + 1;
+                let readable = i64::from(2 * n + 1);
+                let writable = i64::from(2 * n + 2);
+                Ok((writable << 32) | readable)
+            },
+        )
+        .unwrap();
+    linker
+        .func_wrap(
+            ASYNC_MOD,
+            "stream_read",
+            |mut caller: Caller<'_, HostCounters>,
+             h: i32,
+             _ptr: i32,
+             _len: i32,
+             _mem: i32|
+             -> wasmtime::Result<i32> {
+                guard(h, "stream_read")?;
+                caller.data_mut().read += 1;
+                Ok(0)
+            },
+        )
+        .unwrap();
+    linker
+        .func_wrap(
+            ASYNC_MOD,
+            "stream_write",
+            |mut caller: Caller<'_, HostCounters>,
+             h: i32,
+             _ptr: i32,
+             len: i32,
+             _mem: i32|
+             -> wasmtime::Result<i32> {
+                guard(h, "stream_write")?;
+                caller.data_mut().write += 1;
+                Ok(len)
+            },
+        )
+        .unwrap();
+    for name in ["stream_drop_readable", "stream_drop_writable"] {
+        linker
+            .func_wrap(
+                ASYNC_MOD,
+                name,
+                move |mut caller: Caller<'_, HostCounters>, h: i32| -> wasmtime::Result<()> {
+                    guard(h, "stream_drop_*")?;
+                    caller.data_mut().drops += 1;
+                    Ok(())
+                },
+            )
+            .unwrap();
+    }
+
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .expect("instantiate");
+    (store, instance)
+}
+
+struct Drivers {
+    p_new: wasmtime::TypedFunc<(), i64>,
+    p_write: wasmtime::TypedFunc<(i32, i32), i32>,
+    p_drop: wasmtime::TypedFunc<i32, ()>,
+    c_read: wasmtime::TypedFunc<(i32, i32), i32>,
+    c_get: wasmtime::TypedFunc<i32, i32>,
+}
+
+fn drivers(store: &mut Store<HostCounters>, instance: &Instance) -> Drivers {
+    Drivers {
+        p_new: instance.get_typed_func(&mut *store, "p_new").unwrap(),
+        p_write: instance.get_typed_func(&mut *store, "p_write").unwrap(),
+        p_drop: instance.get_typed_func(&mut *store, "p_drop").unwrap(),
+        c_read: instance.get_typed_func(&mut *store, "c_read").unwrap(),
+        c_get: instance.get_typed_func(&mut *store, "c_get").unwrap(),
+    }
+}
+
+/// Split a packed `stream_new` result: low 32 = readable, high 32 = writable.
+fn split(pair: i64) -> (i32, i32) {
+    ((pair & 0xFFFF_FFFF) as i32, (pair >> 32) as i32)
+}
+
+fn assert_no_host_calls(store: &Store<HostCounters>) {
+    let c = store.data();
+    assert_eq!(
+        (c.new, c.read, c.write, c.drops),
+        (0, 0, 0, 0),
+        "bridged stream ops must never cross the host boundary"
+    );
+}
+
+/// Count the memories declared by the fused core module (independent
+/// wasmparser derivation).
+fn count_memories(fused: &[u8]) -> usize {
+    let mut count = 0;
+    for payload in wasmparser::Parser::new(0).parse_all(fused) {
+        if let wasmparser::Payload::MemorySection(reader) = payload.unwrap() {
+            count += reader.into_iter().count();
+        }
+    }
+    count
+}
+
+/// Oracle (a) — round-trip: the producer writes `[1, 2, 3, 4]` through a
+/// bridge-local stream and the consumer reads the same bytes back, with
+/// ZERO host intrinsic calls. (`ls_st_1_` prefix: LS-ST-1 gate fixture.)
+#[test]
+fn ls_st_1_round_trip_local_stream_never_crosses_host() {
+    let fused = fuse_pair();
+    let (mut store, instance) = instantiate(&fused);
+    let d = drivers(&mut store, &instance);
+
+    let pair = d.p_new.call(&mut store, ()).unwrap();
+    let (readable, writable) = split(pair);
+    assert_ne!(
+        (readable as u32) & LOCAL_TAG,
+        0,
+        "in-module stream_new must mint a bridge-local (tagged) readable end"
+    );
+    assert_ne!(
+        (writable as u32) & LOCAL_TAG,
+        0,
+        "writable end must be tagged"
+    );
+
+    let written = d.p_write.call(&mut store, (writable, 4)).unwrap();
+    assert_eq!(written, 4, "ring has space: all 4 bytes accepted");
+
+    let read = d.c_read.call(&mut store, (readable, 8)).unwrap();
+    assert_eq!(
+        read, 4,
+        "read returns the buffered byte count, not the request"
+    );
+
+    for i in 0..4 {
+        let byte = d.c_get.call(&mut store, i).unwrap();
+        assert_eq!(byte, i + 1, "byte {i} must survive the bridge intact");
+    }
+
+    assert_no_host_calls(&store);
+}
+
+/// Oracle (b) — cross-memory chain: producer memory ≠ consumer memory
+/// (multi-memory fusion keeps one memory per component, plus the bridge
+/// memory), and data still arrives intact across the two `memory.copy`
+/// hops (producer mem → bridge ring → consumer mem).
+#[test]
+fn cross_memory_chain_preserves_data_across_distinct_memories() {
+    let fused = fuse_pair();
+    assert_eq!(
+        count_memories(&fused),
+        3,
+        "fused module must carry producer memory + consumer memory + bridge memory"
+    );
+
+    let (mut store, instance) = instantiate(&fused);
+    let d = drivers(&mut store, &instance);
+
+    let (readable, writable) = split(d.p_new.call(&mut store, ()).unwrap());
+
+    // 300 bytes exercises multi-byte copies and the (i+1) & 0xff wrap.
+    assert_eq!(d.p_write.call(&mut store, (writable, 300)).unwrap(), 300);
+    assert_eq!(d.c_read.call(&mut store, (readable, 4096)).unwrap(), 300);
+    for i in 0..300 {
+        let expected = (i + 1) & 0xff;
+        let byte = d.c_get.call(&mut store, i).unwrap();
+        assert_eq!(byte, expected, "byte {i} corrupted crossing memories");
+    }
+
+    assert_no_host_calls(&store);
+}
+
+/// Oracle (c) — backpressure: a write larger than RING_CAP returns the
+/// accepted count (= RING_CAP, ADR-2 Partial); once the consumer drains
+/// the ring, a follow-up write accepts the rest.
+#[test]
+fn backpressure_partial_write_then_drain_then_resume() {
+    let fused = fuse_pair();
+    let (mut store, instance) = instantiate(&fused);
+    let d = drivers(&mut store, &instance);
+
+    let (readable, writable) = split(d.p_new.call(&mut store, ()).unwrap());
+
+    let requested = RING_CAP as i32 + 904; // 5000 > ring capacity
+    let accepted = d.p_write.call(&mut store, (writable, requested)).unwrap();
+    assert_eq!(
+        accepted, RING_CAP as i32,
+        "write > capacity must return the accepted count, not trap or queue"
+    );
+
+    // Ring is full now: another write is pure backpressure (0 ≠ EOF).
+    assert_eq!(
+        d.p_write.call(&mut store, (writable, 1)).unwrap(),
+        0,
+        "full ring must report 0 accepted (ADR-2: 0 from write is backpressure)"
+    );
+
+    // Drain everything the ring holds.
+    let drained = d
+        .c_read
+        .call(&mut store, (readable, RING_CAP as i32 + 904))
+        .unwrap();
+    assert_eq!(
+        drained, RING_CAP as i32,
+        "drain returns exactly the fill level"
+    );
+    assert_eq!(d.c_get.call(&mut store, 0).unwrap(), 1);
+    assert_eq!(
+        d.c_get.call(&mut store, RING_CAP as i32 - 1).unwrap(),
+        (RING_CAP as i32) & 0xff,
+        "last drained byte must match the producer pattern"
+    );
+
+    // Producer retries the unaccepted tail (ADR-2: producer is the retry
+    // authority). The wrap-around copy path is exercised here: the write
+    // starts at ring offset 4096 & 4095 = 0 after one full cycle… and a
+    // second partial cycle below crosses the ring boundary.
+    let resumed = d.p_write.call(&mut store, (writable, 904)).unwrap();
+    assert_eq!(
+        resumed, 904,
+        "after drain the ring must accept the remainder"
+    );
+    let read2 = d.c_read.call(&mut store, (readable, 8192)).unwrap();
+    assert_eq!(read2, 904);
+    assert_eq!(d.c_get.call(&mut store, 0).unwrap(), 1);
+    assert_eq!(d.c_get.call(&mut store, 903).unwrap(), 904 & 0xff);
+
+    // Cross the ring boundary mid-write: both cursors sit at 5000, so the
+    // ring offset is 5000 & 4095 = 904 and a 3500-byte transfer splits
+    // into 3192 + 308 — the two-part wrapping memory.copy path runs with
+    // both parts non-empty, on the write AND the read side.
+    assert_eq!(d.p_write.call(&mut store, (writable, 3500)).unwrap(), 3500);
+    assert_eq!(d.c_read.call(&mut store, (readable, 8192)).unwrap(), 3500);
+    for i in [0, 3191, 3192, 3499] {
+        assert_eq!(
+            d.c_get.call(&mut store, i).unwrap(),
+            (i + 1) & 0xff,
+            "byte {i} corrupted across the ring wrap boundary"
+        );
+    }
+
+    assert_no_host_calls(&store);
+}
+
+/// Oracle (d) — EOF: while the stream is open and empty, read returns
+/// `-5` (ADR-2 Pending); after `drop_writable` the reader drains the
+/// remaining bytes and only THEN observes `0` (EOF), which is sticky.
+/// (`ls_st_1_` prefix: LS-ST-1 gate fixture.)
+#[test]
+fn ls_st_1_eof_only_after_writer_drop_and_drain() {
+    let fused = fuse_pair();
+    let (mut store, instance) = instantiate(&fused);
+    let d = drivers(&mut store, &instance);
+
+    let (readable, writable) = split(d.p_new.call(&mut store, ()).unwrap());
+
+    // Open + empty ⇒ Pending, NOT EOF.
+    assert_eq!(
+        d.c_read.call(&mut store, (readable, 8)).unwrap(),
+        -5,
+        "open+empty must be Pending (-5), distinguishable from EOF"
+    );
+
+    assert_eq!(d.p_write.call(&mut store, (writable, 4)).unwrap(), 4);
+    d.p_drop.call(&mut store, writable).unwrap();
+
+    // Buffered bytes drain first — dropping the writer must not lose data.
+    assert_eq!(d.c_read.call(&mut store, (readable, 2)).unwrap(), 2);
+    assert_eq!(d.c_get.call(&mut store, 0).unwrap(), 1);
+    assert_eq!(d.c_get.call(&mut store, 1).unwrap(), 2);
+    assert_eq!(d.c_read.call(&mut store, (readable, 8)).unwrap(), 2);
+    assert_eq!(d.c_get.call(&mut store, 0).unwrap(), 3);
+    assert_eq!(d.c_get.call(&mut store, 1).unwrap(), 4);
+
+    // Drained + writer-dropped ⇒ EOF (0), and it stays EOF.
+    assert_eq!(d.c_read.call(&mut store, (readable, 8)).unwrap(), 0);
+    assert_eq!(
+        d.c_read.call(&mut store, (readable, 8)).unwrap(),
+        0,
+        "EOF is sticky"
+    );
+
+    assert_no_host_calls(&store);
+}
+
+/// Fallback dispatch: exhausting all bridge slots makes `stream_new`
+/// fall back to the HOST intrinsic (untagged handles), and ops on those
+/// handles route to the host imports — the stubs see them and accept
+/// them (the guard only rejects TAGGED handles).
+#[test]
+fn slot_exhaustion_falls_back_to_host_stream() {
+    let fused = fuse_pair();
+    let (mut store, instance) = instantiate(&fused);
+    let d = drivers(&mut store, &instance);
+
+    for i in 0..SLOT_COUNT {
+        let (readable, _writable) = split(d.p_new.call(&mut store, ()).unwrap());
+        assert_ne!(
+            (readable as u32) & LOCAL_TAG,
+            0,
+            "slot {i} must still be bridge-local"
+        );
+    }
+    assert_eq!(store.data().new, 0, "no host fallback before exhaustion");
+
+    // Ninth stream: bridge slots exhausted → host mints it.
+    let (readable, writable) = split(d.p_new.call(&mut store, ()).unwrap());
+    assert_eq!(
+        store.data().new,
+        1,
+        "exhaustion must fall back to host stream_new"
+    );
+    assert_eq!(
+        (readable as u32) & LOCAL_TAG,
+        0,
+        "host-minted readable end must be untagged"
+    );
+    assert_eq!((writable as u32) & LOCAL_TAG, 0);
+
+    // Ops on the host handle cross to the host import (and only those).
+    assert_eq!(d.p_write.call(&mut store, (writable, 4)).unwrap(), 4);
+    assert_eq!(
+        store.data().write,
+        1,
+        "foreign-handle write must reach the host"
+    );
+    assert_eq!(d.c_read.call(&mut store, (readable, 4)).unwrap(), 0);
+    assert_eq!(
+        store.data().read,
+        1,
+        "foreign-handle read must reach the host"
+    );
+    d.p_drop.call(&mut store, writable).unwrap();
+    assert_eq!(
+        store.data().drops,
+        1,
+        "foreign-handle drop must reach the host"
+    );
+}

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -718,13 +718,18 @@ artifacts:
     description: >
       When two fused components share a `stream<T>` endpoint, meld shall
       emit an in-module adapter that bridges the two sides without round-
-      tripping through the host. Two modes:
-      (a) same-memory (single-memory fusion): direct in-module ring buffer,
-      zero-copy.
-      (b) different-memory (multi-memory): `stream_read` → in-module copy
-      loop → `stream_write` chain, with `cabi_realloc` null-guard policy
-      per LS-A-7.
-    status: planned
+      tripping through the host. Shipped shape (shim-dispatch bridge,
+      #141 design comment + ADR-3 amendment): one bridge ring memory +
+      per-component dispatch shims with hardwired memory immediates;
+      handles minted in-module carry bit 31 (LOCAL_TAG) and route to the
+      ring, host handles keep routing to the retained pulseengine:async
+      imports. Same-memory fusion is the identical codegen with caller-
+      memory immediates 0 — the original "zero-copy same-memory ring"
+      claim is amended to "no host crossing, single copy", because the
+      ABI's caller-buffer contract (stream_read(handle, buf_ptr, …))
+      requires a copy into the caller's buffer regardless; fusion removes
+      the double host round-trip per chunk.
+    status: implemented
     tags: [roadmap, p3-async, v0.29.0]
     links:
       - type: derives-from
@@ -733,22 +738,37 @@ artifacts:
         target: "#141"
     fields:
       implementation:
+        - meld-core/src/p3_bridge.rs
         - meld-core/src/p3_stream.rs
         - meld-core/src/resolver.rs
       verification-method: test
       verification-description: >
-        Status correction (audit 2026-06-10, reverting the bulk flip in
-        PR #211): only the DETECTION half shipped in v0.9.0 (#173) —
-        `StreamPairGraph` built at resolve time (resolver.rs /
-        p3_stream.rs), gated by the four ADR-3 detection fixtures. The
-        emitter this requirement actually demands (same-memory ring
-        buffer; cross-memory read→copy→write chain) is NOT implemented:
-        fused stream traffic still round-trips through `pulseengine:async`
-        host imports, fact.rs contains no stream bridging code, and the
-        named runtime fixtures (zero-copy, chain, backpressure, EOF) exist
-        only as ABI-enum unit tests. ADR-3 (status open) records the
-        deferral as the chosen path. Emitter + runtime fixtures + Mythos
-        pass are the v0.29.0 scope (docs/roadmap.md).
+        Honest history: only the DETECTION half shipped in v0.9.0 (#173)
+        — `StreamPairGraph` built at resolve time, gated by the four
+        ADR-3 detection fixtures — and the emitter was MISSING until
+        v0.29.0 (the v0.9.0-era `implemented` status was a bulk-sync
+        error, reverted in PR #221 after the 2026-06-10 audit). The
+        v0.29.0 emitter (p3_bridge.rs, consuming the StreamPairGraph) is
+        verified by four RUNTIME oracles in tests/p3_bridge_runtime.rs
+        that fuse two hand-built components through the real pipeline
+        and execute the fused module under wasmtime with host stubs that
+        trap on any bridge-local (bit-31-tagged) handle:
+        (1) ls_st_1_round_trip_local_stream_never_crosses_host — bytes
+        [1,2,3,4] producer→consumer through a local stream, zero host
+        intrinsic calls; (2)
+        cross_memory_chain_preserves_data_across_distinct_memories —
+        multi-memory fusion (producer mem ≠ consumer mem ≠ bridge mem),
+        300-byte pattern intact across both memory.copy hops; (3)
+        backpressure_partial_write_then_drain_then_resume — write >
+        RING_CAP returns the accepted count (ADR-2 Partial), 0 on a full
+        ring, remainder accepted after drain, two-part ring-wrap copy
+        exercised on write and read; (4)
+        ls_st_1_eof_only_after_writer_drop_and_drain — read is -5
+        (Pending) while open+empty, drains buffered bytes after
+        drop_writable, returns 0 (EOF, sticky) only once drained.
+        slot_exhaustion_falls_back_to_host_stream additionally pins the
+        graceful host fallback (9th stream is host-minted and its ops
+        reach the host imports). LS-ST-1 records the hazard analysis.
       milestone: v0.29.0
 
   - id: SR-34

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -3111,3 +3111,77 @@ loss-scenarios:
       standalone, compute()==42 ∧ greet()==7) and the full wit-bindgen
       runtime suite (WASI imports stay declared — wrong-drop
       regression).
+
+  - id: LS-ST-1
+    title: stream bridge mis-routes an op or corrupts ring cursors
+    uca: UCA-A-4
+    hazards: [H-1, H-3, H-4]
+    type: inadequate-control-algorithm
+    scenario: >
+      The #141 stream-bridge emitter dispatches every stream op on
+      handle bit 31 (LOCAL_TAG): tagged → in-module ring ops against the
+      bridge memory; untagged → the retained pulseengine:async host
+      import. A wrong dispatch in either direction is silent data-plane
+      corruption: a LOCAL handle forwarded to the host targets a stream
+      the runtime never minted (data vanishes or the runtime corrupts an
+      unrelated handle's state [H-3]); a FOREIGN handle routed to the
+      ring reads/writes a bridge slot whose header was never claimed
+      [H-1]. Independently, the ring protocol itself can be emitted
+      wrong: swapped memory.copy src/dst immediates (the UCA-A-4
+      pattern, now with a third memory in play), a fill-level computed
+      with saturating instead of wrapping u32 arithmetic, a missed
+      second copy part at the ring wrap boundary, or rd/wr cursor
+      updates landing at the wrong header offset — each corrupts bytes
+      or cursor state while every call still returns a plausible count
+      [H-4]. The ADR-2 contract is also routable wrong-by-construction:
+      returning 0 from an open-and-empty read turns Pending into a
+      false EOF; returning Pending after the writer dropped wedges the
+      consumer forever.
+    causal-factors:
+      - >-
+        the bridge must reimplement the host runtime's stream
+        semantics in raw core-wasm codegen — there is no shared
+        implementation to diverge-check against, only the ADR-2
+        contract
+      - >-
+        memory immediates are hardwired per component (the ABI's
+        dynamic mem_idx cannot be honoured in-module), so a per-
+        component shim wired with another component's memory index
+        compiles and validates but copies through the wrong memory
+      - >-
+        cursor arithmetic correctness depends on RING_CAP being a
+        power of two and on u32 wrap-around being intentional; a
+        future "cleanup" to checked arithmetic would break the
+        full-vs-empty distinction
+      - >-
+        the host-handle invariant (host handles < 2^31, ADR-2
+        small-int convention) is owned by the runtime, not meld; a
+        runtime minting large handles would alias the tag
+    process-model-flaw: >
+      The emitter's model is "handle provenance is decidable from bit
+      31 alone". That holds only while in-module minting is the sole
+      source of tagged handles and the runtime honours the small-int
+      convention — so the dispatch and the ring protocol must be pinned
+      by runtime fixtures whose host stubs trap on any tagged handle,
+      making a mis-route loud instead of silent.
+    status: approved
+    priority: high
+    fix: >
+      p3_bridge.rs emits the dispatch prologue from a single shared
+      helper (emit_host_fallback) and the ring ops with bridge/caller
+      memory immediates taken from the merged memory_index_map. Pinned
+      by the four runtime oracles in tests/p3_bridge_runtime.rs, which
+      fuse two hand-built components through the real pipeline and
+      execute the fused module under wasmtime with host stubs that TRAP
+      on any bit-31-tagged handle:
+      ls_st_1_round_trip_local_stream_never_crosses_host (local
+      round-trip, zero host calls),
+      cross_memory_chain_preserves_data_across_distinct_memories
+      (3-memory integrity incl. byte-pattern check),
+      backpressure_partial_write_then_drain_then_resume (Partial at
+      RING_CAP, 0-accepted on full ring, resume after drain, two-part
+      wrap copy on both sides), and
+      ls_st_1_eof_only_after_writer_drop_and_drain (Pending -5 while
+      open+empty; EOF 0 only after drop_writable AND drain; sticky).
+      slot_exhaustion_falls_back_to_host_stream pins the untagged
+      fallback direction (host ops are reached exactly once each).


### PR DESCRIPTION
v0.29.0 scope — the emitter the SR-33 audit proved was never built (closes #141; design recorded on the issue, ADR-3 path-N follow-up).

## What

`meld-core/src/p3_bridge.rs` (Tier-5, pre-registered in #238): when the fused module's `StreamPairGraph` is non-empty, meld emits a **bridge memory** (slot headers + 8×4096B rings), per-component **shims** for the five stream intrinsics with the component's memory index hardwired, and rewires intrinsic call sites to the shims. Dispatch on handle bit 31: locally-minted handles → in-module ring ops (no host crossing); foreign handles → the retained host imports; slot exhaustion → host `stream_new` fallback. ADR-2 contract preserved end-to-end (write returns accepted count, 0 = backpressure; read returns bytes, 0 = EOF only after writer-drop AND drain, −5 Pending; drop_writable half-closes).

## Oracles (runtime, through the REAL pipeline)

Five fixtures fuse two hand-built components (which trigger the real pair detector — untyped `stream` canon entries + fusion connection via a linked core-module export) and execute under wasmtime with host stubs that **trap on any tagged handle** plus zero-call counters:

- `ls_st_1_round_trip_local_stream_never_crosses_host`
- `cross_memory_chain_preserves_data_across_distinct_memories`
- `backpressure_partial_write_then_drain_then_resume`
- `ls_st_1_eof_only_after_writer_drop_and_drain`
- `slot_exhaustion_falls_back_to_host_stream`

All pass; workspace 537/0; clippy/fmt clean. LS-ST-1 approved; SR-33 → implemented (honest history note kept; ADR-3 "zero-copy" amended to "no host crossing, single copy").

## Notes & limitations (documented in-module)

Emitter runs before adapter wiring (adapter indices bake in `functions.len()`); slots retire on `drop_readable` (no reuse — degrades to host, never loses data); cancel ops stay host-routed (bridged ops never block); module-wide `stream_new` takeover is the accepted static-pairing over-approximation; shared-memory mode is the same codegen with immediates 0 but has no dedicated runtime fixture.

Mythos clean-room pass to follow as comment + label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)