### PR TITLE
fix(adapter): validate malformed UTF-8 in UTF-8→UTF-16 transcode (closes #251)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -3015,9 +3015,14 @@ impl FactStyleGenerator {
             (StringEncoding::Utf8, StringEncoding::Utf8)
         );
 
-        // Scratch locals: src_idx, dst_idx, out_ptr, cu, code_point, and cu2
-        // (the second surrogate unit, used by the UTF-16→UTF-8 low-surrogate
-        // validation — LS-P-16 mid-string mitigation).
+        // Scratch locals: src_idx, dst_idx, out_ptr, cu/byte, code_point, and
+        // a 6th unit. In the UTF-16→UTF-8 direction the 6th unit is `cu2`
+        // (the second surrogate unit, used by the low-surrogate validation —
+        // LS-P-16 mid-string mitigation). In the UTF-8→UTF-16 direction the
+        // 6th unit is `cont` (a continuation byte being validated — #251
+        // malformed-UTF-8 hardening: invalid continuation / lead / overlong /
+        // surrogate / out-of-range detection). Only one direction's transcoder
+        // runs per generated function, so the two uses never alias.
         let scratch_locals: u32 = if needs_transcoding_locals { 6 } else { 0 };
         let post_return_base = param_count as u32 + scratch_locals;
 
@@ -3130,12 +3135,14 @@ impl FactStyleGenerator {
             }
         };
 
-        // Scratch locals: src_idx, dst_idx (code units), out_ptr, byte, code_point
+        // Scratch locals: src_idx, dst_idx (code units), out_ptr, byte,
+        // code_point, and cont (a continuation byte being validated — #251).
         let src_idx_local = param_count as u32;
         let dst_idx_local = param_count as u32 + 1;
         let out_ptr_local = param_count as u32 + 2;
         let byte_local = param_count as u32 + 3;
         let cp_local = param_count as u32 + 4;
+        let cont_local = param_count as u32 + 5;
 
         // Source reads use caller_memory, destination writes use callee_memory
         let src_mem8 = wasm_encoder::MemArg {
@@ -3205,6 +3212,49 @@ impl FactStyleGenerator {
         func.instruction(&Instruction::LocalSet(byte_local));
 
         // --- Decode UTF-8 sequence into code_point, advance src_idx ---
+        //
+        // #251 malformed-UTF-8 hardening. The decode arms below validate the
+        // *content* of every multi-byte sequence, not just (LS-P-19)
+        // truncation. The Canonical ABI mandates lossy U+FFFD replacement for
+        // any ill-formed UTF-8 (H-4.4 incorrect transcoding); on detection we
+        // follow the established LS-P-19 convention of emitting U+FFFD (one
+        // UTF-16 code unit) and consuming ONLY the lead byte (src_idx += 1),
+        // so the offending continuation/trailing byte is reprocessed on the
+        // next iteration. This always makes progress (>= 1 byte consumed) and
+        // is consistent with the existing truncation handling. It can emit
+        // more U+FFFDs than the strict Unicode "maximal subpart" rule for
+        // some multi-continuation cases, but never decodes to a wrong scalar.
+        //
+        // Helper closures keep the repeated WASM emission DRY:
+
+        // Emit: cp = U+FFFD; src_idx += 1 (replacement, consume lead only).
+        let emit_fffd_consume_lead = |func: &mut Function| {
+            func.instruction(&Instruction::I32Const(0xFFFD));
+            func.instruction(&Instruction::LocalSet(cp_local));
+            func.instruction(&Instruction::LocalGet(src_idx_local));
+            func.instruction(&Instruction::I32Const(1));
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::LocalSet(src_idx_local));
+        };
+
+        // Push mem8[ptr + src_idx + off] onto the stack (a continuation byte).
+        let push_byte_at = |func: &mut Function, off: i32| {
+            func.instruction(&Instruction::LocalGet(0));
+            func.instruction(&Instruction::LocalGet(src_idx_local));
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::I32Const(off));
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::I32Load8U(src_mem8));
+        };
+
+        // Push: (cont_local & 0xC0) != 0x80  (true => NOT a continuation byte).
+        let push_not_continuation = |func: &mut Function| {
+            func.instruction(&Instruction::LocalGet(cont_local));
+            func.instruction(&Instruction::I32Const(0xC0));
+            func.instruction(&Instruction::I32And);
+            func.instruction(&Instruction::I32Const(0x80));
+            func.instruction(&Instruction::I32Ne);
+        };
 
         // if byte < 0x80: 1-byte ASCII
         func.instruction(&Instruction::LocalGet(byte_local));
