### PR TITLE
fix(adapter): mid-string lone high surrogate → U+FFFD in UTF-16→UTF-8 (LS-P-16)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -3015,8 +3015,10 @@ impl FactStyleGenerator {
             (StringEncoding::Utf8, StringEncoding::Utf8)
         );
 
-        // Scratch locals: src_idx, dst_idx, out_ptr, byte (+ code_point for UTF-8/16)
-        let scratch_locals: u32 = if needs_transcoding_locals { 5 } else { 0 };
+        // Scratch locals: src_idx, dst_idx, out_ptr, cu, code_point, and cu2
+        // (the second surrogate unit, used by the UTF-16→UTF-8 low-surrogate
+        // validation — LS-P-16 mid-string mitigation).
+        let scratch_locals: u32 = if needs_transcoding_locals { 6 } else { 0 };
         let post_return_base = param_count as u32 + scratch_locals;
 
         let mut local_decls: Vec<(u32, wasm_encoder::ValType)> = Vec::new();
@@ -3543,6 +3545,7 @@ impl FactStyleGenerator {
         let out_ptr_local = param_count as u32 + 2;
         let cu_local = param_count as u32 + 3;
         let cp_local = param_count as u32 + 4;
+        let cu2_local = param_count as u32 + 5;
 
         // Source reads (UTF-16) use caller_memory, destination writes (UTF-8) use callee_memory
         let src_mem16 = wasm_encoder::MemArg {
@@ -3651,17 +3654,15 @@ impl FactStyleGenerator {
             }
             func.instruction(&Instruction::Else);
             {
-                // Surrogate pair: read low surrogate
+                // High surrogate with at least one more code unit available.
+                // LS-P-16 (mid-string mitigation): validate that the next
+                // unit is actually a low surrogate before treating this as a
+                // pair. An unvalidated second unit (e.g. a high surrogate
+                // followed by an ASCII char) underflows `cu2 - 0xDC00` and
+                // yields a garbage code point that the 4-byte encoder writes
+                // into callee memory (H-4.4 incorrect transcoding). The
+                // Canonical ABI mandates lossy U+FFFD replacement instead.
                 // cu2 = mem16[ptr + (src_idx + 1) * 2]
-                // code_point = 0x10000 + ((cu - 0xD800) << 10) + (cu2 - 0xDC00)
-                func.instruction(&Instruction::I32Const(0x10000));
-                func.instruction(&Instruction::LocalGet(cu_local));
-                func.instruction(&Instruction::I32Const(0xD800_u32 as i32));
-                func.instruction(&Instruction::I32Sub);
-                func.instruction(&Instruction::I32Const(10));
-                func.instruction(&Instruction::I32Shl);
-                func.instruction(&Instruction::I32Add);
-                // Load low surrogate
                 func.instruction(&Instruction::LocalGet(0));
                 func.instruction(&Instruction::LocalGet(src_idx_local));
                 func.instruction(&Instruction::I32Const(1));
@@ -3670,15 +3671,51 @@ impl FactStyleGenerator {
                 func.instruction(&Instruction::I32Shl);
                 func.instruction(&Instruction::I32Add);
                 func.instruction(&Instruction::I32Load16U(src_mem16));
+                func.instruction(&Instruction::LocalSet(cu2_local));
+
+                // is_low_surrogate = (cu2 >= 0xDC00) && (cu2 < 0xE000)
+                func.instruction(&Instruction::LocalGet(cu2_local));
                 func.instruction(&Instruction::I32Const(0xDC00_u32 as i32));
-                func.instruction(&Instruction::I32Sub);
-                func.instruction(&Instruction::I32Add);
-                func.instruction(&Instruction::LocalSet(cp_local));
-                // src_idx += 2
-                func.instruction(&Instruction::LocalGet(src_idx_local));
-                func.instruction(&Instruction::I32Const(2));
-                func.instruction(&Instruction::I32Add);
-                func.instruction(&Instruction::LocalSet(src_idx_local));
+                func.instruction(&Instruction::I32GeU);
+                func.instruction(&Instruction::LocalGet(cu2_local));
+                func.instruction(&Instruction::I32Const(0xE000_u32 as i32));
+                func.instruction(&Instruction::I32LtU);
+                func.instruction(&Instruction::I32And);
+                func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                {
+                    // Valid surrogate pair:
+                    // cp = 0x10000 + ((cu - 0xD800) << 10) + (cu2 - 0xDC00)
+                    func.instruction(&Instruction::I32Const(0x10000));
+                    func.instruction(&Instruction::LocalGet(cu_local));
+                    func.instruction(&Instruction::I32Const(0xD800_u32 as i32));
+                    func.instruction(&Instruction::I32Sub);
+                    func.instruction(&Instruction::I32Const(10));
+                    func.instruction(&Instruction::I32Shl);
+                    func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::LocalGet(cu2_local));
+                    func.instruction(&Instruction::I32Const(0xDC00_u32 as i32));
+                    func.instruction(&Instruction::I32Sub);
+                    func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::LocalSet(cp_local));
+                    // src_idx += 2 (consume both units)
+                    func.instruction(&Instruction::LocalGet(src_idx_local));
+                    func.instruction(&Instruction::I32Const(2));
+                    func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::LocalSet(src_idx_local));
+                }
+                func.instruction(&Instruction::Else);
+                {
+                    // Mid-string lone high surrogate → U+FFFD, consuming only
+                    // the high surrogate so the next unit is reprocessed
+                    // normally on the following iteration.
+                    func.instruction(&Instruction::I32Const(0xFFFD));
+                    func.instruction(&Instruction::LocalSet(cp_local));
+                    func.instruction(&Instruction::LocalGet(src_idx_local));
+                    func.instruction(&Instruction::I32Const(1));
+                    func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::LocalSet(src_idx_local));
+                }
+                func.instruction(&Instruction::End); // end low-surrogate validation
             }
             func.instruction(&Instruction::End); // end LS-P-16 lone-surrogate check
         }

