### PR TITLE
fix(adapter): lone low surrogate → U+FFFD in UTF-16→UTF-8 (closes #249)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -3721,9 +3721,34 @@ impl FactStyleGenerator {
         }
         func.instruction(&Instruction::Else);
         {
-            // BMP character: code_point = cu
+            // Not a high surrogate. A lone LOW surrogate (cu in
+            // [0xDC00, 0xE000)) cannot legitimately appear unpaired here —
+            // the high-surrogate arm above consumes both halves of every
+            // valid pair, so any low surrogate reaching this branch is
+            // malformed input. Replace it with U+FFFD per the Canonical
+            // ABI (#249) rather than emitting the malformed 3-byte UTF-8 of
+            // a surrogate code point (ED B0 80 .. ED BF BF). Any other unit
+            // is a genuine BMP scalar value, encoded directly. Either way
+            // exactly one code unit is consumed.
+            // cp = is_low_surrogate(cu) ? 0xFFFD : cu
             func.instruction(&Instruction::LocalGet(cu_local));
-            func.instruction(&Instruction::LocalSet(cp_local));
+            func.instruction(&Instruction::I32Const(0xDC00_u32 as i32));
+            func.instruction(&Instruction::I32GeU);
+            func.instruction(&Instruction::LocalGet(cu_local));
+            func.instruction(&Instruction::I32Const(0xE000_u32 as i32));
+            func.instruction(&Instruction::I32LtU);
+            func.instruction(&Instruction::I32And);
+            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+            {
+                func.instruction(&Instruction::I32Const(0xFFFD));
+                func.instruction(&Instruction::LocalSet(cp_local));
+            }
+            func.instruction(&Instruction::Else);
+            {
+                func.instruction(&Instruction::LocalGet(cu_local));
+                func.instruction(&Instruction::LocalSet(cp_local));
+            }
+            func.instruction(&Instruction::End); // end lone-low-surrogate check
             // src_idx += 1
             func.instruction(&Instruction::LocalGet(src_idx_local));
             func.instruction(&Instruction::I32Const(1));

--- a/meld-core/tests/adapter_safety.rs
+++ b/meld-core/tests/adapter_safety.rs
@@ -2589,3 +2589,87 @@ fn test_sr17_utf16_to_utf8_midstring_lone_surrogate_replacement() {
          code point from the unvalidated second unit)."
     );
 }
+
+/// Comprehensive malformed-UTF-16 matrix for UTF-16 → UTF-8 transcoding
+/// (#249): every unpaired surrogate, at every position, must become U+FFFD
+/// (UTF-8 `EF BF BD`, byte sum 619), and valid pairs must still decode.
+/// The callee sums received UTF-8 bytes; expected sums are hand-computed
+/// from: U+FFFD=619, 'A'=0x41=65, 'B'=0x42=66, U+1F600 → `F0 9F 98 80`=679.
+///
+/// This closes the lone-LOW-surrogate gap (#249, surfaced by PR #248's
+/// Mythos pass) alongside the lone-HIGH cases fixed in v0.11 / #248, and
+/// pins the whole class so a regression in any single arm is caught.
+#[test]
+fn test_sr17_utf16_to_utf8_malformed_surrogate_matrix() {
+    // (input UTF-16 code units, expected callee byte-sum, label)
+    let cases: &[(&[u16], i32, &str)] = &[
+        (&[0xDC00, 0x0041], 684, "leading lone low → FFFD + A"),
+        (&[0x0041, 0xDC00], 684, "trailing lone low → A + FFFD"),
+        (
+            &[0x0041, 0xDC00, 0x0042],
+            750,
+            "mid lone low → A + FFFD + B",
+        ),
+        (
+            &[0xDC00, 0xDC00],
+            1238,
+            "consecutive lone lows → FFFD + FFFD",
+        ),
+        (&[0xDFFF], 619, "last low surrogate value alone → FFFD"),
+        (&[0xD83D, 0xDE00], 679, "valid pair U+1F600 still decodes"),
+        (
+            &[0xDC00, 0xD83D, 0xDE00],
+            1298,
+            "lone low then valid pair → FFFD + U+1F600",
+        ),
+        (
+            &[0xD800, 0xD800, 0x0041],
+            1303,
+            "consecutive lone highs → FFFD + FFFD + A",
+        ),
+    ];
+
+    for (units, expected, label) in cases {
+        let callee = build_callee_string_component();
+        let caller = build_caller_utf16_lowering_component(units);
+        let config = FuserConfig {
+            memory_strategy: MemoryStrategy::MultiMemory,
+            attestation: false,
+            component_provenance: false,
+            address_rebasing: false,
+            preserve_names: false,
+            custom_sections: meld_core::CustomSectionHandling::Drop,
+            dwarf_handling: meld_core::DwarfHandling::Strip,
+            output_format: meld_core::OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
+        };
+        let mut fuser = Fuser::new(config);
+        fuser
+            .add_component_named(&callee, Some("callee-utf8"))
+            .expect("callee parse");
+        fuser
+            .add_component_named(&caller, Some("caller-utf16"))
+            .expect("caller parse");
+        let (fused, _) = fuser.fuse_with_stats().expect("fusion");
+
+        let mut validator = wasmparser::Validator::new();
+        validator
+            .validate_all(&fused)
+            .unwrap_or_else(|e| panic!("#249 [{label}]: output must validate: {e}"));
+
+        let mut ec = Config::new();
+        ec.wasm_multi_memory(true);
+        let engine = Engine::new(&ec).unwrap();
+        let module = RuntimeModule::new(&engine, &fused).unwrap();
+        let mut store = Store::new(&engine, ());
+        let instance = Instance::new(&mut store, &module, &[]).unwrap();
+        let run = instance
+            .get_typed_func::<(), i32>(&mut store, "run")
+            .unwrap();
+        let result = run.call(&mut store, ()).unwrap();
+        assert_eq!(
+            result, *expected,
+            "#249 [{label}]: input {units:#06x?} expected byte-sum {expected}, got {result}"
+        );
+    }
+}

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -987,6 +987,16 @@ loss-scenarios:
       (run() == 500); after, it is U+FFFD + 'A' (sum 684). Runtime
       oracle: test_sr17_utf16_to_utf8_midstring_lone_surrogate_replacement.
       All causal factors of LS-P-16 are now mitigated and runtime-pinned.