@@ -3223,211 +3273,292 @@ impl FactStyleGenerator {
         }
         func.instruction(&Instruction::Else);
         {
-            // if byte < 0xE0: 2-byte sequence
+            // if byte < 0xC2: invalid lead — a lone continuation byte
+            // (0x80–0xBF) masquerading as a lead, or an overlong 2-byte lead
+            // (0xC0, 0xC1). #251 case 2. Reject before the 2-byte arm so these
+            // never enter the decoder. → U+FFFD, consume lead only.
             func.instruction(&Instruction::LocalGet(byte_local));
-            func.instruction(&Instruction::I32Const(0xE0));
+            func.instruction(&Instruction::I32Const(0xC2));
             func.instruction(&Instruction::I32LtU);
             func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
             {
-                // LS-P-19: emit U+FFFD when the 2-byte sequence's
-                // continuation byte would be read past the end of input
-                // (truncated multi-byte lead). Pre-v0.11 trapped via
-                // `unreachable`; the Canonical-ABI-correct behaviour is
-                // lossy replacement with U+FFFD (a single UTF-16 code
-                // unit), consuming only the lead byte. The continuations
-                // would have started a valid sequence in another world;
-                // by not consuming bytes past the lead we leave that
-                // possibility open for the next iteration.
-                func.instruction(&Instruction::LocalGet(src_idx_local));
-                func.instruction(&Instruction::I32Const(1));
-                func.instruction(&Instruction::I32Add);
-                func.instruction(&Instruction::LocalGet(1));
-                func.instruction(&Instruction::I32GeU);
-                func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
-                {
-                    // Truncated 2-byte lead → U+FFFD.
-                    func.instruction(&Instruction::I32Const(0xFFFD));
-                    func.instruction(&Instruction::LocalSet(cp_local));
-                    func.instruction(&Instruction::LocalGet(src_idx_local));
-                    func.instruction(&Instruction::I32Const(1));
-                    func.instruction(&Instruction::I32Add);
-                    func.instruction(&Instruction::LocalSet(src_idx_local));
-                }
-                func.instruction(&Instruction::Else);
-                {
-                    // cp = (byte & 0x1F) << 6 | (b1 & 0x3F)
-                    func.instruction(&Instruction::LocalGet(byte_local));
-                    func.instruction(&Instruction::I32Const(0x1F));
-                    func.instruction(&Instruction::I32And);
-                    func.instruction(&Instruction::I32Const(6));
-                    func.instruction(&Instruction::I32Shl);
-                    func.instruction(&Instruction::LocalGet(0));
-                    func.instruction(&Instruction::LocalGet(src_idx_local));
-                    func.instruction(&Instruction::I32Add);
-                    func.instruction(&Instruction::I32Const(1));
-                    func.instruction(&Instruction::I32Add);
-                    func.instruction(&Instruction::I32Load8U(src_mem8));
-                    func.instruction(&Instruction::I32Const(0x3F));
-                    func.instruction(&Instruction::I32And);
-                    func.instruction(&Instruction::I32Or);
-                    func.instruction(&Instruction::LocalSet(cp_local));
-                    // src_idx += 2
-                    func.instruction(&Instruction::LocalGet(src_idx_local));
-                    func.instruction(&Instruction::I32Const(2));
-                    func.instruction(&Instruction::I32Add);
-                    func.instruction(&Instruction::LocalSet(src_idx_local));
-                }
-                func.instruction(&Instruction::End); // end LS-P-19 (2-byte) check
+                emit_fffd_consume_lead(func);
             }
             func.instruction(&Instruction::Else);
             {
-                // if byte < 0xF0: 3-byte sequence
+                // if byte < 0xE0: 2-byte sequence (lead 0xC2–0xDF, well-formed).
                 func.instruction(&Instruction::LocalGet(byte_local));
-                func.instruction(&Instruction::I32Const(0xF0));
+                func.instruction(&Instruction::I32Const(0xE0));
                 func.instruction(&Instruction::I32LtU);
                 func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
                 {
-                    // LS-P-19: emit U+FFFD when the 3-byte sequence's
-                    // continuation bytes would extend past the end of
-                    // input. Pre-v0.11 trapped; now substitutes the
-                    // truncated lead with U+FFFD and consumes only the
-                    // lead byte.
+                    // LS-P-19: emit U+FFFD when the 2-byte sequence's
+                    // continuation byte would be read past the end of input
+                    // (truncated multi-byte lead). Pre-v0.11 trapped via
+                    // `unreachable`; the Canonical-ABI-correct behaviour is
+                    // lossy replacement with U+FFFD (a single UTF-16 code
+                    // unit), consuming only the lead byte. The continuations
+                    // would have started a valid sequence in another world;
+                    // by not consuming bytes past the lead we leave that
+                    // possibility open for the next iteration.
                     func.instruction(&Instruction::LocalGet(src_idx_local));
-                    func.instruction(&Instruction::I32Const(2));
+                    func.instruction(&Instruction::I32Const(1));
                     func.instruction(&Instruction::I32Add);
                     func.instruction(&Instruction::LocalGet(1));
                     func.instruction(&Instruction::I32GeU);
                     func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
                     {
-                        // Truncated 3-byte lead → U+FFFD.
-                        func.instruction(&Instruction::I32Const(0xFFFD));
-                        func.instruction(&Instruction::LocalSet(cp_local));
-                        func.instruction(&Instruction::LocalGet(src_idx_local));
-                        func.instruction(&Instruction::I32Const(1));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::LocalSet(src_idx_local));
+                        // Truncated 2-byte lead → U+FFFD.
+                        emit_fffd_consume_lead(func);
                     }
                     func.instruction(&Instruction::Else);
                     {
-                        // cp = (byte & 0x0F) << 12 | (b1 & 0x3F) << 6 | (b2 & 0x3F)
-                        func.instruction(&Instruction::LocalGet(byte_local));
-                        func.instruction(&Instruction::I32Const(0x0F));
-                        func.instruction(&Instruction::I32And);
-                        func.instruction(&Instruction::I32Const(12));
-                        func.instruction(&Instruction::I32Shl);
-                        // b1
-                        func.instruction(&Instruction::LocalGet(0));
-                        func.instruction(&Instruction::LocalGet(src_idx_local));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Const(1));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Load8U(src_mem8));
-                        func.instruction(&Instruction::I32Const(0x3F));
-                        func.instruction(&Instruction::I32And);
-                        func.instruction(&Instruction::I32Const(6));
-                        func.instruction(&Instruction::I32Shl);
-                        func.instruction(&Instruction::I32Or);
-                        // b2
-                        func.instruction(&Instruction::LocalGet(0));
-                        func.instruction(&Instruction::LocalGet(src_idx_local));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Const(2));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Load8U(src_mem8));
-                        func.instruction(&Instruction::I32Const(0x3F));
-                        func.instruction(&Instruction::I32And);
-                        func.instruction(&Instruction::I32Or);
-                        func.instruction(&Instruction::LocalSet(cp_local));
-                        // src_idx += 3
-                        func.instruction(&Instruction::LocalGet(src_idx_local));
-                        func.instruction(&Instruction::I32Const(3));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::LocalSet(src_idx_local));
+                        // #251 case 1: validate the continuation byte.
+                        push_byte_at(func, 1);
+                        func.instruction(&Instruction::LocalSet(cont_local));
+                        push_not_continuation(func);
+                        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                        {
+                            // b1 is not a continuation byte → U+FFFD, consume lead.
+                            emit_fffd_consume_lead(func);
+                        }
+                        func.instruction(&Instruction::Else);
+                        {
+                            // cp = (byte & 0x1F) << 6 | (b1 & 0x3F).
+                            // Lead >= 0xC2 guarantees cp >= 0x80, so no overlong
+                            // check is needed (the 0xC0/0xC1 leads were rejected
+                            // above).
+                            func.instruction(&Instruction::LocalGet(byte_local));
+                            func.instruction(&Instruction::I32Const(0x1F));
+                            func.instruction(&Instruction::I32And);
+                            func.instruction(&Instruction::I32Const(6));
+                            func.instruction(&Instruction::I32Shl);
+                            func.instruction(&Instruction::LocalGet(cont_local));
+                            func.instruction(&Instruction::I32Const(0x3F));
+                            func.instruction(&Instruction::I32And);
+                            func.instruction(&Instruction::I32Or);
+                            func.instruction(&Instruction::LocalSet(cp_local));
+                            // src_idx += 2
+                            func.instruction(&Instruction::LocalGet(src_idx_local));
+                            func.instruction(&Instruction::I32Const(2));
+                            func.instruction(&Instruction::I32Add);
+                            func.instruction(&Instruction::LocalSet(src_idx_local));
+                        }
+                        func.instruction(&Instruction::End); // end 2-byte continuation check
                     }
