### PR TITLE
fix(p3-async): relocate ref.func in expression-form element segments (LS-M-9)

### DIFF
--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -1601,7 +1601,7 @@ impl Fuser {
         if !merged.elements.is_empty() {
             let mut elements = wasm_encoder::ElementSection::new();
             for segment in &merged.elements {
-                elements.segment(segments::encode_element_segment(segment));
+                segments::encode_element_segment(&mut elements, segment);
             }
             module.section(&elements);
         }

--- a/meld-core/src/p3_async.rs
+++ b/meld-core/src/p3_async.rs
@@ -1287,14 +1287,26 @@ fn shift_function_indices(
                     *f = bump(*f);
                 }
             }
-            crate::segments::ReindexedElementItems::Expressions(_) => {
-                // Expressions hold encoded ConstExpr bytes (already
-                // baked). For ref.func the function index is encoded
-                // inside; we cannot easily rewrite without re-parsing.
-                // P3 async lowering does not currently support this
-                // case and components that hit it will be flagged.
-                // The vast majority of element segments in fused
-                // output use Functions(_) form.
+            crate::segments::ReindexedElementItems::Expressions(exprs) => {
+                // Expressions now carry the STRUCTURED, merger-reindexed
+                // `ParsedConstExpr` form, so the `ref.func` index is
+                // accessible and can be shifted just like the Functions
+                // arm. Only `RefFunc` carries a defined-function index
+                // that this P3 shift moves; the other variants are left
+                // untouched (see below).
+                for e in exprs.iter_mut() {
+                    if let crate::segments::ParsedConstExpr::RefFunc(idx) = e {
+                        *idx = bump(*idx);
+                    }
+                    // RefNull/GlobalGet/I32Const/I64Const/F32Const/
+                    // F64Const/V128Const need no +k shift here:
+                    //  - GlobalGet was already remapped to its final
+                    //    global index by the merger, and P3 prepends only
+                    //    FUNCTION imports — it does not shift globals.
+                    //  - RefNull carries a (type) heap index, not a
+                    //    function index; P3 prepends no types either.
+                    //  - the scalar/vector consts carry no index at all.
+                }
             }
         }
     }

--- a/meld-core/src/segments.rs
+++ b/meld-core/src/segments.rs
@@ -20,7 +20,8 @@ use crate::parser::CoreModule;
 use crate::rewriter::{IndexMaps, convert_abstract_heap_type};
 use crate::{Error, Result};
 use wasm_encoder::{
-    ConstExpr, DataSegment, DataSegmentMode, ElementMode, ElementSegment, Elements, RefType,
+    ConstExpr, DataSegment, DataSegmentMode, ElementMode, ElementSection, ElementSegment, Elements,
+    RefType,
 };
 use wasmparser::{DataSectionReader, ElementItems, ElementKind, ElementSectionReader, Operator};
 
@@ -164,8 +165,13 @@ pub struct ReindexedElementSegment {
 pub enum ReindexedElementItems {
     /// Simple function indices (reindexed)
     Functions(Vec<u32>),
-    /// Expressions (reindexed)
-    Expressions(Vec<ConstExpr>),
+    /// Expressions (reindexed). Held in STRUCTURED `ParsedConstExpr` form —
+    /// already remapped by the merger via [`reindex_element_segment`] — rather
+    /// than opaque encoded `ConstExpr` bytes, so that a later pass (notably the
+    /// P3-async function-index shift, see `p3_async::shift_function_indices`)
+    /// can still read and bump the `ref.func` index inside the expression.
+    /// Encoded to `ConstExpr` only at final emit (see [`encode_element_segment`]).
+    Expressions(Vec<ParsedConstExpr>),
 }
 
 /// Reindexed data segment ready for encoding
@@ -380,10 +386,10 @@ pub fn reindex_element_segment(
             ReindexedElementItems::Functions(remapped)
         }
         ElementItems_::Expressions(exprs) => {
-            let remapped: Vec<ConstExpr> = exprs
-                .iter()
-                .map(|e| e.reindex(maps).to_const_expr())
-                .collect();
+            // Keep the STRUCTURED, merger-reindexed form so a later
+            // function-index shift (P3-async) can still bump `ref.func`.
+            // Encoding is deferred to `encode_element_segment`.
+            let remapped: Vec<ParsedConstExpr> = exprs.iter().map(|e| e.reindex(maps)).collect();
             ReindexedElementItems::Expressions(remapped)
         }
     };
