### PR TITLE
fix(adapter): fail loud on unsupported cross-encoding transcode (#253 inc 1)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -3070,12 +3070,29 @@ impl FactStyleGenerator {
                 self.emit_latin1_to_utf8_transcode(&mut func, param_count, target_func, options);
             }
 
-            _ => {
-                // Other combinations - fall back to direct call for now
+            (caller_enc, callee_enc) if caller_enc == callee_enc => {
+                // Same encoding (e.g. Utf16→Utf16, Latin1→Latin1): no
+                // transcoding needed, a verbatim copy is correct.
                 for i in 0..param_count {
                     func.instruction(&Instruction::LocalGet(i as u32));
                 }
                 func.instruction(&Instruction::Call(target_func));
+            }
+
+            (caller_enc, callee_enc) => {
+                // #253: a cross-encoding pair with no transcoder implemented
+                // (e.g. Latin1→Utf16, Utf8→Latin1, Utf16→Latin1 — note
+                // CompactUTF16 maps to Latin1). Previously this fell through
+                // to a verbatim byte copy, silently MIS-transcoding
+                // well-formed input (H-4.4). Fail loudly instead of emitting
+                // a wrong adapter — the per-pair transcoders are tracked as
+                // follow-up work. Reaching here means the resolver requested
+                // a transcoding meld cannot yet perform correctly.
+                return Err(crate::Error::AdapterGeneration(format!(
+                    "unsupported string transcoding: {caller_enc:?} -> {callee_enc:?} \
+                     (no transcoder implemented; a verbatim copy would silently \
+                     corrupt well-formed input — see #253)"
+                )));
             }
         }
 

--- a/meld-core/tests/adapter_safety.rs
+++ b/meld-core/tests/adapter_safety.rs
@@ -2174,6 +2174,13 @@ fn test_sr17_utf8_to_utf16_supplementary_plane_transcoding() {
 /// memory, and `run` calls `process-string(0, code_units.len())` — the
 /// length is a UTF-16 code-unit count, per the canonical ABI.
 fn build_caller_utf16_lowering_component(code_units: &[u16]) -> Vec<u8> {
+    build_caller_lowering_component(code_units, CanonicalOption::UTF16)
+}
+
+/// Like `build_caller_utf16_lowering_component` but parameterized on the
+/// `canon lower` string encoding, so tests can drive other caller-side
+/// encodings (e.g. CompactUTF16 → Latin1) through the resolver.
+fn build_caller_lowering_component(code_units: &[u16], lower_encoding: CanonicalOption) -> Vec<u8> {
     let mut data_bytes = Vec::new();
     for cu in code_units {
         data_bytes.extend_from_slice(&cu.to_le_bytes());
@@ -2373,7 +2380,7 @@ fn build_caller_utf16_lowering_component(code_units: &[u16]) -> Vec<u8> {
         canon.lower(
             0,
             [
-                CanonicalOption::UTF16,
+                lower_encoding,
                 CanonicalOption::Memory(0),
                 CanonicalOption::Realloc(0),
             ],
@@ -2807,4 +2814,48 @@ fn test_sr17_utf8_to_utf16_malformed_matrix() {
             "#251 [{label}]: input {bytes:#04x?} expected code-unit-sum {expected}, got {result}"
         );
     }
+}
+
+/// #253 fail-loud guard: a cross-encoding pair with no transcoder
+/// implemented must FAIL fusion loudly rather than silently emit a
+/// verbatim byte copy that mis-transcodes well-formed input. A caller
+/// that lowers with CompactUTF16 (which meld maps to Latin1) into a
+/// UTF-16 callee produces the unimplemented (Latin1, Utf16) pair; fusion
+/// must return Err, not a silently-wrong module.
+#[test]
+fn test_253_unsupported_cross_encoding_transcode_fails_loud() {
+    let callee = build_callee_utf16_string_component(); // lifts UTF-16
+    let caller = build_caller_lowering_component(&[0x0041], CanonicalOption::CompactUTF16);
+
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        component_provenance: false,
+        address_rebasing: false,
+        preserve_names: false,
+        custom_sections: meld_core::CustomSectionHandling::Drop,
+        dwarf_handling: meld_core::DwarfHandling::Strip,
+        output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
+    };
+
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&callee, Some("callee-utf16"))
+        .expect("callee parse");
+    fuser
+        .add_component_named(&caller, Some("caller-compact"))
+        .expect("caller parse");
+
+    let result = fuser.fuse_with_stats();
+    assert!(
+        result.is_err(),
+        "#253: (Latin1/CompactUTF16 -> Utf16) has no transcoder; fusion must \
+         fail loudly rather than emit a silently-wrong verbatim copy. Got Ok."
+    );
+    let msg = format!("{:?}", result.err().unwrap());
+    assert!(
+        msg.contains("transcoding") || msg.contains("#253"),
+        "#253: error should name the unsupported transcoding; got: {msg}"
+    );
 }


### PR DESCRIPTION
First increment on #253 — converts a silent miscompile into a loud failure.

## Bug
`generate_transcoding_adapter`'s `_` catch-all emitted a verbatim byte copy for every unhandled encoding pair. Since `needs_transcoding()` is `caller != callee` (always true for mismatches) and the adapter is generated on `crosses_memory && needs_transcoding`, the unimplemented cross-encoding pairs — `(Latin1,Utf16)`, `(Utf8,Latin1)`, `(Utf16,Latin1)`; CompactUTF16 maps to Latin1 — **silently mis-transcoded well-formed input** (H-4.4): bytes copied raw under a different encoding.

## This increment
Split the catch-all: same-encoding (`Utf16→Utf16`, `Latin1→Latin1`) keeps the correct verbatim copy; different-encoding-unhandled returns `Err(AdapterGeneration)`. meld now **refuses rather than corrupts**. The three missing transcoders (`Latin1↔Utf16`, `*↔Latin1`) remain tracked on #253 as the complete fix.

## Verification
- `test_253_unsupported_cross_encoding_transcode_fails_loud`: a CompactUTF16-lowering caller (→Latin1) into a UTF-16 callee — fusion now returns `Err`. **Confirms #253 reachability end-to-end** (the resolver does produce the `(Latin1, Utf16)` pair).
- No existing fixture relied on the silent path: full suite **546/0**, incl. 73 wit_bindgen runtime tests. clippy/fmt clean.

## Tier-5
`fact.rs` → Mythos clean-room pass to follow as comment + `mythos-pass-done` label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)