-                    func.instruction(&Instruction::End); // end LS-P-19 (3-byte) check
+                    func.instruction(&Instruction::End); // end LS-P-19 (2-byte) check
                 }
                 func.instruction(&Instruction::Else);
                 {
-                    // 4-byte sequence (byte >= 0xF0)
-                    // LS-P-19: trap when the 4-byte sequence's continuation
-                    // bytes would extend past the end of the input — without
-                    // this guard a truncated 4-byte lead at the buffer tail
-                    // reads up to 3 bytes of attacker-adjacent caller memory
-                    // and folds them into the encoded code point.
-                    // LS-P-19: emit U+FFFD when the 4-byte sequence's
-                    // continuation bytes would extend past the end of
-                    // input. Pre-v0.11 trapped; now substitutes the
-                    // truncated lead with U+FFFD and consumes only the
-                    // lead byte.
-                    func.instruction(&Instruction::LocalGet(src_idx_local));
-                    func.instruction(&Instruction::I32Const(3));
-                    func.instruction(&Instruction::I32Add);
-                    func.instruction(&Instruction::LocalGet(1));
-                    func.instruction(&Instruction::I32GeU);
+                    // if byte < 0xF0: 3-byte sequence (lead 0xE0–0xEF).
+                    func.instruction(&Instruction::LocalGet(byte_local));
+                    func.instruction(&Instruction::I32Const(0xF0));
+                    func.instruction(&Instruction::I32LtU);
                     func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
                     {
-                        // Truncated 4-byte lead → U+FFFD.
-                        func.instruction(&Instruction::I32Const(0xFFFD));
-                        func.instruction(&Instruction::LocalSet(cp_local));
+                        // LS-P-19: emit U+FFFD when the 3-byte sequence's
+                        // continuation bytes would extend past the end of
+                        // input. Pre-v0.11 trapped; now substitutes the
+                        // truncated lead with U+FFFD and consumes only the
+                        // lead byte.
                         func.instruction(&Instruction::LocalGet(src_idx_local));
-                        func.instruction(&Instruction::I32Const(1));
+                        func.instruction(&Instruction::I32Const(2));
                         func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::LocalSet(src_idx_local));
+                        func.instruction(&Instruction::LocalGet(1));
+                        func.instruction(&Instruction::I32GeU);
+                        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                        {
+                            // Truncated 3-byte lead → U+FFFD.
+                            emit_fffd_consume_lead(func);
+                        }
+                        func.instruction(&Instruction::Else);
+                        {
+                            // #251 case 1: validate BOTH continuation bytes.
+                            // not_cont(b1) | not_cont(b2) → reject.
+                            push_byte_at(func, 1);
+                            func.instruction(&Instruction::LocalSet(cont_local));
+                            push_not_continuation(func);
+                            push_byte_at(func, 2);
+                            func.instruction(&Instruction::LocalSet(cont_local));
+                            push_not_continuation(func);
+                            func.instruction(&Instruction::I32Or);
+                            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                            {
+                                // A continuation byte is not 10xxxxxx → U+FFFD.
+                                emit_fffd_consume_lead(func);
+                            }
+                            func.instruction(&Instruction::Else);
+                            {
+                                // cp = (byte & 0x0F) << 12 | (b1 & 0x3F) << 6 | (b2 & 0x3F)
+                                func.instruction(&Instruction::LocalGet(byte_local));
+                                func.instruction(&Instruction::I32Const(0x0F));
+                                func.instruction(&Instruction::I32And);
+                                func.instruction(&Instruction::I32Const(12));
+                                func.instruction(&Instruction::I32Shl);
+                                // b1
+                                push_byte_at(func, 1);
+                                func.instruction(&Instruction::I32Const(0x3F));
+                                func.instruction(&Instruction::I32And);
+                                func.instruction(&Instruction::I32Const(6));
+                                func.instruction(&Instruction::I32Shl);
+                                func.instruction(&Instruction::I32Or);
+                                // b2
+                                push_byte_at(func, 2);
+                                func.instruction(&Instruction::I32Const(0x3F));
+                                func.instruction(&Instruction::I32And);
+                                func.instruction(&Instruction::I32Or);
+                                func.instruction(&Instruction::LocalSet(cp_local));
+                                // #251 cases 3 & 4: reject overlong
+                                // (cp < 0x800) and UTF-8-encoded surrogates
+                                // (0xD800 <= cp < 0xE000). overlong | surrogate.
+                                func.instruction(&Instruction::LocalGet(cp_local));
+                                func.instruction(&Instruction::I32Const(0x800));
+                                func.instruction(&Instruction::I32LtU);
+                                func.instruction(&Instruction::LocalGet(cp_local));
+                                func.instruction(&Instruction::I32Const(0xD800));
+                                func.instruction(&Instruction::I32GeU);
+                                func.instruction(&Instruction::LocalGet(cp_local));
+                                func.instruction(&Instruction::I32Const(0xE000));
+                                func.instruction(&Instruction::I32LtU);
+                                func.instruction(&Instruction::I32And);
+                                func.instruction(&Instruction::I32Or);
+                                func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                                {
+                                    // Overlong or surrogate → U+FFFD, consume lead.
+                                    emit_fffd_consume_lead(func);
+                                }
+                                func.instruction(&Instruction::Else);
+                                {
+                                    // Well-formed 3-byte. src_idx += 3.
+                                    func.instruction(&Instruction::LocalGet(src_idx_local));
+                                    func.instruction(&Instruction::I32Const(3));
+                                    func.instruction(&Instruction::I32Add);
+                                    func.instruction(&Instruction::LocalSet(src_idx_local));
+                                }
+                                func.instruction(&Instruction::End); // end 3-byte overlong/surrogate check
+                            }
+                            func.instruction(&Instruction::End); // end 3-byte continuation check
+                        }
+                        func.instruction(&Instruction::End); // end LS-P-19 (3-byte) check
                     }
                     func.instruction(&Instruction::Else);
                     {
-                        // cp = (byte & 0x07) << 18 | (b1 & 0x3F) << 12 | (b2 & 0x3F) << 6 | (b3 & 0x3F)
+                        // 4-byte sequence (byte >= 0xF0).
+                        // #251 case 2: leads 0xF5–0xFF can only produce
+                        // out-of-range code points; reject them up front so
+                        // they never enter the 4-byte decoder.
                         func.instruction(&Instruction::LocalGet(byte_local));
-                        func.instruction(&Instruction::I32Const(0x07));
-                        func.instruction(&Instruction::I32And);
-                        func.instruction(&Instruction::I32Const(18));
-                        func.instruction(&Instruction::I32Shl);
-                        // b1
-                        func.instruction(&Instruction::LocalGet(0));
-                        func.instruction(&Instruction::LocalGet(src_idx_local));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Const(1));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Load8U(src_mem8));
-                        func.instruction(&Instruction::I32Const(0x3F));
-                        func.instruction(&Instruction::I32And);
-                        func.instruction(&Instruction::I32Const(12));
-                        func.instruction(&Instruction::I32Shl);
-                        func.instruction(&Instruction::I32Or);
-                        // b2
-                        func.instruction(&Instruction::LocalGet(0));
-                        func.instruction(&Instruction::LocalGet(src_idx_local));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Const(2));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Load8U(src_mem8));
-                        func.instruction(&Instruction::I32Const(0x3F));
-                        func.instruction(&Instruction::I32And);
-                        func.instruction(&Instruction::I32Const(6));
-                        func.instruction(&Instruction::I32Shl);
-                        func.instruction(&Instruction::I32Or);
-                        // b3
-                        func.instruction(&Instruction::LocalGet(0));
-                        func.instruction(&Instruction::LocalGet(src_idx_local));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Const(3));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Load8U(src_mem8));
-                        func.instruction(&Instruction::I32Const(0x3F));
-                        func.instruction(&Instruction::I32And);
-                        func.instruction(&Instruction::I32Or);
-                        func.instruction(&Instruction::LocalSet(cp_local));
-                        // src_idx += 4
-                        func.instruction(&Instruction::LocalGet(src_idx_local));
-                        func.instruction(&Instruction::I32Const(4));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::LocalSet(src_idx_local));
+                        func.instruction(&Instruction::I32Const(0xF5));
+                        func.instruction(&Instruction::I32GeU);
+                        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                        {
+                            emit_fffd_consume_lead(func);
+                        }
+                        func.instruction(&Instruction::Else);
+                        {
+                            // LS-P-19: emit U+FFFD when the 4-byte sequence's
+                            // continuation bytes would extend past the end of
+                            // input — without this guard a truncated 4-byte
+                            // lead at the buffer tail reads up to 3 bytes of
+                            // attacker-adjacent caller memory and folds them
+                            // into the encoded code point. Pre-v0.11 trapped;
+                            // now substitutes the truncated lead with U+FFFD
+                            // and consumes only the lead byte.
+                            func.instruction(&Instruction::LocalGet(src_idx_local));
+                            func.instruction(&Instruction::I32Const(3));
+                            func.instruction(&Instruction::I32Add);
+                            func.instruction(&Instruction::LocalGet(1));
+                            func.instruction(&Instruction::I32GeU);
+                            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                            {
+                                // Truncated 4-byte lead → U+FFFD.
+                                emit_fffd_consume_lead(func);
+                            }
+                            func.instruction(&Instruction::Else);
+                            {
+                                // #251 case 1: validate all THREE continuation bytes.
+                                push_byte_at(func, 1);
+                                func.instruction(&Instruction::LocalSet(cont_local));
+                                push_not_continuation(func);
+                                push_byte_at(func, 2);
+                                func.instruction(&Instruction::LocalSet(cont_local));
+                                push_not_continuation(func);
+                                func.instruction(&Instruction::I32Or);
+                                push_byte_at(func, 3);
+                                func.instruction(&Instruction::LocalSet(cont_local));
+                                push_not_continuation(func);
+                                func.instruction(&Instruction::I32Or);
+                                func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                                {
+                                    // A continuation byte is not 10xxxxxx → U+FFFD.
+                                    emit_fffd_consume_lead(func);
+                                }
+                                func.instruction(&Instruction::Else);
+                                {
+                                    // cp = (byte & 0x07) << 18 | (b1 & 0x3F) << 12 | (b2 & 0x3F) << 6 | (b3 & 0x3F)
+                                    func.instruction(&Instruction::LocalGet(byte_local));
+                                    func.instruction(&Instruction::I32Const(0x07));
+                                    func.instruction(&Instruction::I32And);
+                                    func.instruction(&Instruction::I32Const(18));
+                                    func.instruction(&Instruction::I32Shl);
+                                    // b1
+                                    push_byte_at(func, 1);
+                                    func.instruction(&Instruction::I32Const(0x3F));
+                                    func.instruction(&Instruction::I32And);
+                                    func.instruction(&Instruction::I32Const(12));
+                                    func.instruction(&Instruction::I32Shl);
+                                    func.instruction(&Instruction::I32Or);
+                                    // b2
+                                    push_byte_at(func, 2);
+                                    func.instruction(&Instruction::I32Const(0x3F));
+                                    func.instruction(&Instruction::I32And);
+                                    func.instruction(&Instruction::I32Const(6));
+                                    func.instruction(&Instruction::I32Shl);
+                                    func.instruction(&Instruction::I32Or);
+                                    // b3
+                                    push_byte_at(func, 3);
+                                    func.instruction(&Instruction::I32Const(0x3F));
+                                    func.instruction(&Instruction::I32And);
+                                    func.instruction(&Instruction::I32Or);
+                                    func.instruction(&Instruction::LocalSet(cp_local));
+                                    // #251 cases 3 & 5: reject overlong
+                                    // (cp < 0x10000) and out-of-range
+                                    // (cp > 0x10FFFF). overlong | oor.
+                                    func.instruction(&Instruction::LocalGet(cp_local));
+                                    func.instruction(&Instruction::I32Const(0x10000));
+                                    func.instruction(&Instruction::I32LtU);
+                                    func.instruction(&Instruction::LocalGet(cp_local));
+                                    func.instruction(&Instruction::I32Const(0x10FFFF));
+                                    func.instruction(&Instruction::I32GtU);
+                                    func.instruction(&Instruction::I32Or);
+                                    func.instruction(&Instruction::If(
+                                        wasm_encoder::BlockType::Empty,
+                                    ));
+                                    {
+                                        // Overlong or out-of-range → U+FFFD, consume lead.
+                                        emit_fffd_consume_lead(func);
+                                    }
+                                    func.instruction(&Instruction::Else);
+                                    {
+                                        // Well-formed 4-byte. src_idx += 4.
+                                        func.instruction(&Instruction::LocalGet(src_idx_local));
+                                        func.instruction(&Instruction::I32Const(4));
+                                        func.instruction(&Instruction::I32Add);
+                                        func.instruction(&Instruction::LocalSet(src_idx_local));
+                                    }
+                                    func.instruction(&Instruction::End); // end 4-byte overlong/oor check
+                                }
+                                func.instruction(&Instruction::End); // end 4-byte continuation check
+                            }
+                            func.instruction(&Instruction::End); // end LS-P-19 (4-byte) check
+                        }
+                        func.instruction(&Instruction::End); // end 4-byte invalid-lead check
                     }
