### PR TITLE
fix(resolver): FixedSizeList copy-layout/pointer-position alignment (LS-R-15)

### DIFF
--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -720,6 +720,20 @@ fn collect_type_copy_layouts(
                 collect_type_copy_layouts(component, elem_ty, out);
             }
         }
+        ComponentValType::FixedSizeList(elem, len) => {
+            // Each element is flattened inline, exactly as the parallel
+            // position walker `collect_pointer_positions` descends
+            // (parser.rs). Omitting this arm desynchronised this layout
+            // array from the pointer-position array: the adapter zips them
+            // by index and falls back to `byte_multiplier = 1` for the
+            // unmatched String/List leaves, undersizing the callee
+            // allocation and truncating the cross-memory copy (LS-R-15 /
+            // H-4.1). Loop `len` times over the element type so one layout
+            // is emitted per flattened pointer-pair leaf.
+            for _ in 0..*len {
+                collect_type_copy_layouts(component, elem, out);
+            }
+        }
         ComponentValType::Type(idx) => {
             if let Some(ct) = component.get_type_definition(*idx)
                 && let ComponentTypeKind::Defined(inner) = &ct.kind
@@ -727,7 +741,7 @@ fn collect_type_copy_layouts(
                 collect_type_copy_layouts(component, inner, out);
             }
         }
-        _ => {} // scalars don't have pointer pairs
+        _ => {} // scalars / options / results / variants — no param-level pointer pairs
     }
 }
 
@@ -5457,6 +5471,46 @@ mod tests {
     #[test]
     fn ls_r_10_intra_adapter_preserves_from_import_module() {
         test_issue112_item5_intra_adapter_preserves_from_import_module();
+    }
+
+    /// LS-R-15 regression: `collect_type_copy_layouts` must descend into
+    /// `FixedSizeList` so its output stays index-aligned with
+    /// `pointer_pair_param_positions` (which does). Pre-fix, a
+    /// `list<list<u64>, 2>` param produced 2 pointer positions but 0 copy
+    /// layouts, so the adapter zipped them misaligned and fell back to
+    /// byte_multiplier=1 (undersized alloc + truncated cross-memory copy).
+    #[test]
+    fn test_lsr12_fixed_size_list_copy_layout_alignment() {
+        use crate::parser::{ComponentValType as V, PrimitiveValType as P};
+        let comp = empty_parsed_component();
+        // list<list<u64>, 2>
+        let inner_list = V::List(Box::new(V::Primitive(P::U64)));
+        let param_ty = V::FixedSizeList(Box::new(inner_list), 2);
+        let params = vec![("p".to_string(), param_ty)];
+
+        let positions = comp.pointer_pair_param_positions(&params);
+        let layouts = collect_param_copy_layouts(&comp, &params);
+
+        assert_eq!(
+            positions.len(),
+            layouts.len(),
+            "pointer positions ({}) and copy layouts ({}) must stay aligned \
+             for FixedSizeList params",
+            positions.len(),
+            layouts.len()
+        );
+        assert_eq!(
+            layouts.len(),
+            2,
+            "list<list<u64>, 2> has two pointer-pair leaves"
+        );
+        for layout in &layouts {
+            assert!(
+                matches!(layout, CopyLayout::Bulk { byte_multiplier: 8 }),
+                "each list<u64> leaf must copy 8 bytes/element, not the \
+                 byte_multiplier=1 fallback; got {layout:?}"
+            );
+        }
     }
 }
 

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -1647,6 +1647,70 @@ loss-scenarios:
       ABI does not provide. (ii) is therefore closed as not-applicable
       rather than implemented; documented in `p3_stream.rs`.
 
