### PR TITLE
release: v0.31.0 — full traceability audit (campaign V closed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-06-13
+
+### Changed (traceability audit — closes the campaign V)
+
+- **Full rivet-V audit, v0.22→v0.30** (#96 campaign tail; PR follows).
+  A clean-room read-only audit walked every SR-1…SR-40 and every
+  approved loss scenario against executed oracles, then this PR
+  applied the corrections:
+  - **Restored SR-37** (auto-memory soundness) — silently dropped by a
+    prior bulk YAML edit (PR #226); now present and `verified`.
+  - **Authored SR-27…SR-30** — had traceability + passing attestation
+    tests but no requirement artifacts; now defined and `verified`.
+  - **16 status upgrades to `verified`** where named oracles
+    demonstrably pass (SR-12/13/15, SR-19–26, SR-31, SR-32, SR-33,
+    SR-39, SR-40), each anchored to executed tests/harnesses.
+  - **SR-34 disposition**: the never-produced Kani cycle harness is
+    accepted on its test oracle (recorded in-artifact, not silent).
+  - **Stale-reference fixes**: SR-35 impl path (dwarf_remap.rs →
+    dwarf.rs), SR-6 proof path, SR-40 proof count (286 → 350),
+    traceability notes for SR-17/25/31, resource-handle draft id
+    collisions renumbered to SR-RH-1…8, proofs/STATUS.md metrics
+    (28 files / 14,487 lines / 350 Qed / 0 admitted + Kani layer).
+  - **LS gate closure**: lib-scope pins added for LS-R-13 and LS-M-6 —
+    `run_ls_verification.py` now reports 45 approved / 45 passed /
+    **0 missing** (was 2 discovery gaps).
+  - **No honest downgrades required**: no SR status was found to
+    overstate reality — the 2026-06-10 SR-33 emitter-gap class of
+    defect does not recur anywhere.
+- **Issues closed**: #218 (formal soundness inc 1, shipped v0.30.0),
+  #139 (smithy reliability — admin-bypass policy lifted and enforced).
+
+### Pre-release Mythos note
+
+No Tier-5 files changed (safety YAML, proofs/STATUS.md, and lib.rs
+test-module additions only).
+
+### Falsification statement
+
+Claim: for every `verified` requirement in scope, the named
+verification oracle exists and passes today. Refute by running the
+named test/harness or `python3 tools/run_ls_verification.py` (exit 0,
+0 missing) and finding a discrepancy.
+
 ## [0.30.0] - 2026-06-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.30.0"
+version = "0.31.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -2684,4 +2684,137 @@ mod tests {
             result
         );
     }
+
+    /// LS-R-13: the stream-cycle detector must not exhaust the call
+    /// stack on a deep linear chain. Re-pins, at lib scope where the LS
+    /// verification gate discovers it, what
+    /// `p3_stream::tests::deep_linear_chain_does_not_overflow_stack`
+    /// pins module-internally: a 50 000-component producer→consumer
+    /// chain (deep enough to overflow the default 8 MB thread stack
+    /// under a recursive Tarjan, which both the first draft and
+    /// petgraph 0.8's tarjan_scc were) is validated without a stack
+    /// overflow and without flagging a spurious cycle. Built entirely
+    /// through the public `p3_stream` API.
+    #[test]
+    fn ls_r_13_deep_linear_chain_does_not_overflow_stack() {
+        use crate::p3_stream::{
+            StreamElement, StreamEndpoint, StreamMemoryMode, StreamPair, StreamPairGraph,
+            StreamRole, cycle_issues_from_pairs,
+        };
+
+        let n = 50_000usize;
+        let mut pairs = Vec::with_capacity(n - 1);
+        for i in 0..(n - 1) {
+            pairs.push(StreamPair {
+                producer: StreamEndpoint {
+                    component: i,
+                    role: StreamRole::Producer,
+                },
+                consumer: StreamEndpoint {
+                    component: i + 1,
+                    role: StreamRole::Consumer,
+                },
+                element: StreamElement::Typed("U8".to_string()),
+                mode: StreamMemoryMode::CrossMemory,
+            });
+        }
+        let graph = StreamPairGraph { pairs };
+        let issues = cycle_issues_from_pairs(&graph);
+        assert!(
+            issues.is_empty(),
+            "linear chain of {n} components must not flag a cycle; got {issues:?}"
+        );
+    }
+
+    /// LS-M-6: the `component-provenance` custom section must be
+    /// present in fused output under the default config (provenance and
+    /// attestation both enabled). The full round-trip/attribution
+    /// oracle lives in tests/component_provenance.rs (an integration
+    /// test, invisible to the LS verification gate's lib scan); this
+    /// lib-scope test pins the minimal contract: fuse two trivial
+    /// components and assert exactly one section named
+    /// `provenance::SECTION_NAME` exists with a non-empty payload.
+    #[test]
+    fn ls_m_6_provenance_section_present_in_fused_output() {
+        use wasm_encoder::{
+            CodeSection, Component, ExportKind, ExportSection, Function, FunctionSection,
+            Instruction, MemorySection, MemoryType, Module as EncoderModule, ModuleSection,
+            TypeSection,
+        };
+
+        /// Minimal valid component: one core module with one function
+        /// returning a constant, one exported memory.
+        fn build_trivial_component(func_export: &str, value: i32) -> Vec<u8> {
+            let mut types = TypeSection::new();
+            types.ty().function([], [wasm_encoder::ValType::I32]);
+
+            let mut functions = FunctionSection::new();
+            functions.function(0);
+
+            let mut memory = MemorySection::new();
+            memory.memory(MemoryType {
+                minimum: 1,
+                maximum: None,
+                memory64: false,
+                shared: false,
+                page_size_log2: None,
+            });
+
+            let mut exports = ExportSection::new();
+            exports.export(func_export, ExportKind::Func, 0);
+            exports.export("memory", ExportKind::Memory, 0);
+
+            let mut code = CodeSection::new();
+            let mut func = Function::new([]);
+            func.instruction(&Instruction::I32Const(value));
+            func.instruction(&Instruction::End);
+            code.function(&func);
+
+            let mut module = EncoderModule::new();
+            module
+                .section(&types)
+                .section(&functions)
+                .section(&memory)
+                .section(&exports)
+                .section(&code);
+
+            let mut component = Component::new();
+            component.section(&ModuleSection(&module));
+            component.finish()
+        }
+
+        // Default config: component_provenance = true, attestation = true.
+        let config = FuserConfig::default();
+        assert!(config.component_provenance && config.attestation);
+
+        let mut fuser = Fuser::new(config);
+        fuser
+            .add_component_named(&build_trivial_component("run-a", 1), Some("comp-a"))
+            .expect("add component a");
+        fuser
+            .add_component_named(&build_trivial_component("run-b", 2), Some("comp-b"))
+            .expect("add component b");
+        let output = fuser.fuse().expect("fuse");
+
+        let mut provenance_payloads: Vec<&[u8]> = Vec::new();
+        for payload in wasmparser::Parser::new(0).parse_all(&output) {
+            if let wasmparser::Payload::CustomSection(reader) =
+                payload.expect("fused output must parse")
+                && reader.name() == provenance::SECTION_NAME
+            {
+                provenance_payloads.push(reader.data());
+            }
+        }
+        assert_eq!(
+            provenance_payloads.len(),
+            1,
+            "fused output must carry exactly one `{}` custom section (LS-M-6)",
+            provenance::SECTION_NAME
+        );
+        assert!(
+            !provenance_payloads[0].is_empty(),
+            "`{}` section payload must not be empty",
+            provenance::SECTION_NAME
+        );
+    }
 }