--- a/meld-core/tests/adapter_safety.rs
+++ b/meld-core/tests/adapter_safety.rs
@@ -2525,3 +2525,67 @@ fn test_sr17_utf16_to_utf8_lone_high_surrogate_replacement() {
          read, or a wrong replacement would not produce 684."
     );
 }
+
+/// LS-P-16 (mid-string, runtime): a high surrogate NOT at end-of-input,
+/// followed by a unit that is **not** a low surrogate, is still a lone
+/// surrogate and must be replaced with U+FFFD — the second unit then
+/// reprocessed on its own. The v0.11 mitigation only handled the
+/// end-of-input case; the unvalidated-second-unit causal factor recorded
+/// in LS-P-16 stayed open until this fix. Before it, `[0xD800, 0x0041]`
+/// computed a garbage code point from `0x0041 - 0xDC00` (u32 underflow)
+/// and emitted wrong UTF-8 (observed run() == 500).
+///
+/// Input [0xD800, 0x0041]: lone high surrogate then 'A'. Correct output
+/// is U+FFFD (UTF-8 EF BF BD) then 'A' (0x41). The callee sums received
+/// UTF-8 bytes: 0xEF + 0xBF + 0xBD + 0x41 = 239 + 191 + 189 + 65 = 684.
+#[test]
+fn test_sr17_utf16_to_utf8_midstring_lone_surrogate_replacement() {
+    let callee = build_callee_string_component(); // UTF-8 lift, sums bytes
+    let caller = build_caller_utf16_lowering_component(&[0xD800, 0x0041]);
+
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        component_provenance: false,
+        address_rebasing: false,
+        preserve_names: false,
+        custom_sections: meld_core::CustomSectionHandling::Drop,
+        dwarf_handling: meld_core::DwarfHandling::Strip,
+        output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
+    };
+
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&callee, Some("callee-utf8"))
+        .expect("callee component should parse");
+    fuser
+        .add_component_named(&caller, Some("caller-utf16"))
+        .expect("caller component should parse");
+
+    let (fused, _stats) = fuser.fuse_with_stats().expect("fusion should succeed");
+
+    let mut validator = wasmparser::Validator::new();
+    validator
+        .validate_all(&fused)
+        .expect("LS-P-16 mid-string: fused output should validate");
+
+    let mut engine_config = Config::new();
+    engine_config.wasm_multi_memory(true);
+    let engine = Engine::new(&engine_config).unwrap();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    let run = instance
+        .get_typed_func::<(), i32>(&mut store, "run")
+        .expect("LS-P-16 mid-string: fused module should export 'run'");
+    let result = run.call(&mut store, ()).unwrap();
+
+    assert_eq!(
+        result, 684,
+        "LS-P-16 mid-string: [0xD800, 0x0041] must transcode to U+FFFD + 'A' \
+         (UTF-8 EF BF BD 41, sum 684). Pre-fix this returned 500 (garbage \
+         code point from the unvalidated second unit)."
+    );
+}

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -975,11 +975,18 @@ loss-scenarios:
       wasmtime that the output is 'A' + U+FFFD (UTF-8 EF BF BD, byte
       sum 684) — proving lossy replacement, not a trap or OOB read.
       Closes the "no regression test for UTF-16 inputs ending on a
