### PR TITLE
test(sr17): close the non-BMP surrogate-pair verification gap

### DIFF
--- a/meld-core/tests/adapter_safety.rs
+++ b/meld-core/tests/adapter_safety.rs
@@ -276,6 +276,13 @@ fn build_callee_string_component() -> Vec<u8> {
 ///   - Exports `run() -> i32` which calls process-string(0, 5)
 ///   - Exports `cabi_realloc` (needed for result copy if any)
 fn build_caller_string_component() -> Vec<u8> {
+    // Default caller passes ASCII "Hello"; the data-parameterized helper
+    // lets transcoding tests vary the source string (e.g. non-BMP code
+    // points that force UTF-16 surrogate pairs — SR-17).
+    build_caller_string_component_data(b"Hello")
+}
+
+fn build_caller_string_component_data(string_bytes: &[u8]) -> Vec<u8> {
     let core_module = {
         let mut types = TypeSection::new();
         // type 0: (i32, i32) -> i32  -- imported process-string
@@ -339,7 +346,7 @@ fn build_caller_string_component() -> Vec<u8> {
         {
             let mut f = Function::new([]);
             f.instruction(&Instruction::I32Const(0)); // ptr
-            f.instruction(&Instruction::I32Const(5)); // len
+            f.instruction(&Instruction::I32Const(string_bytes.len() as i32)); // byte len
             f.instruction(&Instruction::Call(0)); // process-string (import)
             f.instruction(&Instruction::End);
             code.function(&f);
@@ -359,7 +366,7 @@ fn build_caller_string_component() -> Vec<u8> {
                 memory_index: 0,
                 offset: &ConstExpr::i32_const(0),
             },
-            data: b"Hello".to_vec(),
+            data: string_bytes.to_vec(),
         });
 
         let mut module = Module::new();
@@ -2069,5 +2076,84 @@ fn test_sr17_utf8_to_utf16_string_transcoding() {
     assert_eq!(
         result, 500,
         "SR-17: run() should return 500 (sum of UTF-16 code units for 'Hello')"
+    );
+}
+
+/// SR-17 (surrogate-pair clause): a supplementary-plane code point
+/// (U+10000 and above) transcoded UTF-8 → UTF-16 must be encoded as a
+/// surrogate PAIR — two code units — not a single truncated unit. The
+/// pre-existing SR-17 transcoding test only exercised ASCII (1 UTF-8
+/// byte → 1 BMP code unit), leaving the `code_point >= 0x10000` branch
+/// of `emit_utf8_to_utf16_transcode` (fact.rs) unexecuted. The
+/// v0.31.0 traceability audit flagged this as SR-17's one open
+/// requirement-text verification gap; this fixture closes it.
+///
+/// Oracle: U+1F600 (😀) is UTF-8 `F0 9F 98 80` (4 bytes). The canonical
+/// surrogate decomposition is:
+///   cp - 0x10000 = 0xF600
+///   high = 0xD800 + (0xF600 >> 10)   = 0xD800 + 0x3D  = 0xD83D
+///   low  = 0xDC00 + (0xF600 & 0x3FF) = 0xDC00 + 0x200 = 0xDE00
+/// The callee sums the received UTF-16 code units, so a correct
+/// surrogate pair yields 0xD83D + 0xDE00 = 55357 + 56832 = 112189.
+/// A buggy single-unit or truncated encoding cannot produce this sum.
+#[test]
+fn test_sr17_utf8_to_utf16_supplementary_plane_transcoding() {
+    let callee = build_callee_utf16_string_component();
+    // "A😀": one BMP code point then one supplementary, to also prove
+    // the dst-cursor advances by 1 then 2 and the units interleave.
+    //   'A'  = 0x0041 (1 UTF-8 byte, 1 code unit)
+    //   '😀' = U+1F600 → D83D DE00 (4 UTF-8 bytes, 2 code units)
+    // Sum = 0x0041 + 0xD83D + 0xDE00 = 65 + 55357 + 56832 = 112254.
+    let caller = build_caller_string_component_data(&[0x41, 0xF0, 0x9F, 0x98, 0x80]);
+
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        component_provenance: false,
+        address_rebasing: false,
+        preserve_names: false,
+        custom_sections: meld_core::CustomSectionHandling::Drop,
+        dwarf_handling: meld_core::DwarfHandling::Strip,
+        output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
+    };
+
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&callee, Some("callee-utf16"))
+        .expect("callee component should parse");
+    fuser
+        .add_component_named(&caller, Some("caller-utf8"))
+        .expect("caller component should parse");
+
+    let (fused, stats) = fuser.fuse_with_stats().expect("fusion should succeed");
+    assert!(
+        stats.adapter_functions > 0,
+        "SR-17: expected a transcoding adapter, got 0"
+    );
+
+    let mut validator = wasmparser::Validator::new();
+    validator
+        .validate_all(&fused)
+        .expect("SR-17: fused output should validate");
+
+    let mut engine_config = Config::new();
+    engine_config.wasm_multi_memory(true);
+    let engine = Engine::new(&engine_config).unwrap();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    let run = instance
+        .get_typed_func::<(), i32>(&mut store, "run")
+        .expect("SR-17: fused module should export 'run'");
+    let result = run.call(&mut store, ()).unwrap();
+
+    assert_eq!(
+        result, 112254,
+        "SR-17: 'A😀' must transcode to UTF-16 code units \
+         [0x0041, 0xD83D, 0xDE00] (surrogate pair for U+1F600); \
+         sum 112254. A wrong sum means the supplementary-plane branch \
+         mis-encodes the surrogate pair."
     );
 }

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -408,7 +408,7 @@ artifacts:
       String transcoding adapters shall produce valid output encoding
       for all valid input, including characters outside the BMP
       (surrogate pair handling for UTF-16).
-    status: implemented
+    status: verified
     tags: [stpa-derived]
     links:
       - type: derives-from
@@ -417,8 +417,18 @@ artifacts:
       implementation: meld-core/src/adapter/fact.rs
       verification-method: test
       verification-description: >
-        Test with strings containing BMP and non-BMP characters;
-        verify round-trip correctness
+        Runtime oracles in tests/adapter_safety.rs, fused and executed
+        under wasmtime: test_sr17_utf8_to_utf16_string_transcoding
+        (BMP/ASCII round-trip) and, since the v0.31.0 audit,
+        test_sr17_utf8_to_utf16_supplementary_plane_transcoding —
+        "A😀" (U+0041 + U+1F600) must transcode to UTF-16 code units
+        [0x0041, 0xD83D, 0xDE00], proving the supplementary-plane
+        surrogate-pair branch of emit_utf8_to_utf16_transcode encodes
+        the high/low surrogates correctly and advances the destination
+        cursor by one then two units. Carried gap: the UTF-16 → UTF-8
+        reverse direction and lone-surrogate U+FFFD substitution are
+        covered structurally (LS-P-16) but not yet by a non-BMP runtime
+        round-trip.
 
   - id: SR-18
     type: requirement

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -189,16 +189,22 @@ verification-status:
     implementation-files: [meld-core/src/adapter/fact.rs]
     tests:
       - adapter_safety::test_sr17_utf8_to_utf16_string_transcoding
+      - adapter_safety::test_sr17_utf8_to_utf16_supplementary_plane_transcoding
       - resolver::tests::test_sr17_all_encoding_pairs_transcoding_matrix
     proofs: []
-    status: partial
+    status: verified
     note: >-
-      Refreshed 2026-06-11: UTF-16 ASCII transcoding is now tested
-      (test_sr17_utf8_to_utf16_string_transcoding) and the resolver's
-      transcoding-requirement matrix is pinned (test_sr17_* in
-      resolver.rs). Remaining open gap — the one left for SR-17: the
-      non-BMP / surrogate-pair clause of the requirement is still
-      untested (no non-BMP UTF-16 or CompactUTF16 round-trip test).
+      Refreshed 2026-06-13: the non-BMP / surrogate-pair clause is now
+      covered by a runtime oracle —
+      test_sr17_utf8_to_utf16_supplementary_plane_transcoding fuses a
+      UTF-8 caller passing "A😀" (U+0041 + U+1F600) into a UTF-16 callee
+      and asserts the received code units are [0x0041, 0xD83D, 0xDE00]
+      (correct surrogate pair), executed under wasmtime. Combined with
+      the ASCII round-trip and the resolver transcoding-requirement
+      matrix, SR-17 is verified. Narrowed carried gap: the UTF-16→UTF-8
+      reverse direction and lone-surrogate U+FFFD substitution are
+      covered structurally (LS-P-16) but lack a non-BMP runtime
+      round-trip — desirable, not blocking.
 
   SR-18:
     implementation-files: [meld-core/src/adapter/fact.rs]


### PR DESCRIPTION
Post-campaign follow-up — closes the one open requirement-text verification gap the v0.31.0 traceability audit flagged.

## Gap
`SR-17` (correct string transcoding) explicitly requires "characters outside the BMP (surrogate pair handling for UTF-16)", but the only runtime test passed ASCII "Hello" — so the `code_point >= 0x10000` surrogate-pair branch of `emit_utf8_to_utf16_transcode` had never executed. Correct by inspection ≠ verified.

## Oracle
`test_sr17_utf8_to_utf16_supplementary_plane_transcoding`: fuses a UTF-8 caller passing **"A😀"** (U+0041 + U+1F600) into the UTF-16 callee, runs the fused module under wasmtime, and asserts the callee receives code units `[0x0041, 0xD83D, 0xDE00]` (sum 112254) — the canonical surrogate pair for U+1F600. This proves the high/low surrogate formulas and the destination-cursor advance (1 unit then 2) across mixed BMP/supplementary input. The code was already correct; this is the missing executing evidence.

`build_caller_string_component` now delegates to a data-parameterized helper (ASCII entry point unchanged).

## Status
- SR-17 → `verified`; traceability note narrowed to the remaining UTF-16→UTF-8 reverse-direction non-BMP gap (desirable, not blocking).
- **No source change** — `adapter_safety.rs` is a test file, not Tier-5; `fact.rs` untouched, so no Mythos pass required.
- adapter_safety **6/6**; LS gate **45/45, 0 missing**; clippy 0; YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)