+  - id: LS-R-15
+    title: FixedSizeList param/result desynchronises copy-layout from pointer-position arrays
+    uca: UCA-R-4
+    hazards: [H-4, H-4.1]
+    type: inadequate-control-algorithm
+    scenario: >
+      The cross-memory adapter copies each pointer-pair (string/list) leaf
+      of a function parameter/result by zipping two parallel arrays BY
+      INDEX: the flat pointer positions (`pointer_pair_param_positions` →
+      `collect_pointer_positions`, parser.rs) and the per-leaf copy layouts
+      (`collect_param_copy_layouts` → `collect_type_copy_layouts`,
+      resolver.rs). The position walker descended into `FixedSizeList`
+      (`list<T, N>`), but `collect_type_copy_layouts` omitted it via its
+      catch-all `_ => {}`. So for any param/result that is or contains a
+      `FixedSizeList` carrying pointer leaves, the layout array was SHORTER
+      than the position array and the two desynchronised: the adapter's
+      `param_layouts.get(i).map(..).unwrap_or(1)` fell back to
+      `byte_multiplier = 1` for the unmatched leaves (fact.rs). Result for
+      e.g. `list<list<u64>, 2>`: the callee `cabi_realloc` is undersized
+      8× and the `memory.copy` transfers 1/8 of each inner list's bytes —
+      the callee then reads `len` u64 elements from a buffer holding
+      `len/8` of real data [UCA-R-4 / H-4.1 wrong copy byte count, H-4
+      truncated cross-memory payload]. With a non-FixedSizeList pointer
+      after a FixedSizeList, the misalignment also shifts a wide list's
+      layout onto the wrong copy site. Reachable for any cross-memory
+      fusion whose interface fn param/result is or contains a
+      `FixedSizeList` with String/List leaves (meld enables the
+      fixed-length-list proposal; existing fixtures only assert the fused
+      module validates, not runtime copy correctness, so it was untested).
+      Surfaced by a Mythos discovery pass on resolver.rs.
+    causal-factors:
+      - >-
+        Two parallel walkers (position vs copy-layout) over the same type
+        tree diverged: the layout walker's catch-all skipped FixedSizeList
+        while the position walker descended into it
+      - >-
+        The adapter zips the arrays by index with an `unwrap_or(1)`
+        byte-multiplier fallback that silently absorbs a length mismatch
+        instead of erroring
+      - >-
+        No runtime test exercised a FixedSizeList-bearing param/result
+        across a memory boundary (fixtures only checked validation)
+    process-model-flaw: >
+      The copy-layout collector's model of "composite types to descend
+      into" omitted FixedSizeList, while the position collector's model
+      included it — a parallel-array invariant (equal length, matching
+      order) maintained by two independently-edited functions that drifted.
+    status: approved
+    priority: high
+    fix: >
+      `collect_type_copy_layouts` gains the `FixedSizeList(elem, len)` arm
+      (recurse `len`× into `elem`), mirroring `collect_pointer_positions`
+      exactly so the two arrays stay equal-length and identically ordered.
+      One collector feeds param/result/params-area layouts, so all three
+      pairings are fixed. Pinned by
+      resolver::tests::test_lsr12_fixed_size_list_copy_layout_alignment
+      (positions.len()==layouts.len()==2, each Bulk{byte_multiplier:8} for
+      `list<list<u64>, 2>`). Mythos-verified: an 8-shape matrix
+      (nested fixed-lists, fixed-list-in-record/tuple, scalar fixed-list,
+      order-sensitive interleaving) holds count AND order AND
+      byte_multiplier; disabling the arm reproduces the desync; the
+      post-fix match arms of both walkers descend into and skip the
+      identical variant sets.
+
   # ==========================================================================
   # Merger scenarios
   # ==========================================================================


### PR DESCRIPTION
Found by a Mythos discovery pass on `resolver.rs`. Fixes a confirmed cross-memory copy bug (H-4.1, memory-safety + semantic divergence).

## Bug
The adapter copies each string/list leaf of a param/result by zipping two parallel arrays **by index**: pointer positions (`collect_pointer_positions`, parser.rs) and copy layouts (`collect_type_copy_layouts`, resolver.rs). The position walker descends into `FixedSizeList` (`list<T, N>`); the layout walker skipped it via `_ => {}`. So for a FixedSizeList-bearing param the layout array was shorter → the arrays desynchronised → the adapter's `.get(i)...unwrap_or(1)` fell back to `byte_multiplier=1`. For `list<list<u64>, 2>` the callee `cabi_realloc` is undersized 8× and only 1/8 of each inner list copies — the callee reads `len` u64s from a buffer holding `len/8` of real data.

## Fix
Add the `FixedSizeList(elem, len)` arm to `collect_type_copy_layouts` (recurse `len`× into `elem`), mirroring `collect_pointer_positions` exactly. One collector feeds param/result/params-area layouts, so all three pairings are fixed.

## Verification
- `test_lsr12_fixed_size_list_copy_layout_alignment`: `positions.len()==layouts.len()==2`, each `Bulk{byte_multiplier:8}` for `list<list<u64>,2>`.
- Workspace lib green; suite exit 0; clippy/fmt clean.
- **Mythos clean-room pass: NO PROVABLE FINDING** — an 8-shape lockstep matrix (nested fixed-lists, fixed-list-in-record/tuple, scalar fixed-list, order-sensitive interleaving) holds count AND order AND byte_multiplier; disabling the arm reproduces the desync; both walkers' post-fix match arms descend into/skip the identical variant sets. Full report next comment.

## Tier-5
`resolver.rs` → Mythos pass done, `mythos-pass-done` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)