-                    func.instruction(&Instruction::End); // end LS-P-19 (4-byte) check
+                    func.instruction(&Instruction::End); // end 3-byte vs 4-byte
                 }
-                func.instruction(&Instruction::End); // end 3-byte vs 4-byte
+                func.instruction(&Instruction::End); // end 2-byte vs 3+byte
             }
-            func.instruction(&Instruction::End); // end 2-byte vs 3+byte
+            func.instruction(&Instruction::End); // end invalid-lead vs valid-multibyte
         }
         func.instruction(&Instruction::End); // end 1-byte vs 2+byte
 

--- a/meld-core/tests/adapter_safety.rs
+++ b/meld-core/tests/adapter_safety.rs
@@ -2673,3 +2673,138 @@ fn test_sr17_utf16_to_utf8_malformed_surrogate_matrix() {
         );
     }
 }
+
+/// Comprehensive malformed-UTF-8 matrix for UTF-8 → UTF-16 transcoding
+/// (#251): the forward-direction analogue of the #249 reverse matrix above.
+/// Every ill-formed UTF-8 sequence — invalid continuation, invalid lead
+/// (lone continuation / overlong 2-byte lead / out-of-range lead), overlong
+/// encoding, UTF-8-encoded surrogate, and out-of-range 4-byte code point —
+/// must transcode to U+FFFD (one UTF-16 code unit, 0xFFFD = 65533) per the
+/// Canonical ABI, never to a wrong scalar. Valid inputs must be unchanged.
+///
+/// The callee sums received UTF-16 code units. Constants: U+FFFD = 65533,
+/// 'A' = 0x41 = 65. Expected sums are hand-derived under the codebase's
+/// established LS-P-19 "emit U+FFFD, consume ONLY the lead byte" convention:
+/// on malformed detection src_idx advances by 1, so any trailing
+/// continuation byte (0x80–0xBF) is reprocessed and — being a lone
+/// continuation acting as a lead — itself becomes another U+FFFD. This makes
+/// several cases emit MORE than one U+FFFD; the per-case derivations spell
+/// out the exact count.
+#[test]
+fn test_sr17_utf8_to_utf16_malformed_matrix() {
+    // (input UTF-8 bytes, expected callee code-unit-sum, label)
+    //
+    // Hand-derivations for the malformed cases (FFFD = 65533):
+    //   [0xC2,0x41]            2-byte lead, 0x41 not a continuation
+    //                          → FFFD (consume lead 0xC2), then 0x41 = 'A' = 65
+    //                          → 65533 + 65 = 65598
+    //   [0x80,0x41]            0x80 is a lone continuation < 0xC2 → invalid lead
+    //                          → FFFD (consume 1), then 0x41 = 65
+    //                          → 65533 + 65 = 65598
+    //   [0xC0,0x80]            0xC0 < 0xC2 → invalid (overlong) lead → FFFD
+    //                          (consume 1); reprocess 0x80, a lone continuation
+    //                          < 0xC2 → invalid lead → FFFD (consume 1)
+    //                          → 65533 + 65533 = 131066
+    //   [0xED,0xA0,0x80]       0xED is a 3-byte lead; conts 0xA0,0x80 are valid
+    //                          continuation bytes, decoding to cp = 0xD800 (a
+    //                          UTF-8-encoded surrogate) → rejected → FFFD,
+    //                          consume ONLY the lead. src_idx now 1: reprocess
+    //                          0xA0 (lone cont) → FFFD, consume 1. src_idx 2:
+    //                          reprocess 0x80 (lone cont) → FFFD, consume 1.
+    //                          THREE U+FFFD → 65533 * 3 = 196599
+    //   [0xF5,0x80,0x80,0x80]  0xF5 >= 0xF5 → out-of-range lead → FFFD,
+    //                          consume 1; the three trailing 0x80 are each lone
+    //                          continuations → FFFD each. FOUR U+FFFD
+    //                          → 65533 * 4 = 262132
+    //   [0xF4,0x90,0x80,0x80]  0xF4 is an in-range 4-byte lead; conts valid,
+    //                          cp = 0x110000 > U+10FFFF (out of range) →
+    //                          rejected → FFFD, consume ONLY the lead. The
+    //                          three trailing bytes 0x90,0x80,0x80 are then
+    //                          each lone continuations → FFFD each. FOUR U+FFFD
+    //                          → 65533 * 4 = 262132
+    //
+    // Valid controls (must be byte-for-byte unchanged from the fast paths):
+    //   [0x41]                 'A' = 65
+    //   [0xC3,0xA9]            é = U+00E9 = 233
+    //   [0xE2,0x82,0xAC]       € = U+20AC = 8364
+    //   [0xF0,0x9F,0x98,0x80]  😀 = U+1F600 → surrogate pair 0xD83D + 0xDE00
+    //                          = 55357 + 56832 = 112189
+    let cases: &[(&[u8], i32, &str)] = &[
+        // Malformed.
+        (&[0xC2, 0x41], 65598, "2-byte bad continuation → FFFD + A"),
+        (&[0x80, 0x41], 65598, "lone continuation as lead → FFFD + A"),
+        (
+            &[0xC0, 0x80],
+            131066,
+            "overlong 2-byte lead 0xC0 + lone cont → FFFD + FFFD",
+        ),
+        (
+            &[0xED, 0xA0, 0x80],
+            196599,
+            "UTF-8-encoded surrogate U+D800 → FFFD x3 (lead + 2 reprocessed conts)",
+        ),
+        (
+            &[0xF5, 0x80, 0x80, 0x80],
+            262132,
+            "out-of-range lead 0xF5 → FFFD x4",
+        ),
+        (
+            &[0xF4, 0x90, 0x80, 0x80],
+            262132,
+            "4-byte > U+10FFFF → FFFD x4 (lead + 3 reprocessed conts)",
+        ),
+        // Valid controls.
+        (&[0x41], 65, "valid ASCII 'A'"),
+        (&[0xC3, 0xA9], 233, "valid 2-byte é U+00E9"),
+        (&[0xE2, 0x82, 0xAC], 8364, "valid 3-byte € U+20AC"),
+        (
+            &[0xF0, 0x9F, 0x98, 0x80],
+            112189,
+            "valid 4-byte 😀 U+1F600 → surrogate pair",
+        ),
+    ];
+
+    for (bytes, expected, label) in cases {
+        let callee = build_callee_utf16_string_component();
+        let caller = build_caller_string_component_data(bytes);
+        let config = FuserConfig {
+            memory_strategy: MemoryStrategy::MultiMemory,
+            attestation: false,
+            component_provenance: false,
+            address_rebasing: false,
+            preserve_names: false,
+            custom_sections: meld_core::CustomSectionHandling::Drop,
+            dwarf_handling: meld_core::DwarfHandling::Strip,
+            output_format: meld_core::OutputFormat::CoreModule,
+            opaque_resources: Vec::new(),
+        };
+        let mut fuser = Fuser::new(config);
+        fuser
+            .add_component_named(&callee, Some("callee-utf16"))
+            .expect("callee parse");
+        fuser
+            .add_component_named(&caller, Some("caller-utf8"))
+            .expect("caller parse");
+        let (fused, _) = fuser.fuse_with_stats().expect("fusion");
+
+        let mut validator = wasmparser::Validator::new();
+        validator
+            .validate_all(&fused)
+            .unwrap_or_else(|e| panic!("#251 [{label}]: output must validate: {e}"));
+
+        let mut ec = Config::new();
+        ec.wasm_multi_memory(true);
+        let engine = Engine::new(&ec).unwrap();
+        let module = RuntimeModule::new(&engine, &fused).unwrap();
+        let mut store = Store::new(&engine, ());
+        let instance = Instance::new(&mut store, &module, &[]).unwrap();
+        let run = instance
+            .get_typed_func::<(), i32>(&mut store, "run")
+            .unwrap();
+        let result = run.call(&mut store, ()).unwrap();
+        assert_eq!(
+            result, *expected,
+            "#251 [{label}]: input {bytes:#04x?} expected code-unit-sum {expected}, got {result}"
+        );
+    }
+}

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -192,6 +192,9 @@ verification-status:
       - adapter_safety::test_sr17_utf8_to_utf16_supplementary_plane_transcoding
       - adapter_safety::test_sr17_utf16_to_utf8_supplementary_plane_transcoding
       - adapter_safety::test_sr17_utf16_to_utf8_lone_high_surrogate_replacement
