### PR TITLE
fix(rewriter): relocate element/data segment indices through fusion (LS-M-8)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -6009,6 +6009,7 @@ mod tests {
             handle_tables: std::collections::HashMap::new(),
             task_return_shims: std::collections::HashMap::new(),
             async_result_globals: std::collections::HashMap::new(),
+            segment_bases: std::collections::HashMap::new(),
         }
     }
 

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -865,6 +865,15 @@ impl Fuser {
                 .unwrap_or(false);
             let memory_initial_pages = module_memory.as_ref().map(|mem| mem.initial);
 
+            // Post-merge re-rewrite: recover this module's segment bases from
+            // the merge-time record (`merged.*.len()` is now the total, not
+            // the base).
+            let (data_segment_base, elem_segment_base) = merged
+                .segment_bases
+                .get(&(comp_idx, mod_idx))
+                .copied()
+                .unwrap_or((0, 0));
+
             let index_maps = merger::build_index_maps_for_module(
                 comp_idx,
                 mod_idx,
@@ -875,6 +884,8 @@ impl Fuser {
                 memory_base_offset,
                 memory64,
                 memory_initial_pages,
+                data_segment_base,
+                elem_segment_base,
             );
 
             let import_func_count = module
@@ -1376,6 +1387,11 @@ impl Fuser {
         // Re-rewrite function bodies for affected modules
         for &(comp_idx, mod_idx) in &affected_modules {
             let module = &self.components[comp_idx].core_modules[mod_idx];
+            let (data_segment_base, elem_segment_base) = merged
+                .segment_bases
+                .get(&(comp_idx, mod_idx))
+                .copied()
+                .unwrap_or((0, 0));
             let index_maps = merger::build_index_maps_for_module(
                 comp_idx,
                 mod_idx,
@@ -1386,6 +1402,8 @@ impl Fuser {
                 0u64,
                 false,
                 None,
+                data_segment_base,
+                elem_segment_base,
             );
             let import_func_count = module
                 .imports

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -146,6 +146,17 @@ pub struct MergedModule {
     /// Maps (component_idx, func_name) → shim globals for async result delivery.
     /// Built after element segment patching. Used by the callback-driving adapter.
     pub async_result_globals: HashMap<(usize, String), Vec<(u32, ValType)>>,
+
+    /// Per-module base offsets into the concatenated `data_segments` / `elements`
+    /// vectors: maps (component_idx, module_idx) → (data_segment_base, elem_base).
+    ///
+    /// Recorded in `merge_core_module` at the point the module's `IndexMaps` is
+    /// built — i.e. BEFORE this module's own segments are appended — so the base
+    /// equals the count of segments contributed by all PRIOR modules, which is
+    /// exactly where this module's local segment indices land in the fused
+    /// section. Re-rewrite passes that run after the full merge (when `.len()`
+    /// no longer equals the base) look the base up here.
+    pub segment_bases: HashMap<(usize, usize), (u32, u32)>,
 }
 
 /// Info about a generated task.return shim function.
@@ -992,6 +1003,7 @@ impl Merger {
             handle_tables: HashMap::new(),
             task_return_shims: HashMap::new(),
             async_result_globals: HashMap::new(),
+            segment_bases: HashMap::new(),
         };
 
         // Process components in topological order
@@ -1206,6 +1218,14 @@ impl Merger {
             // redirected to handle table functions.
             for &(comp_idx, mod_idx) in &affected_modules {
                 let module = &components[comp_idx].core_modules[mod_idx];
+                // This pass runs AFTER the full merge, so `merged.*.len()` is
+                // the total segment count, not this module's base. Recover the
+                // correct per-module base recorded during the main merge loop.
+                let (data_segment_base, elem_segment_base) = merged
+                    .segment_bases
+                    .get(&(comp_idx, mod_idx))
+                    .copied()
+                    .unwrap_or((0, 0));
                 let index_maps = build_index_maps_for_module(
                     comp_idx,
                     mod_idx,
@@ -1216,6 +1236,8 @@ impl Merger {
                     0u64,  // memory_base_offset
                     false, // memory64
                     None,  // memory_initial_pages
+                    data_segment_base,
+                    elem_segment_base,
                 );
                 let import_func_count = module
                     .imports
@@ -1862,6 +1884,21 @@ impl Merger {
             .map(|mem| mem.memory64)
             .unwrap_or(false);
         let memory_initial_pages = module_memory.as_ref().map(|mem| mem.initial);
+
+        // Segment base offsets: this module's local segment indices land in
+        // the concatenated section at `base + local`. Capture the bases NOW,
+        // before this module's own segments are appended (lines below), so
+        // they count only PRIOR modules' segments — exactly mirroring how
+        // `func_offset = merged.functions.len()` is captured before this
+        // module's functions are pushed. Record them on `merged` so the
+        // post-merge re-rewrite pass (resource-import redirect) can recover
+        // the correct base after `.len()` no longer equals it.
+        let data_segment_base = merged.data_segments.len() as u32;
+        let elem_segment_base = merged.elements.len() as u32;
+        merged
+            .segment_bases
+            .insert((comp_idx, mod_idx), (data_segment_base, elem_segment_base));
+
         let index_maps = build_index_maps_for_module(
             comp_idx,
             mod_idx,
@@ -1872,6 +1909,8 @@ impl Merger {
             memory_base_offset,
             memory64,
             memory_initial_pages,
+            data_segment_base,
+            elem_segment_base,
         );
 
         // Second pass: extract and rewrite function bodies
@@ -2836,6 +2875,8 @@ pub(crate) fn build_index_maps_for_module(
     memory_base_offset: u64,
     memory64: bool,
     memory_initial_pages: Option<u64>,
+    data_segment_base: u32,
+    elem_segment_base: u32,
 ) -> IndexMaps {
     let mut maps = IndexMaps::new();
     maps.address_rebasing = address_rebasing;
@@ -2944,6 +2985,27 @@ pub(crate) fn build_index_maps_for_module(
                 maps.memories.insert(full_idx, new_idx);
             }
         }
+    }
+
+    // Build data-segment and element-segment maps.
+    //
+    // The merger concatenates every module's segments into one shared
+    // section in deterministic merge order, so this module's local segment
+    // `local` lands at fused ordinal `base + local`, where `base` is the
+    // number of segments contributed by all PRIOR modules. The caller
+    // supplies that base (captured from `merged.data_segments.len()` /
+    // `merged.elements.len()` BEFORE this module's segments are appended —
+    // the same timing as `func_offset = merged.functions.len()`).
+    //
+    // Data/element segments are never imported in core wasm, so there is
+    // no import-count adjustment as there is for funcs/globals/tables/mems.
+    let data_segment_count = crate::segments::count_data_segments(module);
+    for local in 0..data_segment_count {
+        maps.data_segments.insert(local, data_segment_base + local);
+    }
+    let elem_segment_count = crate::segments::count_element_segments(module);
+    for local in 0..elem_segment_count {
+        maps.elements.insert(local, elem_segment_base + local);
     }
 
     maps
@@ -3511,6 +3573,7 @@ mod tests {
             handle_tables: HashMap::new(),
             task_return_shims: HashMap::new(),
             async_result_globals: HashMap::new(),
+            segment_bases: HashMap::new(),
         };
 
         // Simulate multi-memory merging for module A (comp 0, mod 0)
@@ -3547,6 +3610,8 @@ mod tests {
             0,
             false,
             None,
+            0,
+            0,
         );
         assert_eq!(maps_a.remap_memory(0), 0);
 
@@ -3560,6 +3625,8 @@ mod tests {
             0,
             false,
             None,
+            0,
+            0,
         );
         assert_eq!(maps_b.remap_memory(0), 1);
     }
@@ -4950,6 +5017,7 @@ mod tests {
             handle_tables: std::collections::HashMap::new(),
             task_return_shims: std::collections::HashMap::new(),
             async_result_globals: std::collections::HashMap::new(),
+            segment_bases: std::collections::HashMap::new(),
         }
     }
 

--- a/meld-core/src/p3_async.rs
+++ b/meld-core/src/p3_async.rs
@@ -1337,6 +1337,11 @@ fn shift_function_indices(
         let memory64 = module_memory.as_ref().map(|m| m.memory64).unwrap_or(false);
         let memory_initial_pages = module_memory.as_ref().map(|m| m.initial);
 
+        let (data_segment_base, elem_segment_base) = merged
+            .segment_bases
+            .get(&(comp_idx, mod_idx))
+            .copied()
+            .unwrap_or((0, 0));
         let index_maps = crate::merger::build_index_maps_for_module(
             comp_idx,
             mod_idx,
@@ -1347,6 +1352,8 @@ fn shift_function_indices(
             0,
             memory64,
             memory_initial_pages,
+            data_segment_base,
+            elem_segment_base,
         );
 
         let import_func_count = module

--- a/meld-core/src/p3_bridge.rs
+++ b/meld-core/src/p3_bridge.rs
@@ -386,6 +386,8 @@ pub fn emit_stream_bridge(
             .unwrap_or(false);
         let memory_initial_pages = module_memory.as_ref().map(|mem| mem.initial);
 
+        let (data_segment_base, elem_segment_base) =
+            merged.segment_bases.get(&(c, m)).copied().unwrap_or((0, 0));
         let index_maps = crate::merger::build_index_maps_for_module(
             c,
             m,
@@ -396,6 +398,8 @@ pub fn emit_stream_bridge(
             0, // memory_base_offset — matches wire_adapter_indices
             memory64,
             memory_initial_pages,
+            data_segment_base,
+            elem_segment_base,
         );
 
         let import_func_count = module

--- a/meld-core/src/rewriter.rs
+++ b/meld-core/src/rewriter.rs
@@ -63,6 +63,19 @@ pub struct IndexMaps {
     pub tables: HashMap<u32, u32>,
     /// Memory index remapping: old -> new
     pub memories: HashMap<u32, u32>,
+    /// Data-segment index remapping: old -> new
+    ///
+    /// The merger concatenates every module's passive/active data segments
+    /// into one shared section, so a module's local segment 0 becomes some
+    /// non-zero ordinal in the fused module. `memory.init` / `data.drop`
+    /// operands must be remapped through this map or they read the wrong
+    /// segment.
+    pub data_segments: HashMap<u32, u32>,
+    /// Element-segment index remapping: old -> new
+    ///
+    /// Same concatenation concern as `data_segments`, for `table.init` /
+    /// `elem.drop`.
+    pub elements: HashMap<u32, u32>,
     /// Memory base offset in bytes (for shared-memory rebasing)
     pub memory_base_offset: u64,
     /// Whether address rebasing is enabled
@@ -112,6 +125,16 @@ impl IndexMaps {
     /// Remap a memory index
     pub fn remap_memory(&self, idx: u32) -> u32 {
         *self.memories.get(&idx).unwrap_or(&idx)
+    }
+
+    /// Remap a data-segment index (`memory.init` / `data.drop`).
+    pub fn remap_data_segment(&self, idx: u32) -> u32 {
+        *self.data_segments.get(&idx).unwrap_or(&idx)
+    }
+
+    /// Remap an element-segment index (`table.init` / `elem.drop`).
+    pub fn remap_elem(&self, idx: u32) -> u32 {
+        *self.elements.get(&idx).unwrap_or(&idx)
     }
 }
 
@@ -316,10 +339,10 @@ fn rewrite_operator(op: Operator<'_>, maps: &IndexMaps) -> Result<Vec<Instructio
             dst_table: maps.remap_table(dst_table),
         },
         TableInit { elem_index, table } => Instruction::TableInit {
-            elem_index,
+            elem_index: maps.remap_elem(elem_index),
             table: maps.remap_table(table),
         },
-        ElemDrop { elem_index } => Instruction::ElemDrop(elem_index),
+        ElemDrop { elem_index } => Instruction::ElemDrop(maps.remap_elem(elem_index)),
 
         // Memory operations - need memory index remapping
         I32Load { memarg } => Instruction::I32Load(convert_memarg(memarg, maps)?),
@@ -380,7 +403,7 @@ fn rewrite_operator(op: Operator<'_>, maps: &IndexMaps) -> Result<Vec<Instructio
         MemoryInit { data_index, mem } => {
             return rewrite_memory_init(data_index, mem, maps);
         }
-        DataDrop { data_index } => Instruction::DataDrop(data_index),
+        DataDrop { data_index } => Instruction::DataDrop(maps.remap_data_segment(data_index)),
         MemoryCopy { dst_mem, src_mem } => {
             return rewrite_memory_copy(src_mem, dst_mem, maps);
         }
@@ -609,6 +632,7 @@ fn rewrite_memory_init(
     mem: u32,
     maps: &IndexMaps,
 ) -> Result<Vec<Instruction<'static>>> {
+    let data_index = maps.remap_data_segment(data_index);
     if !maps.address_rebasing {
         return Ok(vec![Instruction::MemoryInit {
             mem: maps.remap_memory(mem),

--- a/meld-core/src/segments.rs
+++ b/meld-core/src/segments.rs
@@ -291,6 +291,38 @@ pub fn parse_data_segments(module: &CoreModule) -> Result<Vec<ParsedDataSegment>
     Ok(segments)
 }
 
+/// Count a module's element segments without fully parsing each entry.
+///
+/// Used to size the per-module element-segment index map: the local indices
+/// `0..count` must each be remapped to `base + local`. Returns 0 when the
+/// module has no element section or the section header cannot be read (the
+/// rewriter then falls back to identity remapping, which is the pre-fix
+/// behaviour for an unmappable index).
+pub fn count_element_segments(module: &CoreModule) -> u32 {
+    let Some((start, end)) = module.element_section_range else {
+        return 0;
+    };
+    let binary_reader = wasmparser::BinaryReader::new(&module.bytes[start..end], 0);
+    match ElementSectionReader::new(binary_reader) {
+        Ok(reader) => reader.count(),
+        Err(_) => 0,
+    }
+}
+
+/// Count a module's data segments without fully parsing each entry.
+///
+/// See [`count_element_segments`] for the sizing rationale.
+pub fn count_data_segments(module: &CoreModule) -> u32 {
+    let Some((start, end)) = module.data_section_range else {
+        return 0;
+    };
+    let binary_reader = wasmparser::BinaryReader::new(&module.bytes[start..end], 0);
+    match DataSectionReader::new(binary_reader) {
+        Ok(reader) => reader.count(),
+        Err(_) => 0,
+    }
+}
+
 /// Reindex an element segment with new index mappings
 /// Faithfully convert a `wasmparser::RefType` to a `wasm_encoder::RefType`,
 /// preserving nullability, abstract heap types, and concrete type indices.

--- a/meld-core/tests/segidx_remap.rs
+++ b/meld-core/tests/segidx_remap.rs
@@ -1,0 +1,380 @@
+//! Element/data SEGMENT-index remap regression tests.
+//!
+//! # The bug (Mythos discovery pass)
+//!
+//! The merger concatenates every module's passive/active data segments into a
+//! SINGLE shared data section (and likewise for element segments), in
+//! deterministic module order. So module B's local segment 0 lands at fused
+//! ordinal 1, B's local segment 1 at ordinal 2, and so on.
+//!
+//! The rewriter, however, used to pass the SEGMENT operand of
+//! `memory.init` / `data.drop` / `table.init` / `elem.drop` through
+//! verbatim. After fusion, module B's `memory.init … data_index:0` therefore
+//! read module A's segment 0 instead of its own. The fused module VALIDATES
+//! and RUNS — it just returns the wrong bytes (proven below: `probe_b`
+//! returned `0xAAAAAAAA`, want `0xBBBBBBBB`).
+//!
+//! The fix adds `data_segments` / `elements` index maps to `IndexMaps`
+//! (mirroring the existing function/type/global/table/memory maps) and remaps
+//! the segment operands through them. The base offset for a module equals the
+//! number of segments contributed by all PRIOR modules in the concatenated
+//! section.
+//!
+//! # Tests
+//!
+//! - `segidx_data_two_modules_distinct_segments` — the core PoC. Two modules,
+//!   each with its own passive data segment + `memory.init data_index:0`.
+//!   `probe_b` must return `0xBBBBBBBB`, `probe_a` must return `0xAAAAAAAA`.
+//!   FAILS pre-fix (probe_b reads A's segment).
+//! - `segidx_elem_two_modules_distinct_segments` — element-segment analogue
+//!   via `table.init` from a passive elem segment.
+//! - `segidx_data_three_modules_base_offset_gt_one` — exercises base offset
+//!   > 1 (module C's segment maps to ordinal 2).
+//! - `segidx_single_module_identity` — regression: one segment, base 0,
+//!   identity remap still works.
+
+use meld_core::{Fuser, FuserConfig, MemoryStrategy};
+use wasm_encoder::{
+    CodeSection, Component, DataCountSection, DataSection, DataSegment, DataSegmentMode,
+    ElementSection, Elements, ExportKind, ExportSection, Function, FunctionSection, Instruction,
+    MemArg, MemorySection, MemoryType, Module, ModuleSection, RefType, TableSection, TableType,
+    TypeSection,
+};
+use wasmtime::{Config, Engine, Instance, Module as RuntimeModule, Store};
+
+fn fuser_config() -> FuserConfig {
+    FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        component_provenance: false,
+        address_rebasing: false,
+        preserve_names: false,
+        custom_sections: meld_core::CustomSectionHandling::Merge,
+        dwarf_handling: meld_core::DwarfHandling::Strip,
+        output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
+    }
+}
+
+fn engine() -> Engine {
+    let mut cfg = Config::new();
+    cfg.wasm_multi_memory(true);
+    cfg.wasm_bulk_memory(true);
+    Engine::new(&cfg).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Data-segment PoC
+// ---------------------------------------------------------------------------
+
+/// Build a standalone single-module component whose probe function copies its
+/// OWN passive data segment 0 into memory via `memory.init data_index:0`, then
+/// loads the i32 back. The 4-byte segment is `fill` (little-endian).
+///
+/// The segment is PASSIVE, so the only way its bytes reach memory is through
+/// `memory.init` — which is exactly the operator whose segment operand the
+/// merger must remap. If the operand is not remapped, after fusion this
+/// module's `memory.init data_index:0` reads whichever module landed at fused
+/// segment 0 instead.
+fn build_data_probe_component(fill: u32, export_name: &str) -> Vec<u8> {
+    let bytes = fill.to_le_bytes();
+
+    let mut types = TypeSection::new();
+    types.ty().function([], [wasm_encoder::ValType::I32]); // type 0: () -> i32
+
+    let mut functions = FunctionSection::new();
+    functions.function(0); // probe: type 0
+
+    let mut memory = MemorySection::new();
+    memory.memory(MemoryType {
+        minimum: 1,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+
+    let mut exports = ExportSection::new();
+    exports.export(export_name, ExportKind::Func, 0);
+    exports.export("memory", ExportKind::Memory, 0);
+
+    let mut code = CodeSection::new();
+    let mut probe = Function::new([]);
+    // memory.init data_index:0 mem:0  (dst=0, src_off=0, len=4)
+    probe.instruction(&Instruction::I32Const(0)); // dst addr
+    probe.instruction(&Instruction::I32Const(0)); // src offset in segment
+    probe.instruction(&Instruction::I32Const(4)); // len
+    probe.instruction(&Instruction::MemoryInit {
+        mem: 0,
+        data_index: 0,
+    });
+    // load the freshly-copied i32 back
+    probe.instruction(&Instruction::I32Const(0));
+    probe.instruction(&Instruction::I32Load(MemArg {
+        offset: 0,
+        align: 2,
+        memory_index: 0,
+    }));
+    probe.instruction(&Instruction::End);
+    code.function(&probe);
+
+    // One PASSIVE data segment (index 0).
+    let mut data = DataSection::new();
+    data.segment(DataSegment {
+        mode: DataSegmentMode::Passive,
+        data: bytes.to_vec(),
+    });
+
+    // `memory.init` requires a DataCount section; it must precede the code
+    // section in the binary.
+    let mut module = Module::new();
+    module
+        .section(&types)
+        .section(&functions)
+        .section(&memory)
+        .section(&exports)
+        .section(&DataCountSection { count: 1 })
+        .section(&code)
+        .section(&data);
+
+    let mut component = Component::new();
+    component.section(&ModuleSection(&module));
+    component.finish()
+}
+
+#[test]
+fn segidx_data_two_modules_distinct_segments() {
+    // Module A's segment is filled 0xAAAAAAAA; module B's is 0xBBBBBBBB.
+    // After fusion the concatenated data section is [A.seg0, B.seg0]. B's
+    // probe does `memory.init data_index:0`; without remapping it reads
+    // ordinal 0 (= A's segment) and returns 0xAAAAAAAA. With the fix it must
+    // read ordinal 1 (its own) and return 0xBBBBBBBB.
+    let comp_a = build_data_probe_component(0xAAAA_AAAA, "probe_a");
+    let comp_b = build_data_probe_component(0xBBBB_BBBB, "probe_b");
+
+    let mut fuser = Fuser::new(fuser_config());
+    fuser.add_component_named(&comp_a, Some("comp-a")).unwrap();
+    fuser.add_component_named(&comp_b, Some("comp-b")).unwrap();
+    let fused = fuser.fuse().unwrap();
+
+    let engine = engine();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    let probe_b = instance
+        .get_typed_func::<(), i32>(&mut store, "probe_b")
+        .expect("probe_b export present");
+    let got_b = probe_b.call(&mut store, ()).unwrap() as u32;
+    assert_eq!(
+        got_b, 0xBBBB_BBBB,
+        "probe_b must read its OWN data segment (0xBBBBBBBB), not module A's \
+         (0xAAAAAAAA) — segment-index remap regression"
+    );
+
+    let probe_a = instance
+        .get_typed_func::<(), i32>(&mut store, "probe_a")
+        .expect("probe_a export present");
+    let got_a = probe_a.call(&mut store, ()).unwrap() as u32;
+    assert_eq!(
+        got_a, 0xAAAA_AAAA,
+        "probe_a must read its own data segment (0xAAAAAAAA)"
+    );
+}
+
+#[test]
+fn segidx_data_three_modules_base_offset_gt_one() {
+    // Three modules force a base offset > 1: module C's local segment 0 must
+    // map to fused ordinal 2.
+    let comp_a = build_data_probe_component(0x1111_1111, "probe_a");
+    let comp_b = build_data_probe_component(0x2222_2222, "probe_b");
+    let comp_c = build_data_probe_component(0x3333_3333, "probe_c");
+
+    let mut fuser = Fuser::new(fuser_config());
+    fuser.add_component_named(&comp_a, Some("comp-a")).unwrap();
+    fuser.add_component_named(&comp_b, Some("comp-b")).unwrap();
+    fuser.add_component_named(&comp_c, Some("comp-c")).unwrap();
+    let fused = fuser.fuse().unwrap();
+
+    let engine = engine();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    for (name, want) in [
+        ("probe_a", 0x1111_1111u32),
+        ("probe_b", 0x2222_2222u32),
+        ("probe_c", 0x3333_3333u32),
+    ] {
+        let f = instance
+            .get_typed_func::<(), i32>(&mut store, name)
+            .unwrap_or_else(|_| panic!("{name} export present"));
+        let got = f.call(&mut store, ()).unwrap() as u32;
+        assert_eq!(
+            got, want,
+            "{name} must read its own data segment ({want:#010x})"
+        );
+    }
+}
+
+#[test]
+fn segidx_single_module_identity() {
+    // Single-module component: one segment, base 0. The remap is the identity
+    // (local 0 -> fused 0); this guards against a fix that breaks the trivial
+    // case.
+    let comp = build_data_probe_component(0xDEAD_BEEF, "probe");
+
+    let mut fuser = Fuser::new(fuser_config());
+    fuser.add_component_named(&comp, Some("solo")).unwrap();
+    let fused = fuser.fuse().unwrap();
+
+    let engine = engine();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    let probe = instance
+        .get_typed_func::<(), i32>(&mut store, "probe")
+        .unwrap();
+    let got = probe.call(&mut store, ()).unwrap() as u32;
+    assert_eq!(got, 0xDEAD_BEEF, "single-module identity remap must hold");
+}
+
+// ---------------------------------------------------------------------------
+// Element-segment PoC (table.init from a passive elem segment)
+// ---------------------------------------------------------------------------
+
+/// Build a single-module component that proves element-segment remapping.
+///
+/// The module has:
+/// - a funcref table (1 slot),
+/// - a constant function `konst() -> i32` returning `marker`,
+/// - a PASSIVE element segment (index 0) holding `[konst]`,
+/// - a probe that does `table.init elem_index:0` into table slot 0, then
+///   `call_indirect`s slot 0 and returns the result.
+///
+/// As with the data case, the passive elem segment is only realized through
+/// `table.init`, whose elem operand must be remapped after the merger
+/// concatenates every module's element segments.
+fn build_elem_probe_component(marker: i32, export_name: &str) -> Vec<u8> {
+    let mut types = TypeSection::new();
+    types.ty().function([], [wasm_encoder::ValType::I32]); // type 0: () -> i32
+
+    let mut functions = FunctionSection::new();
+    functions.function(0); // konst: type 0
+    functions.function(0); // probe: type 0
+
+    let mut tables = TableSection::new();
+    tables.table(TableType {
+        element_type: RefType::FUNCREF,
+        minimum: 1,
+        maximum: None,
+        table64: false,
+        shared: false,
+    });
+
+    let mut memory = MemorySection::new();
+    memory.memory(MemoryType {
+        minimum: 1,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+
+    let mut exports = ExportSection::new();
+    // func 0 = konst, func 1 = probe
+    exports.export(export_name, ExportKind::Func, 1);
+    exports.export("memory", ExportKind::Memory, 0);
+
+    let mut code = CodeSection::new();
+    // konst() -> i32
+    {
+        let mut f = Function::new([]);
+        f.instruction(&Instruction::I32Const(marker));
+        f.instruction(&Instruction::End);
+        code.function(&f);
+    }
+    // probe() -> i32
+    {
+        let mut f = Function::new([]);
+        // table.init elem_index:0 table:0  (dst=0, src=0, len=1)
+        f.instruction(&Instruction::I32Const(0)); // dst in table
+        f.instruction(&Instruction::I32Const(0)); // src in segment
+        f.instruction(&Instruction::I32Const(1)); // len
+        f.instruction(&Instruction::TableInit {
+            elem_index: 0,
+            table: 0,
+        });
+        // call_indirect table slot 0, type 0
+        f.instruction(&Instruction::I32Const(0));
+        f.instruction(&Instruction::CallIndirect {
+            type_index: 0,
+            table_index: 0,
+        });
+        f.instruction(&Instruction::End);
+        code.function(&f);
+    }
+
+    // One PASSIVE element segment (index 0) holding [konst] (func 0).
+    let mut elements = ElementSection::new();
+    let func_indices = [0u32];
+    elements.segment(wasm_encoder::ElementSegment {
+        mode: wasm_encoder::ElementMode::Passive,
+        elements: Elements::Functions(std::borrow::Cow::Borrowed(&func_indices)),
+    });
+
+    let mut module = Module::new();
+    module
+        .section(&types)
+        .section(&functions)
+        .section(&tables)
+        .section(&memory)
+        .section(&exports)
+        .section(&elements)
+        .section(&code);
+
+    let mut component = Component::new();
+    component.section(&ModuleSection(&module));
+    component.finish()
+}
+
+#[test]
+fn segidx_elem_two_modules_distinct_segments() {
+    // Module A's elem segment references its konst (returns 0x0A0A);
+    // module B's references its konst (returns 0x0B0B). After fusion the
+    // element sections concatenate; without elem-index remap, B's
+    // `table.init elem_index:0` installs A's konst into B's table and
+    // returns 0x0A0A. With the fix, probe_b returns 0x0B0B.
+    let comp_a = build_elem_probe_component(0x0A0A, "probe_a");
+    let comp_b = build_elem_probe_component(0x0B0B, "probe_b");
+
+    let mut fuser = Fuser::new(fuser_config());
+    fuser.add_component_named(&comp_a, Some("comp-a")).unwrap();
+    fuser.add_component_named(&comp_b, Some("comp-b")).unwrap();
+    let fused = fuser.fuse().unwrap();
+
+    let engine = engine();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    let probe_b = instance
+        .get_typed_func::<(), i32>(&mut store, "probe_b")
+        .expect("probe_b export present");
+    let got_b = probe_b.call(&mut store, ()).unwrap();
+    assert_eq!(
+        got_b, 0x0B0B,
+        "probe_b must install its OWN element segment's funcref (0x0B0B), \
+         not module A's (0x0A0A) — elem-index remap regression"
+    );
+
+    let probe_a = instance
+        .get_typed_func::<(), i32>(&mut store, "probe_a")
+        .expect("probe_a export present");
+    let got_a = probe_a.call(&mut store, ()).unwrap();
+    assert_eq!(
+        got_a, 0x0A0A,
+        "probe_a must install its own funcref (0x0A0A)"
+    );
+}

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -3031,6 +3031,63 @@ loss-scenarios:
       output that validates without multi-memory and behaves
       correctly at runtime (B's data at its rebased base).
 
+  - id: LS-M-8
+    title: Element/data segment index operands not relocated during fusion
+    uca: UCA-M-1
+    hazards: [H-1, H-3]
+    type: inadequate-control-algorithm
+    scenario: >
+      The rewriter relocated function/type/global/table/memory index
+      operands but passed element/data SEGMENT index operands through
+      verbatim in `memory.init` / `data.drop` / `table.init` /
+      `elem.drop` — and `IndexMaps` carried no segment maps at all. The
+      merger, however, concatenates every module's passive segments into
+      one shared section (merge order), so module B's segment 0 becomes
+      ordinal 1 in the fused module. B's `memory.init … data_index:0`
+      therefore reads module A's segment. End-to-end reproduced: a fused
+      two-module component validated and RAN, but `probe_b` read
+      0xAAAAAAAA (A's data) instead of 0xBBBBBBBB — silent
+      semantic divergence [H-1 behaves differently from the composed
+      input / H-3 wrong-entity reference]. For an out-of-range stale
+      index it instead yields an invalid module (downstream
+      parse/validate failure). Reachable for any fusion where a
+      non-first module uses bulk-memory/table segment-index
+      instructions. Surfaced by a Mythos discovery pass on rewriter.rs.
+    causal-factors:
+      - >-
+        IndexMaps had no element/data segment index space; the four
+        segment-index-bearing ops copied their operand unchanged
+      - >-
+        These ops were explicitly handled (so they looked correct) but
+        incompletely — only their memory/table index was remapped, not
+        the segment index
+      - >-
+        No test exercised a passive segment instruction in a
+        non-first merged module (the only place the ordinal shifts)
+    process-model-flaw: >
+      The relocation model enumerated the "entity" index spaces
+      (functions, types, globals, tables, memories) but omitted the
+      element/data segment ordinal spaces, which the merger likewise
+      concatenates and therefore must also be relocated.
+    status: approved
+    priority: high
+    fix: >
+      IndexMaps gains `data_segments`/`elements` maps (+ identity-default
+      remap_data_segment/remap_elem mirroring remap_func). merge_core_module
+      captures the segment base (= count of prior modules' segments,
+      before this module's are appended — same timing as func_offset, the
+      sole deterministic append site) and populates local→base+local;
+      the base is recorded in MergedModule.segment_bases so the four
+      post-merge re-rewrite callers use the correct base (they re-parse
+      original module bytes with a fresh IndexMaps, so segment indices are
+      remapped exactly once — Mythos-verified, no double-remap). The
+      rewriter remaps elem_index (TableInit/ElemDrop) and data_index
+      (DataDrop, rewrite_memory_init). Pinned by tests/segidx_remap.rs:
+      two-module data + element distinct-segment round-trips (each probe
+      reads its OWN segment), a three-module base-offset>1 case, and a
+      single-module identity case; the multi-module cases fail on
+      pre-fix code (non-vacuity confirmed).
+
   - id: LS-D-1
     title: remapped DWARF emits a wrong code address for a fused function
     uca: UCA-M-9


### PR DESCRIPTION
Found by a Mythos discovery pass on `rewriter.rs`. Fixes a confirmed, end-to-end-reproduced **silent semantic-divergence** bug (H-1/H-3).

## Bug
The rewriter relocated function/type/global/table/memory operands but passed **element/data segment indices** through verbatim in `memory.init` / `data.drop` / `table.init` / `elem.drop` — and `IndexMaps` had no segment maps. The merger concatenates every module's passive segments into one shared section, so a non-first module's segment 0 becomes ordinal ≥1. **Reproduced end-to-end:** a fused two-module component validated and ran, but `probe_b` read `0xAAAAAAAA` (module A's data) instead of `0xBBBBBBBB`. Out-of-range stale indices instead produce an invalid module.

## Fix
`IndexMaps` gains `data_segments`/`elements` maps (identity-default `remap_*`, mirroring `remap_func`). `merge_core_module` captures the segment base (count of prior modules' segments, before appending this module's — same timing as the proven `func_offset` capture, the sole deterministic append site) and populates `local → base+local`; the base is recorded in `MergedModule.segment_bases` so the four post-merge re-rewrite callers use the correct base. The rewriter remaps `elem_index` (TableInit/ElemDrop) and `data_index` (DataDrop, `rewrite_memory_init`).

## Verification
- `tests/segidx_remap.rs`: two-module **data** + **element** distinct-segment round-trips (each probe reads its OWN segment), a **three-module base-offset>1** case, and a single-module identity case. Multi-module cases **fail on pre-fix code** (non-vacuity confirmed by stashing the fix).
- Workspace **552/0** (via exit code); wit_bindgen_runtime 73/73; multi_memory 5/5; clippy/fmt clean.
- **Mythos clean-room pass over rewriter.rs + merger.rs + segments.rs: NO PROVABLE FINDING** — all 5 risks falsified, the **double-remap-via-re-rewrite** risk refuted with two independent proofs (re-rewrite callers re-parse *original* bytes with a fresh IndexMaps → single application; the map is keyed by original-local index → an already-shifted operand misses the keyset → identity). Full report next comment.

## Tier-5
`rewriter.rs` + `merger.rs` (+ `segments.rs` count helpers) → Mythos pass done, `mythos-pass-done` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)