--- a/proofs/STATUS.md
+++ b/proofs/STATUS.md
@@ -4,14 +4,25 @@ Implementation vs formal verification coverage for the Meld fusion pipeline.
 
 ## Numbers at a Glance
 
+Counts refreshed 2026-06-11 (v0.31.0 traceability audit).
+
 | Metric | Count |
 |--------|-------|
-| Rocq `.v` files | 23 |
-| Rocq lines (total) | 13,330 |
-| Closed proofs (Qed) | 286 |
+| Rocq `.v` files | 28 |
+| Rocq lines (total) | 14,487 |
+| Closed proofs (Qed) | 350 |
 | Admitted proofs | 0 |
-| Rust lines (`meld-core/src`) | 8,218 |
-| Proof-to-code ratio | 1.62x |
+| Rust lines (`meld-core/src`, recursive, incl. inline tests) | 41,378 |
+| Proof-to-code ratio | 0.35x |
+
+Measurement method: Rocq counts via `find proofs -name "*.v"` (file
+count, total `wc -l`, `grep -c "Qed."` summed). Rust lines via
+`find meld-core/src -name "*.rs" | xargs wc -l` — this counts ALL
+sources under `meld-core/src` including `adapter/` and the inline
+`#[cfg(test)]` test modules (a large share of the total), so the
+proof-to-code ratio is conservative and not comparable to the earlier
+8,218 figure, which counted only top-level production files of a much
+smaller codebase.
 
 ## Pipeline Coverage Matrix
 
@@ -28,6 +39,27 @@ Implementation vs formal verification coverage for the Meld fusion pipeline.
 | **Spec layer** | — | — | `spec/*.v` (6 files) | 4,392 | Covered | Wasm core types, component model, fusion types, instruction semantics, forward simulation (fully proved), trap simulation (forward direction) |
 
 Proof file paths are relative to `proofs/` (e.g. `merge/*.v` means `proofs/transformations/merge/*.v`).
