### PR TITLE
fix(reftype): preserve concrete/GC reference types through fusion (closes #258, LS-A-22)

### DIFF
--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -1381,16 +1381,32 @@ impl Merger {
         shared_memory_plan: Option<&SharedMemoryPlan>,
         unresolved_assignments: &UnresolvedImportAssignments,
     ) -> Result<()> {
-        // Merge types
+        // Merge types.
+        //
+        // Two passes: first record every type's old->merged index mapping, then
+        // build the merged types. The split is required because a func type's
+        // param/result may be a concrete typed-ref `(ref $t)` whose index `t`
+        // can forward-reference another type in this same module; remapping it
+        // needs the *complete* mapping for the module to already be in place.
         let type_offset = merged.types.len() as u32;
-        for (old_idx, ty) in module.types.iter().enumerate() {
+        for (old_idx, _ty) in module.types.iter().enumerate() {
             merged.type_index_map.insert(
                 (comp_idx, mod_idx, old_idx as u32),
                 type_offset + old_idx as u32,
             );
+        }
+        for ty in module.types.iter() {
             merged.types.push(MergedFuncType {
-                params: ty.params.clone(),
-                results: ty.results.clone(),
+                params: ty
+                    .params
+                    .iter()
+                    .map(|&p| remap_concrete_val_type(p, comp_idx, mod_idx, merged))
+                    .collect(),
+                results: ty
+                    .results
+                    .iter()
+                    .map(|&r| remap_concrete_val_type(r, comp_idx, mod_idx, merged))
+                    .collect(),
             });
         }
 
@@ -1510,7 +1526,9 @@ impl Merger {
             merged
                 .table_index_map
                 .insert((comp_idx, mod_idx, old_table_idx), new_idx);
-            merged.tables.push(convert_table_type(table));
+            merged
+                .tables
+                .push(convert_table_type(table, comp_idx, mod_idx, merged));
         }
 
         // Merge globals (defined globals only; imported globals handled below)
@@ -1528,10 +1546,8 @@ impl Merger {
                 merged,
                 &global.content_type,
             );
-            merged.globals.push(MergedGlobal {
-                ty: convert_global_type(global),
-                init_expr,
-            });
+            let ty = convert_global_type(global, comp_idx, mod_idx, merged);
+            merged.globals.push(MergedGlobal { ty, init_expr });
         }
 
         // Resolve imported global indices via intra-component module_resolutions.
@@ -2363,7 +2379,12 @@ impl Merger {
                     merged.imports.push(MergedImport {
                         module,
                         name,
-                        entity_type: EntityType::Table(convert_table_type(t)),
+                        entity_type: EntityType::Table(convert_table_type(
+                            t,
+                            unresolved.component_idx,
+                            unresolved.module_idx,
+                            merged,
+                        )),
                         component_idx: Some(unresolved.component_idx),
                     });
                 }
@@ -2418,7 +2439,12 @@ impl Merger {
                     merged.imports.push(MergedImport {
                         module,
                         name,
-                        entity_type: EntityType::Global(convert_global_type(g)),
+                        entity_type: EntityType::Global(convert_global_type(
+                            g,
+                            unresolved.component_idx,
+                            unresolved.module_idx,
+                            merged,
+                        )),
                         component_idx: Some(unresolved.component_idx),
                     });
                 }
@@ -2705,11 +2731,70 @@ fn convert_memory_type(mem: &MemoryType) -> EncoderMemoryType {
     }
 }
 
-/// Convert parser TableType to encoder TableType
-fn convert_table_type(table: &TableType) -> EncoderTableType {
+/// Remap a concrete heap-type index embedded in a `RefType` through the
+/// per-module type index map, so it points at the correct merged type.
+///
+/// Concrete indices on `RefType`s produced by the parser are *module-level*
+/// (see `parser.rs::convert_ref_type`). When the merger renumbers types it
+/// records `(comp_idx, mod_idx, old_idx) -> merged_idx` in
+/// `merged.type_index_map` (built at the top of `merge_module`). This applies
+/// that same mapping. Abstract heap types carry no index and are returned
+/// unchanged.
+///
+/// This mirrors the concrete-heap-type remap already done for `ref.null` const
+/// expressions (the `RefNull` arm in `convert_const_expr`); that path remaps
+/// indices in *const-expression operands*, whereas this remaps the indices in
+/// *type/table/global section declarations*. The two cover disjoint structures,
+/// so applying this does not double-remap anything that path already handles.
+fn remap_concrete_ref_type(
+    rt: RefType,
+    comp_idx: usize,
+    mod_idx: usize,
+    merged: &MergedModule,
+) -> RefType {
+    let heap_type = match rt.heap_type {
+        wasm_encoder::HeapType::Concrete(old_idx) => {
+            let new_idx = merged
+                .type_index_map
+                .get(&(comp_idx, mod_idx, old_idx))
+                .copied()
+                .unwrap_or(old_idx);
+            wasm_encoder::HeapType::Concrete(new_idx)
+        }
+        other => other,
+    };
+    RefType { heap_type, ..rt }
+}
+
+/// Remap a concrete heap-type index embedded in a `ValType` (no-op for
+/// non-reference value types). Used for func-signature params/results and
+/// global content types. See [`remap_concrete_ref_type`].
+fn remap_concrete_val_type(
+    ty: ValType,
+    comp_idx: usize,
+    mod_idx: usize,
+    merged: &MergedModule,
+) -> ValType {
+    match ty {
+        ValType::Ref(rt) => ValType::Ref(remap_concrete_ref_type(rt, comp_idx, mod_idx, merged)),
+        other => other,
+    }
+}
+
+/// Convert parser TableType to encoder TableType.
+///
+/// `element_type` may be a concrete typed-ref (`(ref null $t)`); its
+/// module-level type index is remapped to the merged-module index via
+/// [`remap_concrete_ref_type`].
+fn convert_table_type(
+    table: &TableType,
+    comp_idx: usize,
+    mod_idx: usize,
+    merged: &MergedModule,
+) -> EncoderTableType {
     EncoderTableType {
         element_type: match table.element_type {
-            ValType::Ref(rt) => rt,
+            ValType::Ref(rt) => remap_concrete_ref_type(rt, comp_idx, mod_idx, merged),
             _ => RefType::FUNCREF,
         },
         table64: false,
@@ -2719,10 +2804,18 @@ fn convert_table_type(table: &TableType) -> EncoderTableType {
     }
 }
 
-/// Convert parser GlobalType to encoder GlobalType
-fn convert_global_type(global: &GlobalType) -> EncoderGlobalType {
+/// Convert parser GlobalType to encoder GlobalType.
+///
+/// `content_type` may be a concrete typed-ref; its module-level type index is
+/// remapped to the merged-module index via [`remap_concrete_val_type`].
+fn convert_global_type(
+    global: &GlobalType,
+    comp_idx: usize,
+    mod_idx: usize,
+    merged: &MergedModule,
+) -> EncoderGlobalType {
     EncoderGlobalType {
-        val_type: global.content_type,
+        val_type: remap_concrete_val_type(global.content_type, comp_idx, mod_idx, merged),
         mutable: global.mutable,
         shared: false,
     }

--- a/meld-core/src/parser.rs
+++ b/meld-core/src/parser.rs
@@ -4,6 +4,7 @@
 //! the core modules, types, imports, and exports needed for fusion.
 
 use crate::attestation::compute_sha256;
+use crate::rewriter::convert_abstract_heap_type;
 use crate::{Error, Result};
 use wasm_encoder::ValType;
 use wasmparser::{
@@ -3772,17 +3773,31 @@ fn convert_val_type(ty: WasmValType) -> ValType {
     }
 }
 
-/// Convert wasmparser RefType to wasm-encoder ValType
+/// Faithfully convert a `wasmparser::RefType` to a `wasm_encoder::ValType`,
+/// preserving nullability, abstract heap types, and concrete type indices.
+///
+/// At parse time, concrete heap-type indices are module-level
+/// (`idx.as_module_index()`); they are remapped to their merged-module index
+/// later by the merger (`convert_table_type` / `MergedFuncType` build /
+/// `convert_global_type`). Mirrors `segments.rs::convert_ref_type`.
+///
+/// Replaces the previous lossy funcref/externref bucketing that flattened
+/// concrete typed references `(ref null $t)` and GC abstract heap types
+/// (struct/array/eq/any/i31/...) to `funcref`, silently weakening the type.
 fn convert_ref_type(rt: wasmparser::RefType) -> ValType {
-    if rt.is_func_ref() {
-        ValType::Ref(wasm_encoder::RefType::FUNCREF)
-    } else if rt.is_extern_ref() {
-        ValType::Ref(wasm_encoder::RefType::EXTERNREF)
-    } else {
-        // For other reference types, default to funcref
-        // This is a simplification - real implementation would handle all ref types
-        ValType::Ref(wasm_encoder::RefType::FUNCREF)
-    }
+    let heap_type = match rt.heap_type() {
+        wasmparser::HeapType::Abstract { shared, ty } => wasm_encoder::HeapType::Abstract {
+            shared,
+            ty: convert_abstract_heap_type(ty),
+        },
+        wasmparser::HeapType::Concrete(idx) | wasmparser::HeapType::Exact(idx) => {
+            wasm_encoder::HeapType::Concrete(idx.as_module_index().unwrap_or(0))
+        }
+    };
+    ValType::Ref(wasm_encoder::RefType {
+        nullable: rt.is_nullable(),
+        heap_type,
+    })
 }
 
 #[cfg(test)]

--- a/meld-core/tests/reftype_fidelity.rs
+++ b/meld-core/tests/reftype_fidelity.rs
@@ -1,0 +1,425 @@
+//! Reference-type fidelity runtime matrix (issue #258).
+//!
+//! Regression coverage for the `convert_ref_type` collapse defect: the parser
+//! used to flatten every concrete typed-ref `(ref null $t)` and GC abstract
+//! heap type to `funcref`, and the merger never remapped concrete heap-type
+//! indices in the type/table/global sections. The two-part fix:
+//!
+//!   Part 1 — `parser.rs::convert_ref_type` faithfully preserves nullability +
+//!            abstract heap type + concrete module-level index.
+//!   Part 2 — `merger.rs` remaps those concrete module-level indices to the
+//!            merged-module type index when emitting tables, func-type
+//!            signatures, and globals.
+//!
+//! Each case fuses a component (or two), asserts the fused output VALIDATES
+//! under `WasmFeatures::all()`, and asserts the relevant reference type is
+//! PRESERVED (not collapsed to funcref) by inspecting the output binary.
+
+use meld_core::{Fuser, FuserConfig, MemoryStrategy, OutputFormat};
+use wasmparser::{
+    CompositeInnerType, GlobalType, HeapType, Parser, Payload, RefType, TableType, ValType,
+    WasmFeatures,
+};
+
+/// Fuse a single component to a core module and return the fused bytes.
+fn fuse_one(wat_src: &str) -> Vec<u8> {
+    let bytes = wat::parse_str(wat_src).expect("WAT should parse");
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        output_format: OutputFormat::CoreModule,
+        ..Default::default()
+    };
+    let mut fuser = Fuser::new(config);
+    fuser.add_component(&bytes).expect("add_component");
+    fuser.fuse().expect("fuse")
+}
+
+/// Fuse two components to a core module and return the fused bytes.
+fn fuse_two(wat_a: &str, wat_b: &str) -> Vec<u8> {
+    let a = wat::parse_str(wat_a).expect("WAT a should parse");
+    let b = wat::parse_str(wat_b).expect("WAT b should parse");
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        output_format: OutputFormat::CoreModule,
+        ..Default::default()
+    };
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&a, Some("comp-a"))
+        .expect("add a");
+    fuser
+        .add_component_named(&b, Some("comp-b"))
+        .expect("add b");
+    fuser.fuse().expect("fuse")
+}
+
+/// Validate fused output under the full feature set (GC, function-references,
+/// multi-memory, etc.). A collapsed-but-valid module would still pass here, so
+/// validation alone is NOT the regression guard — the type-preservation asserts
+/// below are.
+fn validate_all(fused: &[u8]) {
+    let mut validator = wasmparser::Validator::new_with_features(WasmFeatures::all());
+    validator
+        .validate_all(fused)
+        .expect("fused module must validate under WasmFeatures::all()");
+}
+
+/// Collect the table types, the func types, and the global types from a fused
+/// core module by re-parsing it.
+struct FusedSections {
+    tables: Vec<TableType>,
+    func_params_results: Vec<(Vec<ValType>, Vec<ValType>)>,
+    globals: Vec<GlobalType>,
+}
+
+fn parse_sections(fused: &[u8]) -> FusedSections {
+    let mut tables = Vec::new();
+    let mut func_params_results = Vec::new();
+    let mut globals = Vec::new();
+
+    for payload in Parser::new(0).parse_all(fused) {
+        match payload.expect("parse payload") {
+            Payload::TypeSection(reader) => {
+                for rec_group in reader {
+                    let rec_group = rec_group.expect("rec group");
+                    for sub in rec_group.into_types() {
+                        if let CompositeInnerType::Func(ft) = &sub.composite_type.inner {
+                            func_params_results.push((ft.params().to_vec(), ft.results().to_vec()));
+                        }
+                    }
+                }
+            }
+            Payload::TableSection(reader) => {
+                for table in reader {
+                    tables.push(table.expect("table").ty);
+                }
+            }
+            Payload::GlobalSection(reader) => {
+                for global in reader {
+                    globals.push(global.expect("global").ty);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    FusedSections {
+        tables,
+        func_params_results,
+        globals,
+    }
+}
+
+/// Is this ref type a *concrete* typed reference (not funcref/externref/etc.)?
+fn is_concrete_ref(rt: &RefType) -> Option<u32> {
+    match rt.heap_type() {
+        HeapType::Concrete(idx) => idx.as_module_index(),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Case 1: typed-func-ref table — element type must stay a concrete ref, not
+// collapse to funcref.
+// ---------------------------------------------------------------------------
+#[test]
+fn case1_typed_ref_table_element_preserved() {
+    let wat = r#"
+(component
+  (core module $m
+    (type $ft (func (param i32) (result i32)))
+    (table $t 1 (ref null $ft))
+    (func $f (export "f") (param i32) (result i32) (local.get 0))
+    (elem (i32.const 0) (ref $ft) (ref.func $f))
+  )
+  (core instance $i (instantiate $m))
+)
+"#;
+    let fused = fuse_one(wat);
+    validate_all(&fused);
+
+    let sections = parse_sections(&fused);
+    // At least one table must carry a CONCRETE typed-func-ref element type
+    // pointing at a func type in the output. If the collapse bug were present
+    // this would be funcref (no concrete index).
+    let concrete_tables: Vec<u32> = sections
+        .tables
+        .iter()
+        .filter_map(|t| is_concrete_ref(&t.element_type))
+        .collect();
+    assert!(
+        !concrete_tables.is_empty(),
+        "case1: expected a concrete typed-ref table element type, got tables: {:?}",
+        sections
+            .tables
+            .iter()
+            .map(|t| t.element_type)
+            .collect::<Vec<_>>()
+    );
+    // The concrete index must point at a real func type in the output.
+    let n_types = sections.func_params_results.len() as u32;
+    for idx in concrete_tables {
+        assert!(
+            idx < n_types,
+            "case1: table element concrete index {idx} out of range (n_types={n_types})"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Case 2: typed-ref table actually USED via call_indirect (type $ft). A wrong
+// or collapsed element type causes a validation failure here.
+// ---------------------------------------------------------------------------
+#[test]
+fn case2_typed_ref_table_used_by_call_indirect() {
+    let wat = r#"
+(component
+  (core module $m
+    (type $ft (func (param i32) (result i32)))
+    (table $t 2 (ref null $ft))
+    (func $impl (param i32) (result i32)
+      (i32.mul (local.get 0) (i32.const 3)))
+    (func $run (export "run") (param i32) (result i32)
+      ;; call through the typed-ref table slot 0
+      (call_indirect $t (type $ft) (local.get 0) (i32.const 0)))
+    (elem (i32.const 0) (ref $ft) (ref.func $impl))
+  )
+  (core instance $i (instantiate $m))
+)
+"#;
+    let fused = fuse_one(wat);
+    // The crux: call_indirect (type $ft) against a typed-ref table only
+    // validates if the table element type is the correct concrete ref.
+    validate_all(&fused);
+
+    let sections = parse_sections(&fused);
+    let concrete = sections
+        .tables
+        .iter()
+        .filter_map(|t| is_concrete_ref(&t.element_type))
+        .count();
+    assert!(
+        concrete >= 1,
+        "case2: typed-ref table collapsed to funcref; tables = {:?}",
+        sections
+            .tables
+            .iter()
+            .map(|t| t.element_type)
+            .collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case 3: two components, each with its OWN func type + typed-ref table. After
+// the merge renumbers types, component B's table concrete index must be
+// remapped to its merged type index (Part 2). A wrong remap points at the
+// wrong type -> validation failure (the table elem type would not match the
+// element segment's `(ref $ft)` items).
+// ---------------------------------------------------------------------------
+#[test]
+fn case3_two_components_concrete_index_remapped() {
+    // Component A: type $fa = (func (param i32) (result i32))
+    let wat_a = r#"
+(component
+  (core module $ma
+    (type $fa (func (param i32) (result i32)))
+    (table $ta 1 (ref null $fa))
+    (func $ga (param i32) (result i32) (local.get 0))
+    (func $run_a (export "run_a") (result i32)
+      (call_indirect $ta (type $fa) (i32.const 7) (i32.const 0)))
+    (elem (i32.const 0) (ref $fa) (ref.func $ga))
+  )
+  (core instance $i (instantiate $ma))
+)
+"#;
+    // Component B: DISTINCT type shape $fb = (func (param i64 i64) (result i64))
+    // so a wrong remap (pointing at A's i32->i32 type) is detectable.
+    let wat_b = r#"
+(component
+  (core module $mb
+    (type $fb (func (param i64 i64) (result i64)))
+    (table $tb 1 (ref null $fb))
+    (func $gb (param i64 i64) (result i64) (i64.add (local.get 0) (local.get 1)))
+    (func $run_b (export "run_b") (result i64)
+      (call_indirect $tb (type $fb) (i64.const 4) (i64.const 5) (i32.const 0)))
+    (elem (i32.const 0) (ref $fb) (ref.func $gb))
+  )
+  (core instance $i (instantiate $mb))
+)
+"#;
+    let fused = fuse_two(wat_a, wat_b);
+    // If B's table concrete index were NOT remapped (left at module-level 0),
+    // it would point at A's (i32)->(i32) type after the merge offset, and the
+    // `(ref $fb)` element items (which ARE remapped, by the const-expr path)
+    // would no longer subtype the table element type -> validation failure.
+    validate_all(&fused);
+
+    let sections = parse_sections(&fused);
+    // Two distinct concrete typed-ref tables must survive, and their concrete
+    // indices must point at func types with the EXPECTED distinct signatures.
+    let concrete_table_indices: Vec<u32> = sections
+        .tables
+        .iter()
+        .filter_map(|t| is_concrete_ref(&t.element_type))
+        .collect();
+    assert_eq!(
+        concrete_table_indices.len(),
+        2,
+        "case3: expected two concrete typed-ref tables, got {:?}",
+        sections
+            .tables
+            .iter()
+            .map(|t| t.element_type)
+            .collect::<Vec<_>>()
+    );
+
+    // Resolve each table's concrete index to its func signature and confirm
+    // one is (i32)->(i32) and the other is (i64,i64)->(i64). This proves the
+    // remap landed on the CORRECT (not merely valid) type for each component.
+    let sigs: Vec<&(Vec<ValType>, Vec<ValType>)> = concrete_table_indices
+        .iter()
+        .map(|&idx| {
+            sections
+                .func_params_results
+                .get(idx as usize)
+                .unwrap_or_else(|| panic!("case3: table concrete index {idx} out of range"))
+        })
+        .collect();
+
+    let has_i32 = sigs
+        .iter()
+        .any(|(p, r)| p.as_slice() == [ValType::I32] && r.as_slice() == [ValType::I32]);
+    let has_i64 = sigs.iter().any(|(p, r)| {
+        p.as_slice() == [ValType::I64, ValType::I64] && r.as_slice() == [ValType::I64]
+    });
+    assert!(
+        has_i32 && has_i64,
+        "case3: typed-ref table indices did not resolve to the expected distinct \
+         signatures (i32->i32 and (i64,i64)->i64); got {sigs:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case 4: GC abstract ref — a global `(ref null any)`. The abstract heap type
+// must be preserved (not collapsed to funcref).
+// ---------------------------------------------------------------------------
+#[test]
+fn case4_gc_abstract_global_preserved() {
+    let wat = r#"
+(component
+  (core module $m
+    (global $g (export "g") (ref null any) (ref.null any))
+  )
+  (core instance $i (instantiate $m))
+)
+"#;
+    let fused = fuse_one(wat);
+    validate_all(&fused);
+
+    let sections = parse_sections(&fused);
+    // The global's content type must be a ref to the `any` abstract heap type.
+    let has_any_ref = sections.globals.iter().any(|g| match g.content_type {
+        ValType::Ref(rt) => matches!(
+            rt.heap_type(),
+            HeapType::Abstract {
+                ty: wasmparser::AbstractHeapType::Any,
+                ..
+            }
+        ),
+        _ => false,
+    });
+    assert!(
+        has_any_ref,
+        "case4: global (ref null any) collapsed; globals = {:?}",
+        sections
+            .globals
+            .iter()
+            .map(|g| g.content_type)
+            .collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case 4b: concrete typed-ref in a function SIGNATURE (param) is preserved and
+// its index remapped (exercises the MergedFuncType param/result remap).
+// ---------------------------------------------------------------------------
+#[test]
+fn case4b_concrete_ref_in_func_signature_preserved() {
+    let wat = r#"
+(component
+  (core module $m
+    (type $ft (func (param i32) (result i32)))
+    ;; $sig takes a (ref null $ft) param -> concrete ref in a signature
+    (type $sig (func (param (ref null $ft)) (result i32)))
+    (func $impl (param i32) (result i32) (local.get 0))
+    (func $use (export "use") (param (ref null $ft)) (result i32)
+      (i32.const 0))
+  )
+  (core instance $i (instantiate $m))
+)
+"#;
+    let fused = fuse_one(wat);
+    validate_all(&fused);
+
+    let sections = parse_sections(&fused);
+    // Some func type must have a concrete-ref param whose index points at the
+    // (i32)->(i32) func type.
+    let mut found = false;
+    for (params, _results) in &sections.func_params_results {
+        for p in params {
+            if let ValType::Ref(rt) = p
+                && let Some(idx) = is_concrete_ref(rt)
+            {
+                // index must be in range and resolve to the i32->i32 type
+                let target = &sections.func_params_results[idx as usize];
+                assert_eq!(
+                    (target.0.as_slice(), target.1.as_slice()),
+                    (&[ValType::I32][..], &[ValType::I32][..]),
+                    "case4b: concrete-ref param index {idx} resolves to wrong type"
+                );
+                found = true;
+            }
+        }
+    }
+    assert!(
+        found,
+        "case4b: no concrete-ref param found in any func signature (collapse regression)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Case 5: regression — plain funcref table + ordinary func signature still
+// fuse and validate, and the funcref table stays funcref (not turned into a
+// spurious concrete ref). The common case must be unchanged.
+// ---------------------------------------------------------------------------
+#[test]
+fn case5_plain_funcref_regression_unchanged() {
+    let wat = r#"
+(component
+  (core module $m
+    (type $ft (func (param i32) (result i32)))
+    (table $t 1 funcref)
+    (func $f (export "f") (param i32) (result i32) (local.get 0))
+    (elem (i32.const 0) func $f)
+  )
+  (core instance $i (instantiate $m))
+)
+"#;
+    let fused = fuse_one(wat);
+    validate_all(&fused);
+
+    let sections = parse_sections(&fused);
+    // Every table must be funcref (abstract Func heap type), none concrete.
+    for t in &sections.tables {
+        assert!(
+            is_concrete_ref(&t.element_type).is_none(),
+            "case5: plain funcref table became a concrete ref: {:?}",
+            t.element_type
+        );
+        assert!(
+            t.element_type.is_func_ref(),
+            "case5: plain funcref table element type changed: {:?}",
+            t.element_type
+        );
+    }
+}

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -2565,6 +2565,72 @@ loss-scenarios:
       parser.rs::convert_ref_type (used for value/global types) is a
       related latent gap, out of scope for this segments.rs fix.
 
+  - id: LS-A-22
+    title: Reference-type collapse in value/table/global types — concrete/GC refs flattened to funcref through fusion
+    uca: UCA-M-4
+    hazards: [H-3]
+    type: inadequate-control-algorithm
+    scenario: >
+      `parser.rs::convert_ref_type` (the value-type sibling of the
+      LS-A-21 element-segment bug) collapsed every reference type with
+      `if is_func_ref() { funcref } else if is_extern_ref() { externref }
+      else { funcref }`, dropping concrete typed function references
+      `(ref null $t)` / `(ref $t)` and GC abstract heap types — and the
+      final `else` defaulted unknown ref types to FUNCREF. This fed
+      table element types (CoreModule.tables[].element_type), func-type
+      signatures (params/results), and global content types. Because
+      neither table emission (`convert_table_type`), the func-type
+      build, nor global emission (`convert_global_type`) remapped
+      concrete heap-type indices, the merged output's tables / signatures
+      / globals carried the WRONG type (funcref instead of the concrete
+      typed ref). Runtime-PoC-confirmed: fusing a core module with
+      `(table 1 (ref null $ft))` produced an output table of element type
+      `funcref` (the concrete typed-func-ref lost). The output often
+      still VALIDATES (silent type weakening / H-3 type confusion rather
+      than an invalid module), but a module that USES the typed-ref table
+      with concrete-type operations (`call_indirect (type $ft)`,
+      `table.get` expecting `(ref $ft)`) hits a type mismatch or semantic
+      divergence. Surfaced as the value-type sibling while fixing the
+      element-segment case (LS-A-21 / #257); filed as #258.
+    causal-factors:
+      - >-
+        parser.rs::convert_ref_type bucketed to funcref/externref with an
+        else→funcref default, discarding concrete index + GC heap type
+      - >-
+        merger table/func-type/global emission applied no concrete
+        heap-type index remap, so even a faithful parse left stale indices
+        after the merge renumbered types
+      - >-
+        no test exercised a typed-ref/GC table, signature, or global —
+        all fixtures used funcref/externref
+    process-model-flaw: >
+      Same pre-GC/pre-typed-refs assumption as LS-A-21, but for the
+      value-type/table/global path: reference types were assumed to be
+      funcref-or-externref, while meld's default feature set enables
+      typed function references and GC, whose concrete/abstract heap
+      types must be preserved and index-remapped.
+    status: approved
+    priority: high
+    fix: >
+      parser.rs::convert_ref_type now converts faithfully (nullability +
+      abstract heap type via convert_abstract_heap_type + concrete module
+      index), mirroring segments.rs (#257). merger.rs remaps concrete
+      heap-type indices when emitting tables (convert_table_type),
+      func-type signatures (a two-pass build so same-module forward
+      references resolve), and globals (convert_global_type), via
+      type_index_map keyed by (comp_idx, mod_idx, old_idx) — disjoint
+      from the existing const-expr-operand remap (convert_const_expr
+      RefNull arm), so no index is remapped twice (Mythos-verified with a
+      global whose declared type and ref.null init both carry a concrete
+      index — each remapped exactly once). Pinned by the runtime matrix
+      tests/reftype_fidelity.rs: typed-ref table preserved, typed-ref
+      table used by call_indirect validates, a two-component fusion where
+      each table's concrete index resolves to its correct distinct
+      signature (proves the remap lands on the right type, not merely a
+      valid one), a GC abstract global preserved, a concrete-ref
+      func-signature param preserved, and a plain-funcref regression
+      control. Closes #258.
+
   - id: LS-A-12
     title: uses_stackful_lift mis-classifies mixed-mode components
     uca: UCA-A-3


### PR DESCRIPTION
Closes #258 — the value-type/table/global sibling of the element-segment fix (#257). Found by the bug-hunt pipeline; fixes a silent type-weakening defect (H-3).

## Bug
`parser.rs::convert_ref_type` collapsed every reference type via `is_func_ref() ? funcref : is_extern_ref() ? externref : funcref`, dropping concrete typed refs `(ref null $t)` and GC abstract heap types. This fed table element types, func-type signatures, and global content types; the merger's table/type/global emission did no concrete-index remap. Runtime-PoC-confirmed: `(table 1 (ref null $ft))` fused to an output table of element type **funcref** — the concrete type lost. Often still validates (silent weakening), but a typed-ref table used by `call_indirect (type $ft)` mismatches.

## Fix (two parts)
- **parser.rs::convert_ref_type** — faithful conversion (nullability + abstract heap type via `convert_abstract_heap_type` + concrete module index), mirroring the #257 segments fix.
- **merger.rs** — new `remap_concrete_ref_type`/`remap_concrete_val_type` remap concrete heap-type indices when emitting **tables** (`convert_table_type`), **func-type signatures** (two-pass build so same-module forward refs resolve), and **globals** (`convert_global_type`), via `type_index_map`. Disjoint from the existing const-expr-operand remap → no double-remap.

## Verification
- `tests/reftype_fidelity.rs` (6 cases): typed-ref table preserved; typed-ref table used by `call_indirect` validates; **two-component fusion where each table's concrete index resolves to its correct distinct signature** (proves the remap lands on the right type, not merely a valid one); GC abstract global preserved; concrete-ref func-signature param preserved; plain-funcref regression control.
- Workspace **555/0** (via exit code); wit_bindgen_runtime 73/73; clippy/fmt clean.
- **Mythos clean-room pass over BOTH parser.rs + merger.rs deltas: NO PROVABLE FINDING** — all five risks falsified incl. double-remap (disjoint output fields, each remapped once), wrong-offset-but-valid (independent 2-component f64/f32 PoC resolves to the semantically correct sig), import-side path (live + correct), and silent-zero (unreachable — parser never runs the validator's rec-group canonicalization). Full report next comment.

## Tier-5
`parser.rs` + `merger.rs` → Mythos pass done, `mythos-pass-done` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)