+      - adapter_safety::test_sr17_utf16_to_utf8_midstring_lone_surrogate_replacement
+      - adapter_safety::test_sr17_utf16_to_utf8_malformed_surrogate_matrix
+      - adapter_safety::test_sr17_utf8_to_utf16_malformed_matrix
       - resolver::tests::test_sr17_all_encoding_pairs_transcoding_matrix
     proofs: []
     status: verified

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -1116,6 +1116,63 @@ loss-scenarios:
     status: approved
     priority: high
 
+  - id: LS-P-20
+    title: UTF-8→UTF-16 transcoder mis-decodes malformed (non-truncated) UTF-8 instead of U+FFFD
+    uca: UCA-P-3
+    hazards: [H-4, H-4.4]
+    type: inadequate-control-algorithm
+    scenario: >
+      `emit_utf8_to_utf16_transcode` (the canonical mirror of the
+      UTF-16→UTF-8 LS-P-16 family) guarded TRUNCATION (LS-P-19) but did
+      not validate the CONTENT of multi-byte sequences. Each arm masked
+      continuation bytes (`& 0x3F`) and lead bits without checking that
+      continuations are actually continuation bytes, that the lead is a
+      valid lead, or that the decoded code point is not overlong / a
+      surrogate / out of range. Malformed-but-in-bounds UTF-8 was
+      therefore decoded to a WRONG code point and emitted as UTF-16
+      [UCA-P-3 / H-4.4 incorrect string transcoding]. Confirmed by PoC:
+      a UTF-8 caller passing `[0xC2, 0x41]` (2-byte lead then an ASCII
+      byte that is not a continuation) transcoded to U+0081
+      (`(0xC2 & 0x1F)<<6 | (0x41 & 0x3F)`), summing to 129 at a
+      code-unit-summing callee, instead of the Canonical-ABI-correct
+      U+FFFD + 'A' (65598). Distinct from LS-P-19 (truncation / OOB
+      read): this is in-bounds content mis-decoding (H-4.4 only, no
+      H-2). Reachable for any cross-memory UTF-8→UTF-16 fusion whose
+      caller string contains malformed UTF-8 (invalid continuation,
+      lone continuation as lead, overlong lead 0xC0/0xC1, out-of-range
+      lead 0xF5-0xFF, overlong encoding, UTF-8-encoded surrogate, or a
+      4-byte value > U+10FFFF). Surfaced while completing the
+      reverse-direction surrogate hardening (#249/#250); filed as #251.
+    causal-factors:
+      - >-
+        No validation that each continuation byte satisfies
+        (b & 0xC0) == 0x80 before masking it into the code point
+      - >-
+        No lead-byte classification — lone continuations (0x80-0xBF)
+        were treated as 2-byte leads and 0xF5-0xFF as 4-byte leads
+      - >-
+        No post-decode validation for overlong encodings, surrogate
+        code points, or values above U+10FFFF
+    process-model-flaw: >
+      The decoder assumed well-formed UTF-8 (mirroring the pre-fix
+      UTF-16 side's "high surrogate implies a valid pair" flaw); fused
+      adapters consume untrusted caller buffers where every malformed
+      form is reachable. The Canonical ABI mandates U+FFFD replacement.
+    status: approved
+    priority: high
+    fix: >
+      Each arm now rejects invalid leads (< 0xC2 before the 2-byte
+      path; >= 0xF5 before the 4-byte path), validates every
+      continuation byte, and rejects overlong (3-byte cp < 0x800,
+      4-byte cp < 0x10000), surrogate (3-byte cp in [0xD800, 0xE000)),
+      and out-of-range (4-byte cp > 0x10FFFF) results — each emitting
+      U+FFFD and consuming only the lead byte (the established LS-P-19
+      convention; always makes progress, may emit more U+FFFDs than the
+      strict maximal-subpart rule). Pinned by the runtime matrix
+      test_sr17_utf8_to_utf16_malformed_matrix (invalid continuation,
+      lone-continuation lead, overlong, UTF-8 surrogate, out-of-range,
+      and valid 1/2/3/4-byte controls incl. boundary code points).
+
   - id: LS-P-17
     title: Caller-encoding match filters on Func only, miscalibrates mixed-encoding callers
     uca: UCA-R-3


### PR DESCRIPTION
Closes #251. The symmetric forward-direction counterpart to the reverse malformed-surrogate hardening (#248/#250) — completes malformed-input handling for both transcode directions.

## Bug (confirmed by PoC)
`emit_utf8_to_utf16_transcode` guarded truncation (LS-P-19) but never validated multi-byte *content*: every arm masked continuation bytes and lead bits blindly. `[0xC2, 0x41]` (2-byte lead + ASCII non-continuation) decoded to U+0081 (sum 129) instead of `U+FFFD + 'A'` (65598).

## Fix
Each arm now → U+FFFD (consume lead only, per the established LS-P-19 convention) on: invalid lead (`<0xC2` covers lone continuations + overlong 0xC0/0xC1; `>=0xF5` out of range), invalid continuation byte (`(b&0xC0)!=0x80`), overlong (3-byte `cp<0x800`, 4-byte `cp<0x10000`), UTF-8-encoded surrogate (`cp∈[0xD800,0xE000)`), and out-of-range (`cp>0x10FFFF`). Valid fast paths and the LS-P-19 truncation guards are unchanged. Added one local (`cont_local`), reusing the free index 5 (mutually exclusive with the reverse transcoder per the dispatch match).

## Verification
- `test_sr17_utf8_to_utf16_malformed_matrix`: invalid continuation, lone-continuation lead, overlong, UTF-8 surrogate, out-of-range, plus valid 1/2/3/4-byte controls. Existing forward tests (ASCII, non-BMP) unchanged. Workspace **545/0**; clippy/fmt clean.
- **Mythos clean-room pass: NO PROVABLE FINDING** — boundary-value PoCs confirm the smallest/largest valid 2/3/4-byte code points (U+0080, U+07FF, U+0800, U+10000, U+10FFFF) and the surrogate-boundary points (U+D7FF, U+E000) pass without false-positive rejection, and truncated-invalid inputs don't OOB. (Full report in the next comment.)
- LS-P-20 approved; SR-17 traceability extended.

## Tier-5
`fact.rs` → Mythos pass done, `mythos-pass-done` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)