@@ -637,7 +643,14 @@ fn rebase_const_expr_value(value: ConstExprValue, base: u64) -> Result<ConstExpr
 }
 
 /// Convert a reindexed element segment to wasm_encoder format for encoding
-pub fn encode_element_segment(segment: &ReindexedElementSegment) -> ElementSegment<'_> {
+/// Encode a reindexed element segment into the given element section.
+///
+/// Takes a `&mut ElementSection` rather than returning an `ElementSegment`
+/// because the `Expressions` arm now holds structured [`ParsedConstExpr`]
+/// values that must be encoded into a temporary `Vec<ConstExpr>` here; that
+/// temporary would not outlive a returned borrowing `ElementSegment`, so the
+/// segment is pushed directly while the temporary is still live.
+pub fn encode_element_segment(section: &mut ElementSection, segment: &ReindexedElementSegment) {
     let mode = match &segment.mode {
         ElementSegmentMode::Active {
             table_index,
@@ -650,14 +663,22 @@ pub fn encode_element_segment(segment: &ReindexedElementSegment) -> ElementSegme
         ElementSegmentMode::Declared => ElementMode::Declared,
     };
 
-    let elements = match &segment.items {
-        ReindexedElementItems::Functions(funcs) => Elements::Functions(funcs.as_slice().into()),
-        ReindexedElementItems::Expressions(exprs) => {
-            Elements::Expressions(segment.element_type, exprs.as_slice().into())
+    match &segment.items {
+        ReindexedElementItems::Functions(funcs) => {
+            section.segment(ElementSegment {
+                mode,
+                elements: Elements::Functions(funcs.as_slice().into()),
+            });
         }
-    };
-
-    ElementSegment { mode, elements }
+        ReindexedElementItems::Expressions(exprs) => {
+            // Encode the structured form at the last possible moment.
+            let encoded: Vec<ConstExpr> = exprs.iter().map(|e| e.to_const_expr()).collect();
+            section.segment(ElementSegment {
+                mode,
+                elements: Elements::Expressions(segment.element_type, encoded.as_slice().into()),
+            });
+        }
+    }
 }
 
 /// Convert a reindexed data segment to wasm_encoder format for encoding
@@ -934,8 +955,10 @@ mod tests {
         assert_eq!(exprs.len(), 1, "should have exactly one expression");
 
         // Encode both the actual and expected ConstExpr to compare bytes.
+        // `Expressions` now holds structured `ParsedConstExpr`; encode it the
+        // same way `encode_element_segment` does (deferred `to_const_expr`).
         let mut actual = Vec::new();
-        exprs[0].encode(&mut actual);
+        exprs[0].to_const_expr().encode(&mut actual);
 
         let mut expected = Vec::new();
         ConstExpr::ref_null(wasm_encoder::HeapType::Concrete(4)).encode(&mut expected);
@@ -1030,14 +1053,13 @@ mod tests {
         // into a fresh module, and validate it.
         let maps = IndexMaps::new();
         let reindexed = reindex_element_segment(&parsed[0], &maps);
-        let encoded = encode_element_segment(&reindexed);
 
         let mut types = wasm_encoder::TypeSection::new();
         types.ty().function([], []);
         let mut funcs = wasm_encoder::FunctionSection::new();
         funcs.function(0);
         let mut elems = wasm_encoder::ElementSection::new();
-        elems.segment(encoded);
+        encode_element_segment(&mut elems, &reindexed);
         let mut code = wasm_encoder::CodeSection::new();
         let mut f = wasm_encoder::Function::new([]);
         f.instruction(&wasm_encoder::Instruction::End);

--- a/meld-core/tests/p3_async_lowering.rs
+++ b/meld-core/tests/p3_async_lowering.rs
@@ -635,3 +635,181 @@ fn async_callback_trampoline_shape_canonical() {
     assert_eq!(i32_size, 4);
     assert_eq!(3 * i32_size, 12, "event tuple is 3 × i32 = 12 bytes");
 }
+
+// ---------------------------------------------------------------------------
+// Regression: expression-form element-segment ref.func relocation under the
+// P3-async function-index shift (fix/p3-elem-expr-reffunc).
+//
+// `shift_function_indices` prepends `k` `pulseengine:async` function imports
+// and bumps every defined-function reference up by `k`. The
+// expression-form element-segment arm used to be a NO-OP, leaving a
+// `(ref.func $b)` inside an `(elem ... funcref (ref.func $b))` STALE: the
+// export for `$b` shifted but the table slot kept pointing at the old index —
+// now a prepended intrinsic import — so `call_indirect` reached the wrong
+// function (SC-3 violation). This test fuses such a component and asserts the
+// element segment's `ref.func` equals `$b`'s (shifted) exported index.
+// ---------------------------------------------------------------------------
+
+/// A P3-async component whose core module exports a function `$b` and has an
+/// EXPRESSION-FORM active element segment `(elem (i32.const 0) funcref
+/// (ref.func $b))`. The `stream<u8>` canonicals force `k` `pulseengine:async`
+/// function imports to be prepended, triggering the index shift.
+fn build_stream_u8_component_with_expr_elem_wat() -> &'static str {
+    r#"
+(component
+  (core module $m
+    (memory (export "memory") 1)
+    (table (export "tab") 4 funcref)
+    (func $a (export "cabi_realloc") (param i32 i32 i32 i32) (result i32)
+      i32.const 0)
+    (func $b (export "b") (result i32) i32.const 42)
+    (elem (i32.const 0) funcref (ref.func $b))
+  )
+  (core instance $i (instantiate $m))
+  (alias core export $i "memory" (core memory $mem))
+  (alias core export $i "cabi_realloc" (core func $rea))
+
+  (type $st (stream u8))
+
+  (canon stream.new $st (core func $sn))
+  (canon stream.read $st async (memory $mem) (realloc $rea) (core func $sr))
+  (canon stream.write $st async (memory $mem) (realloc $rea) (core func $sw))
+  (canon stream.drop-readable $st (core func $sdr))
+  (canon stream.drop-writable $st (core func $sdw))
+)
+"#
+}
+
+/// A k=0 control: the same core module/element segment but a pure-P2
+/// component (no stream/future) so NO intrinsic imports are prepended and no
+/// shift occurs. The elem ref must still equal the exported index of `$b`.
+fn build_p2_component_with_expr_elem_wat() -> &'static str {
+    r#"
+(component
+  (core module $m
+    (memory (export "memory") 1)
+    (table (export "tab") 4 funcref)
+    (func $a (export "cabi_realloc") (param i32 i32 i32 i32) (result i32)
+      i32.const 0)
+    (func $b (export "b") (result i32) i32.const 42)
+    (elem (i32.const 0) funcref (ref.func $b))
+  )
+  (core instance $i (instantiate $m))
+)
+"#
+}
+
+/// Return the function index of the core-module export named `name`, if any.
+fn func_export_index(fused: &[u8], name: &str) -> Option<u32> {
+    for payload in wasmparser::Parser::new(0).parse_all(fused) {
+        if let Ok(wasmparser::Payload::ExportSection(reader)) = payload {
+            for exp in reader.into_iter().flatten() {
+                if exp.name == name && matches!(exp.kind, wasmparser::ExternalKind::Func) {
+                    return Some(exp.index);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Return every `ref.func` function index found in expression-form element
+/// segments of the (single) core module in `fused`.
+fn elem_expr_ref_func_indices(fused: &[u8]) -> Vec<u32> {
+    let mut out = Vec::new();
+    for payload in wasmparser::Parser::new(0).parse_all(fused) {
+        if let Ok(wasmparser::Payload::ElementSection(reader)) = payload {
+            for elem in reader.into_iter().flatten() {
+                if let wasmparser::ElementItems::Expressions(_, exprs) = elem.items {
+                    for ce in exprs.into_iter().flatten() {
+                        for op in ce.get_operators_reader().into_iter().flatten() {
+                            if let wasmparser::Operator::RefFunc { function_index } = op {
+                                out.push(function_index);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn p3_shift_relocates_expr_form_elem_ref_func() {
+    let wat_src = build_stream_u8_component_with_expr_elem_wat();
+    let bytes = match wat::parse_str(wat_src) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: wat crate cannot parse P3 stream syntax: {e}");
+            return;
+        }
+    };
+
+    let mut fuser = Fuser::new(FuserConfig::default());
+    fuser
+        .add_component_named(&bytes, Some("stream-u8-expr-elem"))
+        .expect("parser should accept the P3 component");
+
+    // Sanity: this fixture must actually trigger a non-zero shift, i.e. some
+    // pulseengine:async imports get prepended. Otherwise the test is vacuous.
+    let fused = fuser.fuse().expect("fuse should succeed");
+    let k = collect_pulseengine_async_imports(&fused).len();
+    assert!(
+        k > 0,
+        "fixture must prepend at least one pulseengine:async import to \
+         exercise the shift; got {k}"
+    );
+
+    let b_idx = func_export_index(&fused, "b").expect("fused core module must export function `b`");
+    let elem_refs = elem_expr_ref_func_indices(&fused);
+    assert_eq!(
+        elem_refs.len(),
+        1,
+        "expected exactly one expression-form elem ref.func, got {elem_refs:?}"
+    );
+    assert_eq!(
+        elem_refs[0], b_idx,
+        "element-segment ref.func must be relocated to track the (shifted) \
+         exported index of `$b` ({b_idx}), not left stale at an intrinsic \
+         import slot (was {})",
+        elem_refs[0]
+    );
+}
+
+#[test]
+fn p3_k0_control_expr_form_elem_ref_func_unchanged() {
+    let wat_src = build_p2_component_with_expr_elem_wat();
+    let bytes = match wat::parse_str(wat_src) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("skipping: wat crate cannot parse this fixture: {e}");
+            return;
+        }
+    };
+
+    let mut fuser = Fuser::new(FuserConfig::default());
+    fuser
+        .add_component_named(&bytes, Some("p2-expr-elem"))
+        .expect("parser should accept the P2 component");
+
+    let fused = fuser.fuse().expect("fuse should succeed");
+    // Control: no intrinsic imports, so no shift.
+    assert_eq!(
+        collect_pulseengine_async_imports(&fused).len(),
+        0,
+        "k=0 control must not prepend any pulseengine:async imports"
+    );
+
+    let b_idx = func_export_index(&fused, "b").expect("fused core module must export function `b`");
+    let elem_refs = elem_expr_ref_func_indices(&fused);
+    assert_eq!(
+        elem_refs.len(),
+        1,
+        "expected one elem ref.func, got {elem_refs:?}"
+    );
+    assert_eq!(
+        elem_refs[0], b_idx,
+        "k=0: element-segment ref.func must match `$b`'s exported index"
+    );
+}

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -3221,6 +3221,68 @@ loss-scenarios:
       single-module identity case; the multi-module cases fail on
       pre-fix code (non-vacuity confirmed).
 
+  - id: LS-M-9
+    title: P3-async lowering does not relocate ref.func in expression-form element segments
+    uca: UCA-M-1
+    hazards: [H-1, H-3]
+    type: inadequate-control-algorithm
+    scenario: >
+      `p3_async.rs::shift_function_indices` (the P3-async lowering pass)
+      prepends `k` `pulseengine:async` function imports and shifts every
+      defined-function reference up by `k` so existing references still
+      resolve. The `ReindexedElementItems::Functions(_)` form was bumped,
+      but the `Expressions(_)` form (a `funcref`/typed-ref element segment
+      whose items are const-expressions like `(ref.func $b)`) was a
+      comment-only NO-OP — neither bumped NOR errored, despite the comment
+      claiming such components would be "flagged". So a `ref.func` index
+      inside an expression-form element segment was left STALE after the
+      shift: the table slot then points at one of the prepended intrinsic
+      imports (e.g. `stream_new`, a `() -> i64` host func) instead of the
+      intended function. A `call_indirect` through that slot invokes the
+      wrong function with an incompatible signature → trap, or (if
+      signatures happen to align) a silent wrong call [UCA-M-1 wrong
+      reference target / H-1 behaves differently from composed input /
+      H-3 index confusion]. Violates SC-3 ("index remapping must account
+      for all reference sites: instructions, init expressions, element
+      segments, …"). End-to-end reproduced: a P3-async component
+      (`stream<u8>` → k=5) with `(elem (i32.const 0) funcref (ref.func $b))`
+      fused to an output where `$b`'s export was bumped 2→7 but the elem
+      ref stayed 2 (= stream_new); a k=0 control was correct, isolating
+      the bug to this shift. The third site of the missing-reference-site
+      relocation class (with LS-M-8 segment indices). Surfaced by a Mythos
+      discovery pass on p3_async.rs.
+    causal-factors:
+      - >-
+        The shift handled Functions-form element segments but the
+        Expressions-form arm silently skipped ref.func indices
+      - >-
+        ReindexedElementItems::Expressions held opaque encoded ConstExpr
+        bytes, so the index was not accessible to the shift at that point
+      - >-
+        No test asserted post-shift ref.func/call targets for an
+        expression-form element segment under P3 lowering (existing tests
+        pinned import emission, not relocation of this reference site)
+    process-model-flaw: >
+      The lowering's enumeration of "function-reference sites to shift"
+      omitted ref.func inside element-segment expressions — the same
+      class as LS-M-8 (segment-index operands) and SC-3's mandate.
+    status: approved
+    priority: high
+    fix: >
+      `ReindexedElementItems::Expressions` now carries the structured,
+      merger-reindexed `Vec<ParsedConstExpr>` instead of opaque
+      `Vec<ConstExpr>` (encoding deferred to `encode_element_segment` at
+      emit), so the function index stays accessible. The P3 shift arm
+      bumps `ParsedConstExpr::RefFunc(idx)` via the same `bump` closure as
+      the Functions arm; GlobalGet/RefNull/scalars are untouched (already
+      finalized by the merger; P3 prepends only function imports). Pinned
+      by tests/p3_async_lowering.rs: `p3_shift_relocates_expr_form_elem_ref_func`
+      (k=5: the elem ref.func equals $b's shifted export index, not an
+      intrinsic-import slot) + a k=0 control; the e2e test fails on pre-fix
+      code (non-vacuity confirmed). Mythos-verified: the deferred encode is
+      byte-identical to the prior eager path across all ParsedConstExpr
+      kinds × all segment modes, and only RefFunc is bumped.
+
   - id: LS-D-1
     title: remapped DWARF emits a wrong code address for a fused function
     uca: UCA-M-9


### PR DESCRIPTION
Found by a Mythos discovery pass on `p3_async.rs`. Fixes a confirmed end-to-end index-relocation bug (H-1/H-3, SC-3 violation) — the third site of the missing-reference-site class (with #260's segment indices).

## Bug
`shift_function_indices` prepends `k` `pulseengine:async` imports and shifts defined-function refs up by `k`. The `Functions`-form element arm bumped correctly, but the `Expressions`-form arm was a comment-only NO-OP (no bump, no error). So a `(ref.func $b)` inside an expression-form element segment stayed stale → the table slot pointed at a prepended intrinsic import (e.g. `stream_new`) instead of `$b` → wrong `call_indirect` / trap. Reproduced end-to-end: `stream<u8>` (k=5) component with `(elem (i32.const 0) funcref (ref.func $b))` → `$b` bumped 2→7 but elem ref stayed 2; a k=0 control was correct.

## Fix
`ReindexedElementItems::Expressions` now carries structured `Vec<ParsedConstExpr>` (encoding deferred to emit) instead of opaque `Vec<ConstExpr>`, so the index stays accessible. The shift arm bumps `ParsedConstExpr::RefFunc(idx)` via the same `bump` closure as Functions; GlobalGet/RefNull/scalars untouched (already merger-finalized; P3 prepends only function imports).

## Verification
- `p3_shift_relocates_expr_form_elem_ref_func` (k=5: elem ref == `$b`'s shifted index, not an intrinsic slot) + k=0 control; fails on pre-fix code (non-vacuity confirmed). segments lib 20/20 (incl. #257/#260 regression); workspace exit 0; clippy/fmt clean.
- **Mythos clean-room pass: NO PROVABLE FINDING** — the deferred encode is **byte-identical** to the prior eager path across all ParsedConstExpr kinds × all segment modes (RefFunc/RefNull-concrete+abstract/GlobalGet, Passive/Declared/Active); only RefFunc is bumped (GlobalGet/RefNull verified untouched); the `&mut ElementSection` sink preserves one-in/one-out ordering; RefNull+typed-ref element validates. Full report next comment.

## Tier-5
`segments.rs` + `p3_async.rs` → Mythos pass done, `mythos-pass-done` applied. (lib.rs is the encode call-site only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)