+
+## Kani Layer (bounded model checking)
+
+Alongside the Rocq proofs, `meld-core/src/abi_proofs.rs` carries Kani
+harnesses for Canonical-ABI invariants (#218 inc 1, SR-40, v0.30.0):
+
+| Harness | Invariant | Status |
+|---------|-----------|--------|
+| `flags_layout_matches_spec` | `flags<N>` follows the spec storage classes at every boundary N in {1, 8, 9, 16, 17, 32, 33, 64} | VERIFICATION SUCCESSFUL (local, 2026-06-11) |
+| `total_flat_params_saturating_monotone` | `total_flat_params` is panic-free and monotone (LS-P-9) | VERIFICATION SUCCESSFUL (local, 2026-06-11) |
+| `ring_cursor_invariant_inductive` | #141 stream-bridge ring-cursor model preserves `fill <= CAP` inductively under u32 wraparound, both wrapping-copy segments in-bounds (parameters compile-tied to the emitter's constants) | VERIFICATION SUCCESSFUL (local, 2026-06-11) |
+
+Run via `cargo kani --harness <name>`; local evidence only — smithy CI
+runners do not ship the Kani toolchain (CI wiring is follow-up under
+#218). Honest CBMC scope cuts, recorded in-module: nondet
+leaf/container and aggregate-padding harnesses for the
+size-multiple-of-align contract do not converge against the current
+`ParsedComponent` shape (heap-state explosion); that contract stays
+pinned by the exhaustive unit tests
+(`test_canonical_abi_element_size_*`, `test_sr17_alignment_*`) until
+the layout core is factored allocation-free.
 
 ## What the Proofs Establish
 

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -158,7 +158,8 @@ artifacts:
       verification-description: >
         Test CopyLayout for: list<u32> (Bulk), list<string> (Elements),
         list<record{name:string, val:u32}> (Elements with inner ptrs).
-        CopyLayout consistency proof (proofs/adapter/).
+        CopyLayout consistency proof
+        (proofs/transformations/adapter/copy_layout_proofs.v).
 
   - id: SR-7
     type: requirement
@@ -292,7 +293,7 @@ artifacts:
       resolved cross-component call whose signature includes pointer
       types (string, list, record with pointer fields) in multi-memory
       mode.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -310,7 +311,7 @@ artifacts:
     description: >
       The adapter shall call cabi_realloc using the post-merge function
       index of the destination component's allocator.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -359,7 +360,7 @@ artifacts:
     description: >
       The adapter shall compute list copy byte length as element_count
       multiplied by canonical_abi_element_size of the element type.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -448,7 +449,7 @@ artifacts:
     description: >
       Given identical input component bytes and identical FuserConfig,
       meld shall produce byte-identical output across invocations.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -469,7 +470,7 @@ artifacts:
       out-of-bounds index, malformed input), meld shall abort with a
       diagnostic error. Partial or best-effort output shall not be
       produced.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -496,7 +497,7 @@ artifacts:
       each canon lower shall reference the correct memory index and
       cabi_realloc for the importing component. The stubs module shall
       define all memories needed by the fused module.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -523,7 +524,7 @@ artifacts:
       only occur when the discriminant indicates a variant case that
       contains pointer fields. When the discriminant indicates no pointer
       payload, the adapter shall skip the pointer copy entirely.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -545,7 +546,7 @@ artifacts:
       module:field name but different type signatures. In multi-memory mode,
       imports from different components shall be kept separate even if they
       share the same name, to allow per-component canon lower configuration.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -570,7 +571,7 @@ artifacts:
       accounting for alignment padding in variant payloads. Return area
       slot metadata (offset, size, is_pointer_pair) shall be computed by
       the resolver and used by the adapter for per-slot copy instructions.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -596,7 +597,7 @@ artifacts:
       The adapter shall pass resource handles through cross-component calls
       without modification (no pointer copy or fixup). Resource drop
       functions shall be forwarded directly.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -617,7 +618,7 @@ artifacts:
       imports, instance export aliases, and component exports. The type
       index mapping (get_type_definition) shall correctly resolve any
       valid type index to its definition.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -630,6 +631,124 @@ artifacts:
       verification-description: >
         Test with component using types from imports, aliases, and
         exports; verify correct type index resolution
+
+  # ==========================================================================
+  # Attestation / supply-chain requirements (SR-27..SR-30, from H-6 / SC-6)
+  #
+  # Authored retroactively in the v0.31.0 traceability audit: these four
+  # requirements had verification-status entries in traceability.yaml and
+  # passing tests (attestation.rs test_sr27..test_sr30) since 2026-03, but
+  # the requirement artifacts themselves were never written down.
+  # ==========================================================================
+
+  - id: SR-27
+    type: requirement
+    title: Attestation input hash integrity
+    description: >
+      For every input component added to a fusion, the attestation shall
+      record a SHA-256 hash and byte size that match an independently
+      computed digest and length of the exact input bytes. The recorded
+      hash identifies the input for supply-chain verification; a
+      mismatch means the attestation does not describe the artifact
+      that was actually fused.
+    status: verified
+    tags: [stpa-derived, attestation, supply-chain]
+    links:
+      - type: derives-from
+        target: SC-6
+      - type: mitigates
+        target: H-6
+    fields:
+      implementation: meld-core/src/attestation.rs
+      verification-method: test
+      verification-description: >
+        attestation::tests::test_sr27_input_hash_integrity — builds an
+        attestation over known input bytes and asserts the recorded
+        hash equals an independently computed SHA-256 and the recorded
+        size equals the actual byte length.
+
+  - id: SR-28
+    type: requirement
+    title: Attestation configuration completeness
+    description: >
+      The attestation metadata shall record every FuserConfig field
+      that influences the fused output (memory_strategy,
+      address_rebasing, preserve_names, custom_sections,
+      dwarf_handling, output_format), so an auditor can reconstruct
+      the exact configuration used for the transformation. Adding a
+      FuserConfig field without recording it in the attestation is a
+      requirement violation; the sentinel test enumerates the required
+      keys and must be updated in the same change.
+    status: verified
+    tags: [stpa-derived, attestation, supply-chain]
+    links:
+      - type: derives-from
+        target: SC-6
+      - type: mitigates
+        target: H-6
+    fields:
+      implementation:
+        - meld-core/src/attestation.rs
+        - meld-core/src/lib.rs
+      verification-method: test
+      verification-description: >
+        attestation::tests::test_sr28_config_completeness — sentinel
+        list of required config keys checked against the
+        tool_parameters map (wsc path) plus a serialization round-trip
+        asserting metadata.memory_strategy survives to JSON.
+
+  - id: SR-29
+    type: requirement
+    title: Attestation serialization round-trip
+    description: >
+      The attestation shall serialize to JSON and deserialize back with
+      all fields intact and non-empty (version, attestation_id,
+      transformation_type, timestamp, per-input hash/name/size, output
+      hash/size, tool name/version, fusion metadata counts).
+      Serialization failures shall surface as Err — to_bytes shall
+      never silently substitute an empty payload, since a downstream
+      consumer would accept the truncated attestation as valid.
+    status: verified
+    tags: [stpa-derived, attestation, supply-chain]
+    links:
+      - type: derives-from
+        target: SC-6
+      - type: mitigates
+        target: H-6
+    fields:
+      implementation: meld-core/src/attestation.rs
+      verification-method: test
+      verification-description: >
+        attestation::tests::test_sr29_attestation_round_trip —
+        to_bytes → from_json round-trip with every field asserted
+        populated; attestation::tests::test_to_bytes_returns_result —
+        regression for the silent `{}` fallback bug (Result-based
+        signature, output is valid non-empty JSON).
+
+  - id: SR-30
+    type: requirement
+    title: Attestation output hash integrity
+    description: >
+      The attestation shall record a SHA-256 hash and byte size of the
+      fused output that match an independently computed digest and
+      length of the output bytes (the dual of SR-27: downstream
+      consumers verify the artifact they received is the artifact the
+      attestation describes).
+    status: verified
+    tags: [stpa-derived, attestation, supply-chain]
+    links:
+      - type: derives-from
+        target: SC-6
+      - type: mitigates
+        target: H-6
+    fields:
+      implementation: meld-core/src/attestation.rs
+      verification-method: test
+      verification-description: >
+        attestation::tests::test_sr30_output_hash_integrity — builds an
+        attestation over known output bytes and asserts the recorded
+        output hash equals an independently computed SHA-256 and the
+        recorded size equals the actual byte length.
 
   # ==========================================================================
   # Requirements from weighted gap analysis (SR-31+)
@@ -645,7 +764,7 @@ artifacts:
       may support multi-module component output (per cfallin's "simple
       component" proposal), but until then, fail-fast rejection is
       required.
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -690,7 +809,7 @@ artifacts:
       returns from stackful mode are deferred to a follow-up under
       the same issue. Documented in ADR-1 addendums 2026-05-13 (a)
       and 2026-05-13 (b).
-    status: implemented
+    status: verified
     tags: [roadmap, p3-async, v0.8.0]
     links:
       - type: derives-from
@@ -729,7 +848,7 @@ artifacts:
       ABI's caller-buffer contract (stream_read(handle, buf_ptr, …))
       requires a copy into the caller's buffer regardless; fusion removes
       the double host round-trip per chunk.
-    status: implemented
+    status: verified
     tags: [roadmap, p3-async, v0.29.0]
     links:
       - type: derives-from
@@ -782,7 +901,12 @@ artifacts:
       (iv) `own<T>` handles passed through a stream must outlive every
       receiver. Each violation returns a typed `Error::ValidationError`
       with the offending site.
-    status: implemented
+      v0.31.0 audit disposition: the Kani cycle-detection harness
+      recorded as a gap was never produced; verification is accepted on
+      the test oracle (ls_r_11_* 3/3 via the LS gate +
+      deep_linear_chain_does_not_overflow_stack pinning LS-R-13). A
+      future Kani harness remains desirable, not blocking.
+    status: verified
     tags: [roadmap, p3-async, v0.12.0, v0.21.0]
     links:
       - type: derives-from
@@ -827,7 +951,7 @@ artifacts:
       - type: supersedes-default-of
         target: LS-CP-4
     fields:
-      implementation: meld-core/src/dwarf_remap.rs
+      implementation: meld-core/src/dwarf.rs
       verification-method: test+cross-repo
       verification-description: >
         Unit tests on `.debug_line` rewrite; cross-repo smoke against
@@ -904,6 +1028,57 @@ artifacts:
         fixture.
       milestone: v0.23.0
 
+  # SR-37 was accidentally deleted by PR #226 (commit fafd00c); restored
+  # verbatim from c50d9d5 in the v0.31.0 traceability audit, with status
+  # upgraded implemented → verified on the recorded evidence.
+  - id: SR-37
+    type: requirement
+    title: Automatic memory-strategy resolution (sound-by-construction default)
+    description: >
+      `MemoryStrategy::Auto` — the default for both `FuserConfig` and the
+      `meld fuse` CLI — shall resolve to shared memory + address rebasing
+      if and only if (a) no input core module contains a `memory.grow`
+      instruction (static probe, conservative on parse failure) and
+      (b) the inputs carry at least two linear memories. Otherwise it
+      shall resolve to multi-memory. If the shared-memory plan refuses
+      the input, fusion shall retry with multi-memory, so Auto accepts
+      every input multi-memory accepts. The resolved strategy shall be
+      reported in `FusionStats` and recorded in the attestation /
+      provenance metadata as the concrete strategy, never as "auto".
+      Rationale: out-of-the-box `meld fuse` output must flow through the
+      `wasm-opt → synth` chain with no extra flags (#172) without ever
+      selecting the shared form where `memory.grow` makes it unsound
+      (merger Bug #7, LS-M-7).
+    status: verified
+    tags: [usability, memory-strategy, v0.22.0]
+    links:
+      - type: tracked-by
+        target: "#172"
+      - type: mitigates
+        target: LS-M-7
+    fields:
+      implementation:
+        - meld-core/src/memory_probe.rs
+        - meld-core/src/lib.rs
+      verification-method: test
+      verification-description: >
+        Unit tests on the probe (grow detected anywhere in any body;
+        memory.size not a false positive; malformed input counts as
+        growing — `ls_m_7_malformed_input_counts_as_grow`). Integration
+        oracle in tests/auto_memory.rs: grow-free inputs fuse to a
+        single-memory output that validates with multi-memory disabled
+        (the `wasm-opt -Os` feature set) and behaves correctly at
+        runtime; a growing input resolves to multi with both memories
+        preserved (`ls_m_7_auto_keeps_multi_when_input_grows`);
+        explicit strategies are never overridden. Manual evidence on
+        the issue repro: `meld fuse a b -o fused.wasm` then
+        `wasm-opt -Os fused.wasm` succeeds with no flags; the explicit
+        `--memory multi` control still reproduces the rejection.
+        Verified (v0.31.0 audit): tests/auto_memory.rs suite 5/5 green
+        plus the ls_m_7_* tests discovered and passing through the LS
+        verification gate.
+      milestone: v0.22.0
+
   - id: SR-38
     type: requirement
     title: Multi-source DWARF merge (bounded relocator)
@@ -957,7 +1132,7 @@ artifacts:
       module still references it. Satisfied imports are dropped from
       the component's import surface with the surviving instance
       indices renumbered consistently at every consumer.
-    status: implemented
+    status: verified
     tags: [roadmap, composition, v0.28.0]
     links:
       - type: derives-from
@@ -993,7 +1168,7 @@ artifacts:
       preserves fill <= CAP inductively under u32 wraparound with both
       wrapping-copy segments in-bounds (model proof, parameters
       compile-tied to the emitter's constants).
-    status: implemented
+    status: verified
     tags: [roadmap, proofs, v0.30.0]
     links:
       - type: derives-from
@@ -1022,6 +1197,7 @@ artifacts:
         (test_canonical_abi_element_size_*, test_sr17_alignment_*);
         a Kani proof becomes tractable once the layout core is
         factored allocation-free. Scope note: the Rocq side carries
-        286 closed proofs (proofs/STATUS.md); these harnesses target
+        350 closed proofs (28 files, 2026-06-11 count)
+        (proofs/STATUS.md); these harnesses target
         the parser-layer gap STATUS.md marks as placeholder.
       milestone: v0.30.0

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -13,7 +13,7 @@
 #   6. Every requirement has at least one verification method
 #   7. No dangling references (all IDs resolve)
 #
-# Last updated: 2026-03-14
+# Last updated: 2026-06-11
 
 # Reverse traceability: which requirements address each loss
 loss-coverage:
@@ -187,10 +187,18 @@ verification-status:
 
   SR-17:
     implementation-files: [meld-core/src/adapter/fact.rs]
-    tests: []
+    tests:
+      - adapter_safety::test_sr17_utf8_to_utf16_string_transcoding
+      - resolver::tests::test_sr17_all_encoding_pairs_transcoding_matrix
     proofs: []
-    status: not-verified
-    note: "CRITICAL GAP: No UTF-16, CompactUTF16, or surrogate pair tests"
+    status: partial
+    note: >-
+      Refreshed 2026-06-11: UTF-16 ASCII transcoding is now tested
+      (test_sr17_utf8_to_utf16_string_transcoding) and the resolver's
+      transcoding-requirement matrix is pinned (test_sr17_* in
+      resolver.rs). Remaining open gap — the one left for SR-17: the
+      non-BMP / surrogate-pair clause of the requirement is still
+      untested (no non-BMP UTF-16 or CompactUTF16 round-trip test).
 
   SR-18:
     implementation-files: [meld-core/src/adapter/fact.rs]
@@ -268,9 +276,16 @@ verification-status:
     implementation-files: [meld-core/src/adapter/fact.rs, meld-core/src/component_wrap.rs]
     tests:
       - wit_bindgen_runtime::test_fuse_wit_bindgen_resources
+      - wit_bindgen_runtime::test_fuse_component_wit_bindgen_resources
+      - wit_bindgen_runtime::test_runtime_wit_bindgen_resources
     proofs: []
-    status: partial
-    note: "Core module fusion works. P2 wrapping blocked on [resource-new]/[resource-rep]/[export] support."
+    status: verified
+    note: >-
+      Refreshed 2026-06-11: the resources fixture now passes all three
+      levels including runtime (test_runtime_wit_bindgen_resources) —
+      the former "P2 wrapping blocked on
+      [resource-new]/[resource-rep]/[export] support" blocker is gone
+      and GAP-5 is resolved.
 
   SR-26:
     implementation-files: [meld-core/src/parser.rs]
@@ -310,10 +325,15 @@ verification-status:
 
   SR-31:
     implementation-files: [meld-core/src/merger.rs]
-    tests: []
+    tests:
+      - merger::tests::ls_m_5_multiply_instantiated_module_rejected
     proofs: []
-    status: not-verified
-    note: "CRITICAL: No detection of multiply-instantiated modules. Silent corruption risk."
+    status: verified
+    note: >-
+      Refreshed 2026-06-11: fail-fast detection is implemented and
+      pinned by ls_m_5_multiply_instantiated_module_rejected
+      (merger.rs:4719), discovered and passing through the LS
+      verification gate.
 
   # Roadmap entries (SR-32..SR-36) — see docs/roadmap.md. status moves
   # planned -> in-progress -> implemented as the milestone proceeds.
@@ -334,23 +354,25 @@ verification-status:
 
   SR-33:
     implementation-files:
-      - meld-core/src/p3_stream.rs   # detection half ONLY (StreamPairGraph)
-      - meld-core/src/resolver.rs    # graph built at resolve time
+      - meld-core/src/p3_bridge.rs
     tests:
-      - meld-core/src/p3_stream.rs::tests::stream_pair_detected_for_connected_producer_consumer
-      - meld-core/src/p3_stream.rs::tests::no_pair_when_components_not_fusion_connected
-      - meld-core/src/p3_stream.rs::tests::no_pair_without_producer_consumer_complementarity
-      - meld-core/src/p3_stream.rs::tests::memory_mode_follows_strategy
+      - p3_bridge_runtime::ls_st_1_round_trip_local_stream_never_crosses_host
+      - p3_bridge_runtime::cross_memory_chain_preserves_data_across_distinct_memories
+      - p3_bridge_runtime::backpressure_partial_write_then_drain_then_resume
+      - p3_bridge_runtime::ls_st_1_eof_only_after_writer_drop_and_drain
+      - p3_bridge_runtime::slot_exhaustion_falls_back_to_host_stream
     proofs: []
-    status: planned
+    status: verified
     note: >-
-      Audited 2026-06-10: detection foundation shipped v0.9.0 (#173,
-      ADR-3 path "detection now, emitter follow-up"); the in-module
-      emitter the requirement demands is not implemented — stream
-      traffic still round-trips through pulseengine:async host imports.
-      safety-requirements.yaml briefly carried status implemented from
-      a bulk sync (PR #211); reverted. Emitter is v0.29.0 scope.
-    note: "v0.9.0 — Cross-component stream<T> fusion (#141). adapter/fact.rs + resolver.rs."
+      Audited 2026-06-11: the v0.29.0 in-module bridge emitter
+      (p3_bridge.rs, consuming the resolve-time StreamPairGraph) is
+      verified by the five runtime oracles in
+      tests/p3_bridge_runtime.rs, which fuse two hand-built components
+      through the real pipeline and execute under wasmtime with host
+      stubs that trap on any bridge-local (bit-31-tagged) handle.
+      History: only the detection half shipped in v0.9.0 (#173); the
+      v0.9.0-era implemented status was a bulk-sync error reverted in
+      PR #221 after the 2026-06-10 audit.
 
   SR-34:
     implementation-files:
@@ -396,11 +418,26 @@ verification-status:
       same evidence; evidence trail on #143.
 
   SR-36:
-    implementation-files: []
-    tests: []
+    implementation-files:
+      - meld-core/src/dwarf.rs
+    tests:
+      - dwarf::tests::adapter_spans_identifies_component_synthetic
+      - dwarf::tests::adapter_spans_recognises_fully_synthetic_sentinel
+      - dwarf::tests::adapter_spans_empty_when_all_source
+      - dwarf::tests::adapter_spans_disjoint_from_source_ranges
+      - dwarf::tests::build_adapter_dwarf_attributes_ranges_to_meld_adapter
+      - dwarf::tests::ls_d_2_rewrite_emits_source_and_adapter_units_in_one_write
+      - adapter_dwarf_e2e::ls_d_2_generated_start_wrapper_is_attributed_to_meld_adapter
     proofs: []
-    status: planned
-    note: "v0.11.0 — DWARF Phase 3 adapter DIEs (#144). Depends on SR-35."
+    status: implemented
+    note: >-
+      Audited 2026-06-11: increments 1-4 shipped (#144, v0.23.0/v0.24.0)
+      — adapter-span enumeration, synthetic-unit builder with
+      write→read round-trip oracle, single-write pipeline emission, and
+      per-class <meld-adapter> lines. Upgrade to verified is gated on
+      the cross-repo witness MC/DC re-run confirming adapter ranges
+      resolve to <meld-adapter> (not "unknown") on a real fused
+      fixture; that re-run has not happened yet.
 
   SR-37:
     implementation-files:
@@ -421,6 +458,58 @@ verification-status:
       LS-N gate incl. ls_m_7_*, Mythos delta-pass); manual wasm-opt 116
       evidence on the issue repro recorded on #172 and in the PR body.
 
+  SR-38:
+    implementation-files:
+      - meld-core/src/dwarf.rs
+    tests:
+      - dwarf::tests::ls_d_3_multi_source_merge_round_trips_both_units
+      - dwarf_passthrough (multi-source policy test on lists.wasm)
+    proofs: []
+    status: verified
+    note: >-
+      v0.26.0 (#208). Multi-source DWARF merge via bounded relocation;
+      out-of-repertoire inputs abort to synthetic-only emission, never
+      a guessed offset. Verified by the gimli-built two-source
+      round-trip (units, files, lines, strp strings survive relocation)
+      plus the real-fixture policy test (287 units merge; 23k line rows
+      parse via llvm-dwarfdump locally). Known limitation carried on
+      #208: DW_AT_location convert-path verifier warnings (variable
+      locations, out of #130 scope).
+
+  SR-39:
+    implementation-files:
+      - meld-core/src/component_wrap.rs
+    tests:
+      - golden_e2e::ls_cp_6_separate_inputs_internalise_link
+      - wit_bindgen_runtime (full suite guards WASI imports staying declared)
+    proofs: []
+    status: verified
+    note: >-
+      v0.28.0 (#212). Separate-input cross-component linking (import
+      internalisation). Verified by the golden-e2e acceptance: fuse
+      consumer.wasm + provider.wasm --component, instantiate standalone
+      in wasmtime with no linker definitions, assert compute()==42 and
+      greet()==7 against the host-linked golden run.
+
+  SR-40:
+    implementation-files:
+      - meld-core/src/abi_proofs.rs
+    tests: []
+    proofs:
+      - abi_proofs::flags_layout_matches_spec (Kani)
+      - abi_proofs::total_flat_params_saturating_monotone (Kani)
+      - abi_proofs::ring_cursor_invariant_inductive (Kani)
+    status: verified
+    note: >-
+      v0.30.0 (#218 inc 1). Three Kani harnesses, each VERIFICATION
+      SUCCESSFUL locally on 2026-06-11 via `cargo kani --harness
+      <name>`. Caveat: local-Kani evidence only — smithy CI runners do
+      not ship the Kani toolchain, so the proofs are not re-checked in
+      CI (wiring is follow-up under #218). Honest scope cuts recorded
+      in-module: nondet leaf/container and aggregate-padding harnesses
+      do not converge in CBMC against the current ParsedComponent
+      shape; that contract stays pinned by the exhaustive unit tests.
+
 # wit-bindgen fixture coverage (14 fixtures × 3 levels = 42 integration tests)
 wit-bindgen-fixtures:
   passing-all-3-levels:
@@ -436,8 +525,7 @@ wit-bindgen-fixtures:
     - lists-alias
     - strings-alias
     - strings-simple
-  core-module-only:
-    - resources  # P2 wrapping blocked on resource handles (SR-25)
+    - resources  # since resource P2-wrapping support landed (SR-25, GAP-5)
   graceful-degradation:
     - fixed-length-lists  # Parser doesn't support 0x67 encoding
 
@@ -482,13 +570,12 @@ gaps:
 
   - id: GAP-5
     description: >
-      SR-25 (resource handles) has partial support — core module fusion
-      works but P2 wrapping fails. Resources fixture exists but only
-      passes core module validation level. Wrapper needs [resource-new],
-      [resource-rep], [export]-prefixed module support.
-    priority: high
-    action: >
-      Implement resource support in component_wrap.rs.
+      SR-25 (resource handles): resource support landed in
+      component_wrap.rs — the resources fixture now passes all three
+      levels including runtime (test_runtime_wit_bindgen_resources).
+      Resolved in the v0.31.0 traceability audit.
+    priority: closed
+    status: resolved
 
   - id: GAP-6
     description: >
@@ -505,10 +592,13 @@ gaps:
       is instantiated more than once. BA RFC #46 discussion (cfallin)
       identifies this as a fundamental component model capability that
       must be handled correctly, not just rejected.
-    priority: critical
-    action: >
-      Immediate: fail-fast rejection in merger. Strategic: multi-module
-      component output per cfallin's "simple component" proposal.
+      Resolved in the v0.31.0 traceability audit: fail-fast rejection
+      is implemented and pinned by
+      ls_m_5_multiply_instantiated_module_rejected (SR-31 verified).
+      The strategic multi-module component output (cfallin's "simple
+      component" proposal) remains future work, not a safety gap.
+    priority: closed
+    status: resolved
     references:
       - "BA RFC #46 discussion, cfallin 2026-03-10"
       - "safety/stpa/weighted-gap-analysis.md GAP-P2-1"

--- a/safety/stpa/resource-handle-stpa.yaml
+++ b/safety/stpa/resource-handle-stpa.yaml
@@ -679,10 +679,18 @@ gap-analysis:
 
 # =============================================================================
 # Recommended New/Updated Safety Requirements
+#
+# Namespace note (v0.31.0 traceability audit): these are DRAFT proposals
+# local to this analysis, renumbered SR-RH-1..SR-RH-8 (from their original
+# draft ids SR-25, SR-32..SR-38) to stop colliding with the unrelated
+# requirements that now occupy SR-32..SR-38 in
+# safety/requirements/safety-requirements.yaml. SR-RH-1 proposes a rewrite
+# of the existing SR-25; the gap-analysis section above intentionally
+# still references SR-25 because it discusses that existing requirement.
 # =============================================================================
 
 requirements:
-  - id: SR-25
+  - id: SR-RH-1
     type: requirement
     title: Correct borrow<T> handle conversion in adapters
     description: >
@@ -715,7 +723,7 @@ requirements:
         Runtime test with 2-component borrow<T> call (callee defines T) and
         3-component borrow<T> chain; verify correct rep/handle conversion.
 
-  - id: SR-32
+  - id: SR-RH-2
     type: requirement
     title: Recursive resource detection in aggregate types
     description: >
@@ -746,7 +754,7 @@ requirements:
         option<own<T>>, and list<own<T>>. Verify all inner handles are
         correctly converted across component boundaries.
 
-  - id: SR-33
+  - id: SR-RH-3
     type: requirement
     title: Own<T> result conversion via resource.new
     description: >
@@ -772,7 +780,7 @@ requirements:
         Verify caller receives a valid handle (not raw rep) and can use it
         in subsequent calls.
 
-  - id: SR-34
+  - id: SR-RH-4
     type: requirement
     title: Own<T> parameter ownership transfer semantics
     description: >
@@ -800,7 +808,7 @@ requirements:
         is freed and destination can use the resource. Verify no double-free
         on subsequent drop.
 
-  - id: SR-35
+  - id: SR-RH-5
     type: requirement
     title: Deterministic resource.rep import disambiguation
     description: >
@@ -824,7 +832,7 @@ requirements:
         [resource-rep] imports for the same resource name. Verify the
         adapter selects the caller's import, not an arbitrary one.
 
-  - id: SR-36
+  - id: SR-RH-6
     type: requirement
     title: Transitive resource type alias resolution
     description: >
@@ -849,7 +857,7 @@ requirements:
         Test with component having 3-level alias chain for resource type.
         Verify resolve_resource_positions returns correct import pair.
 
-  - id: SR-37
+  - id: SR-RH-7
     type: requirement
     title: Toplevel resource import resolution in P2 wrapper
     description: >
@@ -874,7 +882,7 @@ requirements:
         Test with resource-import-and-export fixture. Verify P2 wrapping
         succeeds and the component passes wasm-tools validate.
 
-  - id: SR-38
+  - id: SR-RH-8
     type: requirement
     title: Correct destructor binding for locally-defined resources
     description: >
@@ -1039,7 +1047,7 @@ fixture-failure-mapping:
     root-cause: >
       First-match strategy in analyze_call_site selects wrong [resource-rep]
       import when multiple candidates exist from different components.
-    recommended-sr: SR-35
+    recommended-sr: SR-RH-5
 
   - fixture: resource_aggregates
     failure-mode: "own<T> handle assertion failure — rep misinterpreted as handle"
@@ -1049,7 +1057,7 @@ fixture-failure-mapping:
     root-cause: >
       Adapter does not call [resource-new] on own<T> return values. Callee
       returns rep, caller interprets it as handle index.
-    recommended-sr: SR-33
+    recommended-sr: SR-RH-3
 
   - fixture: ownership
     failure-mode: "Resource ownership transfer trap"
@@ -1060,7 +1068,7 @@ fixture-failure-mapping:
       Adapter does not clean up source-side handle table entry when own<T>
       ownership transfers. Handle leaks lead to double-free or stale handle
       access.
-    recommended-sr: SR-34
+    recommended-sr: SR-RH-4
 
   - fixture: resource_borrow_in_record
     failure-mode: "borrow<T> inside record not converted"
@@ -1070,7 +1078,7 @@ fixture-failure-mapping:
     root-cause: >
       resource_param_positions does not recurse into record fields to detect
       borrow<T>. Handle passes through without conversion.
-    recommended-sr: SR-32
+    recommended-sr: SR-RH-2
 
   - fixture: resource_with_lists
     failure-mode: "Data corruption in resource+list combination"
@@ -1081,7 +1089,7 @@ fixture-failure-mapping:
       CopyLayout and resource detection are independent subsystems. Neither
       handles the intersection: resource handles inside list elements or
       alongside list pointer pairs in return areas.
-    recommended-sr: SR-32
+    recommended-sr: SR-RH-2
 
   - fixture: resource-import-and-export
     failure-mode: "P2 wrapper cannot resolve toplevel resource import"
@@ -1092,4 +1100,4 @@ fixture-failure-mapping:
       resolve_import_to_instance does not handle resource imports at the
       component level (outside of named interface instances). Fallback
       Category C only covers [resource-drop], not [resource-rep]/[resource-new].
-    recommended-sr: SR-37
+    recommended-sr: SR-RH-7


### PR DESCRIPTION
**Final release of the v0.22→v0.31 autonomous campaign.** Closes #96.

A clean-room read-only audit walked every SR-1…SR-40 and every approved loss scenario against **executed** oracles (full lib + integration suites, all 3 Kani harnesses, `run_ls_verification.py`, `rivet check`); this PR applies the corrections.

## Highlights
- **Restored SR-37** — auto-memory soundness requirement silently dropped by PR #226's bulk edit; the audit caught it via a `git -S` diff. Now `verified`.
- **Authored SR-27…SR-30** — had traceability entries + passing attestation tests but no requirement artifacts. Defined, `verified`.
- **16 → `verified`** where named oracles pass (SR-12/13/15, 19–26, 31, 32, 33, 39, 40). **No honest downgrades needed** — nothing overstates reality (the 2026-06-10 SR-33 emitter-gap class does not recur).
- **SR-34** Kani-cycle-harness gap given a written in-artifact disposition (accepted on test oracle).
- **Stale fixes**: SR-35/SR-6 paths, SR-40 proof count 286→350, resource-handle draft id collisions → SR-RH-1…8, STATUS.md metrics refreshed + Kani layer documented.
- **LS gate**: lib-scope pins for LS-R-13 + LS-M-6 → **45/45, 0 missing** (was 2 discovery gaps).

## Verification (run locally on this branch)
- `cargo fmt --all --check` clean · `cargo clippy --workspace --all-targets` **0 warnings** · `cargo test --workspace --no-fail-fast` **539 passed / 0 failed**
- `python3 tools/run_ls_verification.py` → **exit 0, 45 passed, 0 missing**
- 3 edited YAML files `yaml.safe_load` OK

## Tier-5
None — safety YAML, proofs/STATUS.md, and lib.rs **test-module** additions only.

Falsification statement in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)