### PR TITLE
fix(adapter): detect resources in option/result/variant/fixed-list aggregates (LS-A-23, UCA-A-16)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -1109,7 +1109,11 @@ impl FactStyleGenerator {
                     if let Some(rep_func) = rep_func {
                         options
                             .inner_resource_fixups
-                            .push((inner.byte_offset, rep_func));
+                            .push(super::InnerResourceFixup {
+                                byte_offset: inner.byte_offset,
+                                rep_func,
+                                guards: inner.guards.clone(),
+                            });
                     } else {
                         log::warn!(
                             "inner-list borrow at offset {} (resource_type_id={}): \
@@ -1634,7 +1638,23 @@ impl FactStyleGenerator {
                 func.instruction(&Instruction::LocalGet(1)); // len
                 func.instruction(&Instruction::I32GeU);
                 func.instruction(&Instruction::BrIf(1));
-                for &(byte_offset, rep_func) in &options.inner_resource_fixups {
+                for fixup in &options.inner_resource_fixups {
+                    let byte_offset = fixup.byte_offset;
+                    let rep_func = fixup.rep_func;
+                    // UCA-A-16: AND-evaluate this fixup's per-element
+                    // discriminant guards before the borrow→rep conversion.
+                    // Empty guards → unconditional (Record/Tuple path). Mirrors
+                    // `emit_inner_pointer_fixup`: load each guard's disc byte
+                    // from the per-element base at the right width, compare,
+                    // AND-chain, and wrap the conversion in an `If`.
+                    let guarded = Self::emit_inner_resource_guard_chain(
+                        &mut func,
+                        &fixup.guards,
+                        dest_ptr_local,
+                        loop_idx,
+                        element_size,
+                        options.callee_memory,
+                    );
                     // addr = dest_ptr + loop_idx * element_size + byte_offset
                     // i32.store needs [addr, value] on stack.
                     // Emit: addr, addr, i32.load → handle, call rep → rep, i32.store
@@ -1664,6 +1684,9 @@ impl FactStyleGenerator {
                         align: 2,
                         memory_index: options.callee_memory,
                     }));
+                    if guarded {
+                        func.instruction(&Instruction::End); // end UCA-A-16 guard If
+                    }
                 }
                 // loop_idx++
                 func.instruction(&Instruction::LocalGet(loop_idx));
@@ -2373,7 +2396,20 @@ impl FactStyleGenerator {
                     func.instruction(&Instruction::LocalGet(len_pos));
                     func.instruction(&Instruction::I32GeU);
                     func.instruction(&Instruction::BrIf(1));
-                    for &(byte_offset, rep_func) in &options.inner_resource_fixups {
+                    for fixup in &options.inner_resource_fixups {
+                        let byte_offset = fixup.byte_offset;
+                        let rep_func = fixup.rep_func;
+                        // UCA-A-16: per-element discriminant guards (see the
+                        // sibling loop in `generate_adapter`). Empty =
+                        // unconditional; mirrors `emit_inner_pointer_fixup`.
+                        let guarded = Self::emit_inner_resource_guard_chain(
+                            &mut func,
+                            &fixup.guards,
+                            dest_local,
+                            res_loop_idx,
+                            element_size,
+                            options.callee_memory,
+                        );
                         // Push addr for store
                         func.instruction(&Instruction::LocalGet(dest_local));
                         func.instruction(&Instruction::LocalGet(res_loop_idx));
@@ -2397,6 +2433,9 @@ impl FactStyleGenerator {
                             align: 2,
                             memory_index: options.callee_memory,
                         }));
+                        if guarded {
+                            func.instruction(&Instruction::End); // end UCA-A-16 guard If
+                        }
                     }
                     func.instruction(&Instruction::LocalGet(res_loop_idx));
                     func.instruction(&Instruction::I32Const(1));
@@ -2766,6 +2805,59 @@ impl FactStyleGenerator {
             }
         }
         layouts.iter().map(depth).max().unwrap_or(0)
+    }
+
+    /// Emit the per-element discriminant-guard chain for an inner-resource
+    /// fixup, returning `true` if an `If` was opened (caller must close it
+    /// with `End` after the conversion). Mirrors the guard emission inside
+    /// [`Self::emit_inner_pointer_fixup`] (UCA-A-16): each guard's
+    /// discriminant byte is loaded from the per-element base
+    /// (`dst_base + loop_idx * element_size + guard.position`) at the width
+    /// selected by `guard.byte_size`, compared to `guard.value`, AND-chained,
+    /// and the result drives an `If`. Empty guards → no `If` (unconditional).
+    fn emit_inner_resource_guard_chain(
+        func: &mut Function,
+        guards: &[crate::resolver::DiscriminantGuard],
+        dst_base_local: u32,
+        loop_idx: u32,
+        element_size: u32,
+        dst_mem: u32,
+    ) -> bool {
+        if guards.is_empty() {
+            return false;
+        }
+        let mut emitted_any = false;
+        for guard in guards {
+            func.instruction(&Instruction::LocalGet(dst_base_local));
+            func.instruction(&Instruction::LocalGet(loop_idx));
+            func.instruction(&Instruction::I32Const(element_size as i32));
+            func.instruction(&Instruction::I32Mul);
+            func.instruction(&Instruction::I32Add);
+            let mem_arg = wasm_encoder::MemArg {
+                offset: guard.position as u64,
+                align: 0,
+                memory_index: dst_mem,
+            };
+            match guard.byte_size {
+                1 => func.instruction(&Instruction::I32Load8U(mem_arg)),
+                2 => func.instruction(&Instruction::I32Load16U(wasm_encoder::MemArg {
+                    align: 1,
+                    ..mem_arg
+                })),
+                _ => func.instruction(&Instruction::I32Load(wasm_encoder::MemArg {
+                    align: 2,
+                    ..mem_arg
+                })),
+            };
+            func.instruction(&Instruction::I32Const(guard.value as i32));
+            func.instruction(&Instruction::I32Eq);
+            if emitted_any {
+                func.instruction(&Instruction::I32And);
+            }
+            emitted_any = true;
+        }
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        true
     }
 
     /// Emit wasm instructions that fix up inner pointers after a bulk copy.
