### PR TITLE
fix(segments): preserve element-segment reference types (closes #256, LS-A-21)

### DIFF
--- a/meld-core/src/segments.rs
+++ b/meld-core/src/segments.rs
@@ -210,11 +210,15 @@ pub fn parse_element_segments(module: &CoreModule) -> Result<Vec<ParsedElementSe
                 (RefType::FUNCREF, ElementItems_::Functions(funcs))
             }
             ElementItems::Expressions(ref_type, expr_reader) => {
-                let element_type = if ref_type.is_func_ref() {
-                    RefType::FUNCREF
-                } else {
-                    RefType::EXTERNREF
-                };
+                // Carry the FULL ref type faithfully — bucketing every
+                // non-funcref to externref (the prior behaviour) dropped
+                // concrete typed function references `(ref $t)` and GC
+                // abstract heap types (struct/array/eq/any/i31/none), and
+                // lost the concrete type index entirely, producing a fused
+                // module that fails wasm validation ("type mismatch:
+                // expected externref, found (ref $type)"). The concrete
+                // index is remapped during reindexing (see remap_ref_type).
+                let element_type = convert_ref_type(ref_type);
                 let mut exprs = Vec::new();
                 for expr in expr_reader {
                     let expr = expr?;
@@ -288,6 +292,40 @@ pub fn parse_data_segments(module: &CoreModule) -> Result<Vec<ParsedDataSegment>
 }
 
 /// Reindex an element segment with new index mappings
+/// Faithfully convert a `wasmparser::RefType` to a `wasm_encoder::RefType`,
+/// preserving nullability, abstract heap types, and concrete type indices.
+/// (Concrete indices are module-level here; they are remapped later by
+/// [`remap_ref_type`].) Replaces the lossy funcref/externref bucketing that
+/// previously corrupted typed-ref and GC element segments.
+fn convert_ref_type(rt: wasmparser::RefType) -> RefType {
+    let heap_type = match rt.heap_type() {
+        wasmparser::HeapType::Abstract { shared, ty } => wasm_encoder::HeapType::Abstract {
+            shared,
+            ty: convert_abstract_heap_type(ty),
+        },
+        wasmparser::HeapType::Concrete(idx) | wasmparser::HeapType::Exact(idx) => {
+            wasm_encoder::HeapType::Concrete(idx.as_module_index().unwrap_or(0))
+        }
+    };
+    RefType {
+        nullable: rt.is_nullable(),
+        heap_type,
+    }
+}
+
+/// Remap a ref type's concrete heap-type index through the merge index maps;
+/// abstract heap types carry no index. Mirrors the `RefNull` heap-type
+/// handling in [`ParsedConstExpr::reindex`].
+fn remap_ref_type(rt: RefType, maps: &IndexMaps) -> RefType {
+    let heap_type = match rt.heap_type {
+        wasm_encoder::HeapType::Concrete(idx) => {
+            wasm_encoder::HeapType::Concrete(maps.remap_type(idx))
+        }
+        other => other,
+    };
+    RefType { heap_type, ..rt }
+}
+
 pub fn reindex_element_segment(
     segment: &ParsedElementSegment,
     maps: &IndexMaps,
@@ -320,7 +358,7 @@ pub fn reindex_element_segment(
 
     ReindexedElementSegment {
         mode,
-        element_type: segment.element_type,
+        element_type: remap_ref_type(segment.element_type, maps),
         items,
     }
 }
@@ -874,6 +912,115 @@ mod tests {
             actual, expected,
             "concrete type index should be remapped from 0 to 4"
         );
+    }
+
+    /// Regression for the element-segment ref-type collapse: reindexing a
+    /// segment whose element type is a CONCRETE typed reference `(ref null
+    /// $t)` must preserve the concrete heap type and remap its index — not
+    /// collapse it to externref (the prior bug dropped the type entirely).
+    #[test]
+    fn test_reindex_element_segment_preserves_and_remaps_concrete_element_type() {
+        let segment = ParsedElementSegment {
+            mode: ParsedElementSegmentMode::Passive,
+            element_type: RefType {
+                nullable: true,
+                heap_type: wasm_encoder::HeapType::Concrete(0),
+            },
+            items: ElementItems_::Expressions(vec![ParsedConstExpr::RefFunc(0)]),
+        };
+        let mut maps = IndexMaps::new();
+        maps.types.insert(0, 4);
+
+        let reindexed = reindex_element_segment(&segment, &maps);
+        assert_eq!(
+            reindexed.element_type,
+            RefType {
+                nullable: true,
+                heap_type: wasm_encoder::HeapType::Concrete(4),
+            },
+            "concrete element type must be preserved and its index remapped 0->4, \
+             not collapsed to externref"
+        );
+    }
+
+    /// End-to-end regression (the discovery-pass PoC): a core module with a
+    /// concrete typed-ref element segment `(elem (ref null 0) (ref.func 0))`
+    /// must survive parse -> reindex -> encode and still VALIDATE. Before the
+    /// fix the segment was re-typed externref while its items stayed funcref,
+    /// so the re-emitted module was rejected ("type mismatch: expected
+    /// externref, found (ref $type)").
+    #[test]
+    fn test_typed_ref_element_segment_roundtrips_and_validates() {
+        let src = r#"(module (type (func)) (func) (elem (ref null 0) (ref.func 0)))"#;
+        let module_bytes = wat::parse_str(src).expect("wat compiles");
+
+        // Locate the element section payload range.
+        let mut elem_range = None;
+        for payload in wasmparser::Parser::new(0).parse_all(&module_bytes) {
+            if let wasmparser::Payload::ElementSection(reader) = payload.expect("payload") {
+                elem_range = Some((reader.range().start, reader.range().end));
+            }
+        }
+        let elem_range = elem_range.expect("module has an element section");
+
+        let module = crate::parser::CoreModule {
+            index: 0,
+            bytes: module_bytes.clone(),
+            types: Vec::new(),
+            imports: Vec::new(),
+            exports: Vec::new(),
+            functions: Vec::new(),
+            memories: Vec::new(),
+            tables: Vec::new(),
+            globals: Vec::new(),
+            start: None,
+            data_count: None,
+            element_count: 1,
+            custom_sections: Vec::new(),
+            code_section_range: None,
+            global_section_range: None,
+            element_section_range: Some(elem_range),
+            data_section_range: None,
+        };
+
+        let parsed = parse_element_segments(&module).expect("parse element segments");
+        assert_eq!(parsed.len(), 1);
+        assert!(
+            matches!(
+                parsed[0].element_type.heap_type,
+                wasm_encoder::HeapType::Concrete(_)
+            ),
+            "parsed element type must stay a concrete typed ref, got {:?}",
+            parsed[0].element_type
+        );
+
+        // Reindex with identity maps (single module), re-encode the segment
+        // into a fresh module, and validate it.
+        let maps = IndexMaps::new();
+        let reindexed = reindex_element_segment(&parsed[0], &maps);
+        let encoded = encode_element_segment(&reindexed);
+
+        let mut types = wasm_encoder::TypeSection::new();
+        types.ty().function([], []);
+        let mut funcs = wasm_encoder::FunctionSection::new();
+        funcs.function(0);
+        let mut elems = wasm_encoder::ElementSection::new();
+        elems.segment(encoded);
+        let mut code = wasm_encoder::CodeSection::new();
+        let mut f = wasm_encoder::Function::new([]);
+        f.instruction(&wasm_encoder::Instruction::End);
+        code.function(&f);
+
+        let mut out = wasm_encoder::Module::new();
+        out.section(&types);
+        out.section(&funcs);
+        out.section(&elems);
+        out.section(&code);
+        let out_bytes = out.finish();
+
+        wasmparser::Validator::new()
+            .validate_all(&out_bytes)
+            .expect("re-encoded module with a typed-ref element segment must validate");
     }
 
     // ---------------------------------------------------------------

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -2500,6 +2500,71 @@ loss-scenarios:
     status: approved
     priority: high
 
+  - id: LS-A-21
+    title: Element-segment reference-type collapse — concrete/GC ref types re-typed externref
+    uca: UCA-M-4
+    hazards: [H-3]
+    type: inadequate-control-algorithm
+    scenario: >
+      `meld-core/src/segments.rs::parse_element_segments` decoded an
+      expression-encoded element segment's reference type with
+      `if ref_type.is_func_ref() { FUNCREF } else { EXTERNREF }`,
+      collapsing EVERY non-funcref element type to externref. A
+      concrete typed function reference `(ref null $t)` / `(ref $t)`
+      lost its heap type AND its concrete type index entirely (the
+      index was never carried into `ParsedElementSegment`, so the
+      `maps.types` remap could never run on it), and GC abstract heap
+      types (struct/array/eq/any/i31/none) were likewise flattened to
+      externref. Because the element ITEMS (e.g. `ref.func 0`) kept
+      their real funcref type while the segment was declared externref,
+      the re-emitted fused module is INVALID — `wasmparser::Validator`
+      rejects it with "type mismatch: expected externref, found
+      (ref $type)". meld turns a valid input module into an invalid
+      output [UCA-M-4 / H-3 index-and-type confusion]. meld's parser
+      enables gc + function-references + reference-types by default
+      (parser.rs), and the merger calls parse → reindex → encode
+      back-to-back with no transformation, so any fused component
+      embedding such a core module carries the corruption verbatim.
+      A silently invalid fused module is a downstream parse/exec
+      failure in every consumer (kiln, wasmtime, browsers). Surfaced
+      by a Mythos discovery pass on segments.rs.
+    causal-factors:
+      - >-
+        Expression-encoded element types bucketed to FUNCREF/EXTERNREF
+        instead of carrying the full RefType (heap type + nullability +
+        concrete index) — the same is_func_ref()-else-externref
+        anti-pattern that also exists in parser.rs::convert_ref_type
+      - >-
+        The concrete type index was dropped at parse time, so the
+        type-index remap in reindex_element_segment had nothing to act on
+      - >-
+        No test exercised a non-funcref expression-encoded element
+        segment (all fixtures used funcref), so validation of the
+        re-emitted module was never checked for typed-ref/GC element
+        segments
+    process-model-flaw: >
+      The model assumed element segments are funcref-or-externref (the
+      pre-GC/pre-typed-refs world). With the typed-function-references
+      and GC proposals — enabled by meld's default feature set —
+      element segments carry concrete and abstract heap types that must
+      be preserved and index-remapped, not bucketed.
+    status: approved
+    priority: high
+    fix: >
+      parse_element_segments now converts the full reference type
+      faithfully (convert_ref_type: nullability + abstract heap type via
+      convert_abstract_heap_type + concrete module index), and
+      reindex_element_segment remaps a concrete heap-type index through
+      maps.remap_type (remap_ref_type), mirroring the existing RefNull
+      const-expr handling. Pinned by
+      segments::tests::test_typed_ref_element_segment_roundtrips_and_validates
+      (a `(elem (ref null 0) (ref.func 0))` module parses → reindexes →
+      re-encodes → VALIDATES) and
+      test_reindex_element_segment_preserves_and_remaps_concrete_element_type.
+      Note: the symmetric is_func_ref()-else-externref site in
+      parser.rs::convert_ref_type (used for value/global types) is a
+      related latent gap, out of scope for this segments.rs fix.
+
   - id: LS-A-12
     title: uses_stackful_lift mis-classifies mixed-mode components
     uca: UCA-A-3


### PR DESCRIPTION
Closes #256 (the element-segment branch of the resource/segment discovery work). Found by a Mythos discovery pass on `segments.rs`.

## Bug
`parse_element_segments` bucketed every expression-encoded element ref type via `if is_func_ref() { FUNCREF } else { EXTERNREF }`. A concrete typed function reference `(ref null $t)` lost its heap type AND its concrete type index (never carried into `ParsedElementSegment` → the `maps.types` remap could never run); GC abstract heap types were likewise flattened. The element ITEMS kept their real funcref type while the segment was re-declared externref, so the re-emitted module is **invalid** — `wasmparser` rejects it (`type mismatch: expected externref, found (ref $type)`). meld's parser enables gc + function-references by default and the merger calls parse→reindex→encode verbatim, so valid input modules became invalid output (**H-3**).

## Fix
`convert_ref_type` carries the full `RefType` faithfully (nullability + abstract heap type via `convert_abstract_heap_type` + concrete module index); `remap_ref_type` remaps a concrete heap-type index through `maps.remap_type` during reindex — mirroring the existing `RefNull` const-expr handling.

## Verification
- `test_typed_ref_element_segment_roundtrips_and_validates` — the discovery PoC: `(elem (ref null 0) (ref.func 0))` now parses → reindexes → re-encodes → **validates** (failed pre-fix). Plus `test_reindex_element_segment_preserves_and_remaps_concrete_element_type` (struct-level, index remapped 0→4, not collapsed).
- Workspace **549/0** (verified via exit code, not pass-count sum); clippy/fmt clean.

## Notes
The symmetric `is_func_ref()-else-externref` site in `parser.rs::convert_ref_type` (value/global types) is a related latent gap, out of scope here — worth a follow-up.

## Tier-5
`segments.rs` → Mythos clean-room pass to follow as comment + `mythos-pass-done` label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)