### PR TITLE
release: v0.30.0 — machine-checked canonical-ABI invariants (#218 inc 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-06-11
+
+### Added
+
+- **Machine-checked Canonical-ABI invariants** (#218 inc 1, SR-40;
+  PR #241). Three Kani harnesses, each VERIFICATION SUCCESSFUL:
+  flags<N> storage classes at every class boundary (LS-A-20),
+  total_flat_params saturating monotonicity (LS-P-9), and the #141
+  stream-bridge ring-cursor invariant under u32 wraparound (model
+  compile-tied to the emitter's constants). Honest scope cuts
+  recorded in-module and in SR-40: nondet leaf/container and
+  aggregate-padding harnesses do not converge in CBMC against the
+  current ParsedComponent heap shape — those contracts remain pinned
+  by the exhaustive unit tests; tractable post allocation-free
+  layout-core refactor. Kani CI wiring is follow-up (runners lack the
+  toolchain); the local invocation is pinned in abi_proofs.rs.
+
+### Pre-release Mythos note
+
+No Tier-5 files changed since v0.29.0 (abi_proofs.rs is
+cfg(kani)-gated; one module-registration line in lib.rs).
+
+### Falsification statement
+
+Claim: the three stated invariants hold for all inputs within the
+harness bounds. Refute by `cargo kani --harness <name>` returning
+FAILED on any of ring_cursor_invariant_inductive,
+total_flat_params_saturating_monotone, flags_layout_matches_spec.
+
 ## [0.29.0] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
Release PR. Scope: #241 (SR-40 implemented; 3× Kani VERIFICATION SUCCESSFUL with honest scope cuts recorded). Falsification statement in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)