@@ -6573,12 +6665,14 @@ mod tests {
             resource_type_id: 100,
             is_owned: false,
             rep_import: Some(rep_a_key.clone()),
+            guards: Vec::new(),
         };
         let inner_b = InnerResource {
             byte_offset: 4,
             resource_type_id: 200,
             is_owned: false,
             rep_import: Some(rep_b_key.clone()),
+            guards: Vec::new(),
         };
 
         // Build a single Elements layout carrying both inner-
@@ -6626,19 +6720,19 @@ mod tests {
             let off_0 = options
                 .inner_resource_fixups
                 .iter()
-                .find(|(off, _)| *off == 0)
+                .find(|f| f.byte_offset == 0)
                 .expect("must have fixup at offset 0");
             let off_4 = options
                 .inner_resource_fixups
                 .iter()
-                .find(|(off, _)| *off == 4)
+                .find(|f| f.byte_offset == 4)
                 .expect("must have fixup at offset 4");
             assert_eq!(
-                off_0.1, 100,
+                off_0.rep_func, 100,
                 "borrow<A> at offset 0 must select rep_a's func (100); got {off_0:?}",
             );
             assert_eq!(
-                off_4.1, 200,
+                off_4.rep_func, 200,
                 "borrow<B> at offset 4 must select rep_b's func (200); got {off_4:?}",
             );
         }
@@ -6661,6 +6755,7 @@ mod tests {
             resource_type_id: 999,
             is_owned: false,
             rep_import: None, // resolver failed to map; pre-fix would `.values().next()`
+            guards: Vec::new(),
         };
 
         let requirements = AdapterRequirements {

--- a/meld-core/src/adapter/mod.rs
+++ b/meld-core/src/adapter/mod.rs
@@ -169,13 +169,31 @@ pub struct AdapterOptions {
     /// Resource own<T> results needing rep→handle conversion (3-component chains).
     pub resource_new_calls: Vec<ResourceOwnResultTransfer>,
     /// Resolved inner resource handles for list elements.
-    /// Each entry: (byte_offset_in_element, merged_func_idx of [resource-rep]).
-    /// Used after bulk list copy to convert handles in callee memory.
-    pub inner_resource_fixups: Vec<(u32, u32)>,
+    /// Used after bulk list copy to convert `borrow<T>` handles in callee
+    /// memory. See [`InnerResourceFixup`] — each carries a per-element
+    /// discriminant-guard chain (UCA-A-16) so handles inside
+    /// option/result/variant payloads are translated only when their case is
+    /// live. An empty chain = unconditional (Record/Tuple/FixedSizeList).
+    pub inner_resource_fixups: Vec<InnerResourceFixup>,
     /// Resource borrow handles inside the params-ptr buffer that need
     /// handle→rep conversion. Each entry contains the byte offset within the
     /// buffer and the merged function index of `[resource-rep]`.
     pub params_area_borrow_fixups: Vec<ParamsAreaResourceFixup>,
+}
+
+/// A per-element `borrow<T>` → rep conversion for a list element, applied
+/// after the bulk copy. `byte_offset` is relative to each element's base and
+/// `rep_func` is the merged function index of the matching `[resource-rep]`
+/// import. `guards` is a chain of [`crate::resolver::DiscriminantGuard`]s the
+/// adapter AND-evaluates per element before firing the conversion — non-empty
+/// when the handle lives inside an option/result/variant payload (UCA-A-16 /
+/// H-11.5). Empty = unconditional. Mirrors [`crate::resolver::InnerPointer`]'s
+/// guard handling.
+#[derive(Debug, Clone)]
+pub struct InnerResourceFixup {
+    pub byte_offset: u32,
+    pub rep_func: u32,
+    pub guards: Vec<crate::resolver::DiscriminantGuard>,
 }
 
 /// Describes a resource handle inside the params-ptr buffer that needs conversion.

--- a/meld-core/src/parser.rs
+++ b/meld-core/src/parser.rs
@@ -2872,6 +2872,43 @@ impl ParsedComponent {
         }
     }
 