-      high surrogate" causal-factor above. (The mid-string lone-
-      surrogate case — high surrogate followed by a non-low unit —
-      still relies on the end-of-input guard; a non-low second unit
-      takes the pair arm. Recorded as a residual: only the
-      end-of-input lone surrogate has a defined U+FFFD path.)
+      high surrogate" causal-factor above. The MID-string variant —
+      a high surrogate followed by a non-low-surrogate unit — was
+      ALSO fixed (the unvalidated-second-unit causal factor that the
+      v0.11 end-of-input-only mitigation left open): the pair arm now
+      validates 0xDC00 <= cu2 < 0xE000 and, on failure, emits U+FFFD
+      for the lone high surrogate and consumes only that unit
+      (reprocessing the second unit normally). Before the fix
+      [0xD800, 0x0041] produced a garbage code point from
+      `0x0041 - 0xDC00` (u32 underflow) and emitted wrong UTF-8
+      (run() == 500); after, it is U+FFFD + 'A' (sum 684). Runtime
+      oracle: test_sr17_utf16_to_utf8_midstring_lone_surrogate_replacement.
+      All causal factors of LS-P-16 are now mitigated and runtime-pinned.
 
   - id: LS-P-18
     title: LS-P-12 bypassed when a record mixes a covered pointer with a hidden conditional one


### PR DESCRIPTION
Closes the last open causal factor of LS-P-16 — found via falsification while building the SR-17 reverse-transcode oracles.

## Bug (confirmed by PoC)
`emit_utf16_to_utf8_transcode`'s surrogate-pair arm treated **any** unit after a high surrogate as a low surrogate, with no `0xDC00 ≤ cu2 < 0xE000` check. A high surrogate followed by a non-low unit (e.g. ASCII) underflows `cu2 - 0xDC00` (u32) → garbage code point → wrong 4-byte UTF-8 into callee memory (H-4.4, malformed-UTF-16 handling). This is the "no validation that the second code unit is a low surrogate" causal factor LS-P-16 documented; the v0.11 fix only handled *end-of-input* lone surrogates.

`[0xD800, 0x0041]` returned **500** (garbage) before; **684** (`U+FFFD + 'A'` = `EF BF BD 41`) after.

## Fix
Validate `0xDC00 ≤ cu2 < 0xE000` in the pair arm. Valid pair → unchanged. Invalid → emit U+FFFD, consume only the high surrogate (second unit reprocessed normally). One added scratch local (`cu2`); per-direction scratch count 5 → 6.

## Verification
- `test_sr17_utf16_to_utf8_midstring_lone_surrogate_replacement` (new runtime oracle, 684).
- All SR-17 transcode tests pass (forward/reverse non-BMP, end-of-input + mid-string lone surrogate). Workspace **543/0**; clippy/fmt clean.
- LS-P-16: all causal factors now mitigated and runtime-pinned.

## Tier-5
`fact.rs` changed → Mythos clean-room pass to follow as comment + `mythos-pass-done` label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)