+      Extended 2026-06-13 (#249): the symmetric LOW-surrogate gap is also
+      closed — a lone low surrogate (cu in [0xDC00, 0xE000) reaching the
+      non-high branch, which can only be malformed input since the high
+      arm consumes both halves of every valid pair) was previously
+      emitted as the malformed 3-byte UTF-8 of a surrogate code point
+      (ED B0 80 .. ED BF BF); it is now replaced with U+FFFD. The whole
+      malformed-UTF-16 class for emit_utf16_to_utf8_transcode is pinned
+      by test_sr17_utf16_to_utf8_malformed_surrogate_matrix (lone low at
+      leading/trailing/mid positions, consecutive lone lows, consecutive
+      lone highs, valid pair, and lone-surrogate-adjacent-to-valid-pair).
 
   - id: LS-P-18
     title: LS-P-12 bypassed when a record mixes a covered pointer with a hidden conditional one


### PR DESCRIPTION
Closes #249. Completes the malformed-UTF-16 hardening of `emit_utf16_to_utf8_transcode`.

## Bug
The transcoder only special-cased **high** surrogates. A lone **low** surrogate (`[0xDC00, 0xE000)`) reaching the non-high branch was emitted as the malformed 3-byte UTF-8 of a surrogate code point (`ED B0 80 .. ED BF BF`) instead of U+FFFD. A low surrogate can only reach that branch as malformed input (the high arm consumes both halves of every valid pair). PoC `[0xDC00, 0x0041]` → 606 (`ED B0 80 41`); correct is 684 (`EF BF BD 41`).

## Fix
The non-high branch replaces a lone low surrogate with U+FFFD; otherwise encodes the BMP scalar directly. One code unit consumed either way — no termination/buffer-bound change.

## Verification — full malformed-UTF-16 matrix
`test_sr17_utf16_to_utf8_malformed_surrogate_matrix` pins the whole class: lone low at leading/trailing/mid, consecutive lone lows, consecutive lone highs, valid pair (U+1F600 still decodes), and lone-surrogate-adjacent-to-valid-pair. Combined with the lone-high oracles (v0.11 end-of-input, #248 mid-string), every unpaired-surrogate path is now runtime-pinned. Workspace **544/0**; clippy/fmt clean.

## Tier-5
`fact.rs` → Mythos clean-room pass to follow as comment + `mythos-pass-done` label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)