+    /// Whether `ty` contains a resource handle (`own<R>`/`borrow<R>`) at any
+    /// depth. Mirror of [`Self::type_contains_pointers`] for the resource
+    /// path: used by `element_inner_resources` to prune option/result/variant
+    /// cases that carry no handle (so no spurious guard-only descriptors are
+    /// emitted), exactly as the pointer arms gate on `type_contains_pointers`
+    /// (UCA-A-16).
+    pub fn type_contains_resources(&self, ty: &ComponentValType) -> bool {
+        match ty {
+            ComponentValType::Own(_) | ComponentValType::Borrow(_) => true,
+            ComponentValType::FixedSizeList(elem, _) => self.type_contains_resources(elem),
+            ComponentValType::Option(inner) => self.type_contains_resources(inner),
+            ComponentValType::Result { ok, err } => {
+                ok.as_ref().is_some_and(|t| self.type_contains_resources(t))
+                    || err
+                        .as_ref()
+                        .is_some_and(|t| self.type_contains_resources(t))
+            }
+            ComponentValType::Record(fields) => {
+                fields.iter().any(|(_, t)| self.type_contains_resources(t))
+            }
+            ComponentValType::Tuple(elems) => elems.iter().any(|t| self.type_contains_resources(t)),
+            ComponentValType::Variant(cases) => cases
+                .iter()
+                .any(|(_, t)| t.as_ref().is_some_and(|t| self.type_contains_resources(t))),
+            ComponentValType::Type(idx) => {
+                if let Some(ct) = self.get_type_definition(*idx)
+                    && let ComponentTypeKind::Defined(inner) = &ct.kind
+                {
+                    self.type_contains_resources(inner)
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        }
+    }
+
     /// Count the number of flat core wasm values a component type flattens to.
     pub fn flat_count(&self, ty: &ComponentValType) -> u32 {
         match ty {
@@ -3139,7 +3176,7 @@ impl ParsedComponent {
                 // `has_pointer_bearing_conditional` check + panic is gone.
                 let element_size = self.canonical_abi_element_size(inner);
                 let inner_ptrs = self.element_inner_pointers(inner, 0, &[]);
-                let inner_res = self.element_inner_resources(inner, 0);
+                let inner_res = self.element_inner_resources(inner, 0, &[]);
                 if inner_ptrs.is_empty() && inner_res.is_empty() {
                     CopyLayout::Bulk {
                         byte_multiplier: element_size,
@@ -3305,14 +3342,28 @@ impl ParsedComponent {
         result
     }
 
-    /// Find resource handles embedded within a composite type's memory layout.
-    /// Returns `(byte_offset, resource_type_id, is_owned)` for each resource found.
+    /// Find resource handles (`own<R>`/`borrow<R>`) embedded within a
+    /// composite type's memory layout.
+    ///
+    /// Each emitted [`InnerResource`] has a byte offset within the element,
+    /// resource type id / ownership, and a `guards` chain that the FACT
+    /// adapter AND-evaluates per element before firing the borrow→rep
+    /// conversion. For resource-bearing option / result / variant payloads,
+    /// the guard chain pins the enclosing discriminant(s) — UCA-A-16 /
+    /// H-11.5. This mirrors [`Self::element_inner_pointers`] exactly: same
+    /// `disc_size`, payload-offset (`align_up(ds, max_case_align)`), and
+    /// per-case `DiscriminantGuard` chain. Record / Tuple / Type / inline
+    /// FixedSizeList handles thread `outer_guards` straight through (empty
+    /// at the top, so they remain unconditional). Guard byte offsets are
+    /// relative to the element base passed in by the outer list's
+    /// per-element loop.
     fn element_inner_resources(
         &self,
         ty: &ComponentValType,
         base: u32,
+        outer_guards: &[crate::resolver::DiscriminantGuard],
     ) -> Vec<crate::resolver::InnerResource> {
-        use crate::resolver::InnerResource;
+        use crate::resolver::{DiscriminantGuard, InnerResource};
         let mut result = Vec::new();
         match ty {
             ComponentValType::Own(id) => {
@@ -3321,6 +3372,7 @@ impl ParsedComponent {
                     resource_type_id: *id,
                     is_owned: true,
                     rep_import: None,
+                    guards: outer_guards.to_vec(),
                 });
             }
             ComponentValType::Borrow(id) => {
@@ -3329,6 +3381,7 @@ impl ParsedComponent {
                     resource_type_id: *id,
                     is_owned: false,
                     rep_import: None,
+                    guards: outer_guards.to_vec(),
                 });
             }
             ComponentValType::Record(fields) => {
@@ -3336,7 +3389,7 @@ impl ParsedComponent {
                 for (_, field_ty) in fields {
                     let align = self.canonical_abi_align(field_ty);
                     offset = align_up(offset, align);
-                    result.extend(self.element_inner_resources(field_ty, offset));
+                    result.extend(self.element_inner_resources(field_ty, offset, outer_guards));
                     offset = offset.saturating_add(self.canonical_abi_element_size(field_ty));
                 }
             }
@@ -3345,18 +3398,105 @@ impl ParsedComponent {
                 for elem_ty in elems {
                     let align = self.canonical_abi_align(elem_ty);
                     offset = align_up(offset, align);
-                    result.extend(self.element_inner_resources(elem_ty, offset));
+                    result.extend(self.element_inner_resources(elem_ty, offset, outer_guards));
                     offset = offset.saturating_add(self.canonical_abi_element_size(elem_ty));
+                }
+            }
+            // Inline FixedSizeList: recurse into each element at its stride —
+            // mirrors the FixedSizeList arm of `element_inner_pointers`. The
+            // handles live within this element's bytes (unlike a dynamic
+            // `List`, which is a separate heap buffer and so is not walked
+            // here, matching the pointer path).
+            ComponentValType::FixedSizeList(elem, len) => {
+                let elem_size = self.canonical_abi_element_size(elem);
+                let mut offset = base;
+                for _ in 0..*len {
+                    result.extend(self.element_inner_resources(elem, offset, outer_guards));
+                    offset = offset.saturating_add(elem_size);
+                }
+            }
+            // UCA-A-16 structural: resource-bearing option/result/variant
+            // payloads emit InnerResource descriptors whose `guards` chain
+            // includes the enclosing discriminant. The adapter AND-evaluates
+            // the chain per element before the borrow→rep conversion, so a
+            // `Some(borrow)` is translated while a `None` slot is left alone.
+            ComponentValType::Option(inner) if self.type_contains_resources(inner) => {
+                let ds = disc_size(2);
+                let payload_align = self.canonical_abi_align(inner);
+                let payload_offset = base + align_up(ds, payload_align);
+                let mut nested = outer_guards.to_vec();
+                nested.push(DiscriminantGuard {
+                    position: base,
+                    value: 1, // option discriminant: 1 = Some
+                    byte_size: ds,
+                });
+                result.extend(self.element_inner_resources(inner, payload_offset, &nested));
+            }
+            ComponentValType::Result { ok, err } => {
+                let ds = disc_size(2);
+                let ok_align = ok
+                    .as_ref()
+                    .map(|t| self.canonical_abi_align(t))
+                    .unwrap_or(1);
+                let err_align = err
+                    .as_ref()
+                    .map(|t| self.canonical_abi_align(t))
+                    .unwrap_or(1);
+                let max_case_align = ok_align.max(err_align);
+                let payload_offset = base + align_up(ds, max_case_align);
+                if let Some(ok_ty) = ok
+                    && self.type_contains_resources(ok_ty)
+                {
+                    let mut nested = outer_guards.to_vec();
+                    nested.push(DiscriminantGuard {
+                        position: base,
+                        value: 0, // result discriminant: 0 = Ok
+                        byte_size: ds,
+                    });
+                    result.extend(self.element_inner_resources(ok_ty, payload_offset, &nested));
+                }
+                if let Some(err_ty) = err
+                    && self.type_contains_resources(err_ty)
+                {
+                    let mut nested = outer_guards.to_vec();
+                    nested.push(DiscriminantGuard {
+                        position: base,
+                        value: 1, // result discriminant: 1 = Err
+                        byte_size: ds,
+                    });
+                    result.extend(self.element_inner_resources(err_ty, payload_offset, &nested));
+                }
+            }
+            ComponentValType::Variant(cases) => {
+                let ds = disc_size(cases.len());
+                let max_case_align = cases
+                    .iter()
+                    .filter_map(|(_, t)| t.as_ref().map(|t| self.canonical_abi_align(t)))
+                    .max()
+                    .unwrap_or(1);
+                let payload_offset = base + align_up(ds, max_case_align);
+                for (case_idx, (_, case_ty)) in cases.iter().enumerate() {
+                    if let Some(t) = case_ty
+                        && self.type_contains_resources(t)
+                    {
+                        let mut nested = outer_guards.to_vec();
+                        nested.push(DiscriminantGuard {
+                            position: base,
+                            value: case_idx as u32,
+                            byte_size: ds,
+                        });
+                        result.extend(self.element_inner_resources(t, payload_offset, &nested));
+                    }
                 }
             }
             ComponentValType::Type(idx) => {
                 if let Some(ct) = self.get_type_definition(*idx)
                     && let ComponentTypeKind::Defined(inner) = &ct.kind
                 {
-                    return self.element_inner_resources(inner, base);
+                    return self.element_inner_resources(inner, base, outer_guards);
                 }
             }
-            _ => {} // scalars, strings, lists, options, variants — skip
+            _ => {} // scalars, strings, dynamic lists — no in-element handle
         }
         result
     }
@@ -5317,6 +5457,226 @@ mod tests {
             CopyLayout::Elements { .. } => {
                 panic!("list<option<u32>> must still be Bulk (no inner pointers)")
             }
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // UCA-A-16 / H-11.5 — resource handles nested in option/result/
+    // variant/fixed-size-list aggregates. Pre-fix, `element_inner_resources`
+    // swallowed these via its catch-all `_ => {}`, so the FACT adapter bulk-
+    // copied the raw handle integer across the instance boundary (no
+    // borrow→rep translation) — wrong-resource / use-after-free / type
+    // confusion. These mirror the LS-P-12 pointer-path matrix above and FAIL
+    // on origin/main (where the count is 0 / Bulk).
+    // ----------------------------------------------------------------
+
+    /// `list<option<borrow<R>>>` → Elements with exactly one inner resource,
+    /// guarded by the option's Some discriminant (value=1).
+    #[test]
+    fn uca_a16_list_of_option_borrow_emits_guarded_inner_resource() {
+        use crate::resolver::CopyLayout;
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::List(Box::new(ComponentValType::Option(Box::new(
+            ComponentValType::Borrow(7),
+        ))));
+        match pc.copy_layout(&ty) {
+            CopyLayout::Elements {
+                inner_resources, ..
+            } => {
+                assert_eq!(
+                    inner_resources.len(),
+                    1,
+                    "exactly one inner resource (the borrow in the Some arm)",
+                );
+                let ir = &inner_resources[0];
+                assert_eq!(ir.resource_type_id, 7);
+                assert!(!ir.is_owned, "borrow → not owned");
+                assert_eq!(
+                    ir.byte_offset, 4,
+                    "borrow handle lives at element-relative byte 4 \
+                     (disc(1) + align pad to i32)",
+                );
+                assert_eq!(ir.guards.len(), 1, "exactly one guard (the option)");
+                let g = &ir.guards[0];
+                assert_eq!(g.position, 0, "option disc at element-relative byte 0");
+                assert_eq!(g.value, 1, "Some = 1");
+                assert_eq!(g.byte_size, 1, "option disc is 1 byte");
+            }
+            CopyLayout::Bulk { .. } => panic!(
+                "list<option<borrow<R>>> must produce Elements with a guarded \
+                 inner resource (UCA-A-16), not Bulk",
+            ),
+        }
+    }
+
+    /// `list<result<borrow<R>, E>>` → inner resource in the Ok arm guarded by
+    /// disc=0; the Err scalar arm carries no resource.
+    #[test]
+    fn uca_a16_list_of_result_borrow_emits_ok_guarded_inner_resource() {
+        use crate::resolver::CopyLayout;
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::List(Box::new(ComponentValType::Result {
+            ok: Some(Box::new(ComponentValType::Borrow(9))),
+            err: Some(Box::new(ComponentValType::Primitive(PrimitiveValType::U32))),
+        }));
+        match pc.copy_layout(&ty) {
+            CopyLayout::Elements {
+                inner_resources, ..
+            } => {
+                assert_eq!(inner_resources.len(), 1, "only the Ok arm carries a borrow");
+                let ir = &inner_resources[0];
+                assert_eq!(ir.resource_type_id, 9);
+                assert!(!ir.is_owned);
+                assert_eq!(ir.guards.len(), 1);
+                assert_eq!(ir.guards[0].value, 0, "result Ok = 0");
+            }
+            CopyLayout::Bulk { .. } => panic!("expected Elements (UCA-A-16)"),
+        }
+    }
+
+    /// `list<variant{a, b(borrow<R>)}>` → inner resource guarded by the
+    /// payload-bearing case's index (case 1).
+    #[test]
+    fn uca_a16_list_of_variant_borrow_emits_case_guarded_inner_resource() {
+        use crate::resolver::CopyLayout;
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::List(Box::new(ComponentValType::Variant(vec![
+            ("a".to_string(), None),
+            ("b".to_string(), Some(ComponentValType::Borrow(13))),
+        ])));
+        match pc.copy_layout(&ty) {
+            CopyLayout::Elements {
+                inner_resources, ..
+            } => {
+                assert_eq!(inner_resources.len(), 1, "only case b carries a borrow");
+                let ir = &inner_resources[0];
+                assert_eq!(ir.resource_type_id, 13);
+                assert!(!ir.is_owned);
+                assert_eq!(ir.guards.len(), 1);
+                assert_eq!(
+                    ir.guards[0].value, 1,
+                    "guard pins the payload-bearing case index (b = 1)",
+                );
+            }
+            CopyLayout::Bulk { .. } => panic!("expected Elements (UCA-A-16)"),
+        }
+    }
+
+    /// `list<fixedlist<own<R>, 2>>` → two unconditional inner resources (the
+    /// inline fixed-size-list elements), one per stride. `own<R>` is detected
+    /// here (the adapter skips translating own at fact.rs, but detection must
+    /// still descend into the FixedSizeList — pre-fix it was swallowed).
+    #[test]
+    fn uca_a16_list_of_fixedlist_own_emits_per_element_inner_resources() {
+        use crate::resolver::CopyLayout;
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::List(Box::new(ComponentValType::FixedSizeList(
+            Box::new(ComponentValType::Own(21)),
+            2,
+        )));
+        match pc.copy_layout(&ty) {
+            CopyLayout::Elements {
+                inner_resources, ..
+            } => {
+                assert_eq!(
+                    inner_resources.len(),
+                    2,
+                    "one inner resource per fixed-list element (stride loop)",
+                );
+                assert_eq!(inner_resources[0].byte_offset, 0);
+                assert_eq!(
+                    inner_resources[1].byte_offset, 4,
+                    "second handle one i32 over"
+                );
+                for ir in &inner_resources {
+                    assert_eq!(ir.resource_type_id, 21);
+                    assert!(ir.is_owned, "own → owned");
+                    assert!(
+                        ir.guards.is_empty(),
+                        "inline fixed-list elements are unconditional (no enclosing disc)",
+                    );
+                }
+            }
+            CopyLayout::Bulk { .. } => panic!("expected Elements (UCA-A-16)"),
+        }
+    }
+
+    /// Regression: `list<record{borrow<R>}>` (the case that ALREADY worked)
+    /// must still be detected, with an EMPTY guard chain (unconditional —
+    /// every element carries the handle).
+    #[test]
+    fn uca_a16_regression_list_of_record_borrow_unconditional() {
+        use crate::resolver::CopyLayout;
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::List(Box::new(ComponentValType::Record(vec![(
+            "h".to_string(),
+            ComponentValType::Borrow(3),
+        )])));
+        match pc.copy_layout(&ty) {
+            CopyLayout::Elements {
+                inner_resources, ..
+            } => {
+                assert_eq!(inner_resources.len(), 1);
+                let ir = &inner_resources[0];
+                assert_eq!(ir.resource_type_id, 3);
+                assert_eq!(ir.byte_offset, 0);
+                assert!(
+                    ir.guards.is_empty(),
+                    "record field handle fires for every element — empty guard chain",
+                );
+            }
+            CopyLayout::Bulk { .. } => panic!("list<record{{borrow}}> must be Elements"),
+        }
+    }
+
+    /// Regression: the POINTER path is unchanged — `list<option<string>>`
+    /// still yields exactly one guarded inner pointer and no inner resources.
+    #[test]
+    fn uca_a16_regression_pointer_path_option_string_unchanged() {
+        use crate::resolver::CopyLayout;
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::List(Box::new(ComponentValType::Option(Box::new(
+            ComponentValType::String,
+        ))));
+        match pc.copy_layout(&ty) {
+            CopyLayout::Elements {
+                inner_pointers,
+                inner_resources,
+                ..
+            } => {
+                assert_eq!(
+                    inner_pointers.len(),
+                    1,
+                    "pointer path: one guarded string ptr"
+                );
+                assert_eq!(inner_pointers[0].guards.len(), 1);
+                assert!(
+                    inner_resources.is_empty(),
+                    "no resource handles in list<option<string>>",
+                );
+            }
+            CopyLayout::Bulk { .. } => panic!("expected Elements"),
+        }
+    }
+
+    /// A pure-scalar option/variant payload (no handle) must NOT emit a
+    /// guard-only inner resource — `type_contains_resources` prunes it, exactly
+    /// as `type_contains_pointers` prunes the pointer path.
+    #[test]
+    fn uca_a16_pure_scalar_option_emits_no_inner_resource() {
+        use crate::resolver::CopyLayout;
+        let pc = empty_parsed_component();
+        let ty = ComponentValType::List(Box::new(ComponentValType::Option(Box::new(
+            ComponentValType::Primitive(PrimitiveValType::U32),
+        ))));
+        match pc.copy_layout(&ty) {
+            CopyLayout::Bulk { .. } => {} // no pointers, no resources
+            CopyLayout::Elements {
+                inner_resources, ..
+            } => assert!(
+                inner_resources.is_empty(),
+                "option<u32> carries no resource handle — must emit none",
+            ),
         }
     }
 

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -131,6 +131,32 @@ pub struct InnerResource {
     /// the fact.rs fallback is logged as a warning and the borrow conversion
     /// is conservatively skipped).
     pub rep_import: Option<(String, String)>,
+    /// A chain of discriminant checks that must ALL hold (AND-evaluated by
+    /// the adapter) before the per-element borrow→rep conversion fires —
+    /// non-empty when the resource handle lives inside an
+    /// option/result/variant payload (UCA-A-16 / H-11.5). Mirrors
+    /// [`InnerPointer::guards`]. All discriminant byte offsets are RELATIVE
+    /// to each element's base, not absolute. Empty = unconditional (fires
+    /// for every element, as for Record / Tuple / FixedSizeList).
+    pub guards: Vec<DiscriminantGuard>,
+}
+
+impl InnerResource {
+    /// Convenience: construct an unconditional inner resource (empty guard
+    /// chain — fires for every element). Used by the Record / Tuple / Type
+    /// paths in `element_inner_resources`, which carry a resource handle at a
+    /// fixed offset present in every element. `rep_import` is left `None`
+    /// here and resolved later by the caller against the callee's resource
+    /// type map.
+    pub fn unconditional(byte_offset: u32, resource_type_id: u32, is_owned: bool) -> Self {
+        Self {
+            byte_offset,
+            resource_type_id,
+            is_owned,
+            rep_import: None,
+            guards: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -2695,6 +2695,75 @@ loss-scenarios:
       func-signature param preserved, and a plain-funcref regression
       control. Closes #258.
 
+  - id: LS-A-23
+    title: Resource handles in option/result/variant/fixed-list inside a list element not detected for translation
+    uca: UCA-A-16
+    hazards: [H-3, H-11.5]
+    type: inadequate-control-algorithm
+    scenario: >
+      `parser.rs::element_inner_resources` (which populates
+      `CopyLayout::Elements.inner_resources` so the FACT adapter can
+      translate `borrow<R>` handles element-by-element across an instance
+      boundary) detected resources nested in Record/Tuple/Type but its
+      catch-all `_ => {}` SWALLOWED Option/Result/Variant/FixedSizeList —
+      while the sibling `element_inner_pointers` (for string/list pointer
+      fixups) DID recurse into all of them. So a `borrow<R>` inside e.g.
+      `list<option<borrow<R>>>` / `list<result<borrow<R>,E>>` /
+      `list<variant{..(borrow<R>)}>` / `list<list<own<R>, N>>` was not
+      detected, and the adapter bulk-copied the raw caller-side handle
+      INTEGER into callee memory instead of translating it through the
+      callee's resource table. The callee then indexes its handle table
+      with the caller's index → wrong resource / use-after-free / type
+      confusion in the fused output [UCA-A-16 / H-11.5 resource nested in
+      aggregate not detected / H-3 wrong-entity reference]. The
+      asymmetric sibling of the LS-P-12 pointer-fixup path and the
+      LS-R-15 copy-layout desync — the same "two parallel walkers over
+      one type tree drifted" root cause. UCA-A-16 / H-11.5 named this
+      hazard explicitly; the Record/Tuple recursion had landed but the
+      Option/Result/Variant/FixedSizeList arms were never closed.
+      Surfaced by a Mythos discovery pass on parser.rs.
+    causal-factors:
+      - >-
+        element_inner_resources omitted Option/Result/Variant/FixedSizeList
+        (catch-all `_ => {}`) while element_inner_pointers recursed into them
+      - >-
+        InnerResource carried no discriminant-guard chain, so even once
+        detected a handle inside an option/variant could not be translated
+        conditionally on the live case
+      - >-
+        no test exercised a resource nested in an option/result/variant/
+        fixed-list inside a list element (only Record/Tuple were covered)
+    process-model-flaw: >
+      The resource-detection model of "aggregates to descend into" lagged
+      the pointer-detection model — a parallel-walker invariant maintained
+      by two independently-edited functions that drifted, identical in
+      shape to LS-R-15.
+    status: approved
+    priority: high
+    fix: >
+      InnerResource gains a `guards: Vec<DiscriminantGuard>` chain (+
+      `unconditional` constructor) mirroring InnerPointer.
+      element_inner_resources gains an `outer_guards` param and
+      Option/Result/Variant/FixedSizeList recursion arms identical to
+      element_inner_pointers (same disc_size, align_up(ds,
+      max_case_align) payload offset, per-case guard values), gated by a
+      new `type_contains_resources`. The adapter (fact.rs) wraps each
+      borrow→rep conversion in `emit_inner_resource_guard_chain` — the
+      byte-identical mirror of the pointer path's guard block — so the
+      handle is translated ONLY when the live discriminant selects its
+      case (empty chain = unconditional, preserving Record/Tuple).
+      `own<R>` remains skipped by the adapter (not translated). Pinned by
+      7 parser tests (resource in option/result/variant/fixed-list
+      detected with correct guard values; Record stays unconditional;
+      pointer path unchanged). Mythos-verified: the resource guard
+      emission is byte-identical to the already-runtime-validated
+      InnerPointer guard path (option-Some, variant-case, nested
+      result-Ok+option-Some chains), so it fires exactly on the live case;
+      resource_borrow / resource_borrow_in_record / resource_import_and_export
+      runtime suites stay green. Carried: no two-component runtime fixture
+      through list<option<borrow>> (behaviour inferred from byte-identity
+      to the LS-P-12 pointer path).
+
   - id: LS-A-12
     title: uses_stackful_lift mis-classifies mixed-mode components
     uca: UCA-A-3


### PR DESCRIPTION
Found by a Mythos discovery pass on `parser.rs`. Closes the still-open arms of the documented hazard UCA-A-16 / H-11.5.

## Bug
`element_inner_resources` (populating `CopyLayout::Elements.inner_resources` for the FACT adapter's per-element `borrow<R>`→rep translation) detected resources in Record/Tuple/Type but its catch-all `_ => {}` **swallowed Option/Result/Variant/FixedSizeList** — while the sibling `element_inner_pointers` recursed into all of them. So a `borrow<R>` inside `list<option<borrow<R>>>` (etc.) was undetected and the adapter bulk-copied the raw caller handle index into callee memory instead of translating it → wrong-resource / use-after-free / type confusion. Same "parallel walkers drifted" root cause as LS-P-12 / LS-R-15.

## Fix (mirrors the working InnerPointer guard mechanism)
- `InnerResource` gains `guards: Vec<DiscriminantGuard>` + `unconditional` ctor.
- `element_inner_resources` gains an `outer_guards` param and Option/Result/Variant/FixedSizeList arms identical to `element_inner_pointers` (same disc_size, `align_up` payload offset, per-case guard values), gated by a new `type_contains_resources`.
- The adapter wraps each borrow→rep conversion in `emit_inner_resource_guard_chain` so the handle is translated **only when the live discriminant selects its case** (empty chain = unconditional, preserving Record/Tuple). `own<R>` stays skipped.

## Verification
- 7 parser tests: resource in option/result/variant/fixed-list detected with correct guard values; Record stays unconditional; pointer path unchanged. Non-vacuity proven (routing the 4 kinds back to the swallow makes the detection tests fail). Workspace lib 351 + adapter_safety 13 + wit_bindgen_runtime 73 (incl. resource_borrow / resource_borrow_in_record / resource_import_and_export) green via exit code; clippy/fmt clean.
- **Mythos clean-room pass: NO PROVABLE FINDING** — the resource guard emission is proven **byte-identical** to the already-runtime-validated InnerPointer guard path (disc load width/offset/compare/AND-chain), so it fires exactly on the live case; payload offsets, nested threading (`result<borrow,borrow>` → mutually-exclusive guards), and own-not-translated all verified. Full report next comment. Carried caveat: no two-component runtime fixture (behaviour inferred from byte-identity to the runtime-validated pointer path).

## Tier-5
`parser.rs` + `resolver.rs` + `adapter/{fact,mod}.rs` → Mythos pass done, `mythos-pass-done` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)