### PR TITLE
fix(p3-stream): don't pair cross-component streams on local type index (LS-R-16)

### DIFF
--- a/meld-core/src/p3_stream.rs
+++ b/meld-core/src/p3_stream.rs
@@ -69,6 +69,24 @@ impl StreamElement {
         let inner = desc.strip_prefix("stream<")?.strip_suffix('>')?;
         Some(StreamElement::Typed(inner.trim().to_string()))
     }
+
+    /// Whether this element type is safe to PAIR across components.
+    ///
+    /// A bare `Type(N)` descriptor is a component-LOCAL type index —
+    /// component A's `Type(5)` and component B's `Type(5)` are unrelated —
+    /// so it is not a valid cross-component key (LS-R-16). Primitive
+    /// descriptors (`Primitive(..)` / scalar names) and the untyped stream
+    /// are globally stable and pairable; a local-index descriptor is not
+    /// (pairing on it risks an over-match that drives the bridge emitter to
+    /// wire incompatible streams). Canonicalising `Type(N)` to a structural
+    /// descriptor — which would make aggregate-element streams pairable — is
+    /// tracked follow-up; until then such streams stay host-routed.
+    fn is_cross_component_pairable(&self) -> bool {
+        match self {
+            StreamElement::Untyped => true,
+            StreamElement::Typed(s) => !s.contains("Type("),
+        }
+    }
 }
 
 /// A component's role on a particular stream element type.
@@ -230,6 +248,22 @@ pub fn pair_streams(
                     // Honest candidate only when element types match —
                     // see the ADR-3 precision boundary.
                     if p_elem != c_elem {
+                        continue;
+                    }
+                    // LS-R-16: a non-primitive stream element type is recorded
+                    // as `Type(N)` where N is a COMPONENT-LOCAL type index, so
+                    // matching it across components is unsound — two DIFFERENT
+                    // element types that collide on the same local index N
+                    // would string-match and manufacture a false pair that
+                    // drives the bridge emitter to wire incompatible streams
+                    // (H-3.1 type confusion), and the same real type at
+                    // different indices would be missed. Until element types
+                    // are canonicalised to a structural cross-component key
+                    // (tracked follow-up), conservatively decline to pair on
+                    // local-index descriptors — the streams stay host-routed,
+                    // which is safe. Primitives serialise as a stable
+                    // `Primitive(..)` descriptor and remain pairable.
+                    if !p_elem.is_cross_component_pairable() {
                         continue;
                     }
                     let candidate = StreamPair {
@@ -960,6 +994,38 @@ mod tests {
         assert_eq!(p.consumer.role, StreamRole::Consumer);
         assert_eq!(p.element, typed("U8"));
         assert_eq!(p.mode, StreamMemoryMode::CrossMemory);
+    }
+
+    /// LS-R-16: two DIFFERENT non-primitive stream element types that
+    /// collide on the same component-LOCAL type index (`Type(0)` in each
+    /// component, but unrelated types) must NOT be paired — pairing on a
+    /// local-index descriptor would manufacture a false pair that drives the
+    /// bridge emitter to wire incompatible streams. They stay host-routed.
+    #[test]
+    fn local_index_element_descriptors_do_not_pair() {
+        // Producer's element is its local Type(0); consumer's element is a
+        // DIFFERENT type that happens to also sit at its local Type(0).
+        let roles = vec![
+            vec![(typed("Type(0)"), StreamRole::Producer)],
+            vec![(typed("Type(0)"), StreamRole::Consumer)],
+        ];
+        let pairs = pair_streams(&roles, &[(0, 1)], StreamMemoryMode::CrossMemory);
+        assert!(
+            pairs.is_empty(),
+            "local-index `Type(N)` descriptors are not a valid cross-component \
+             key and must not be paired (over-match would wire incompatible \
+             streams); got {pairs:?}"
+        );
+        // Sanity: primitive descriptors on the same shape DO still pair.
+        let prim_roles = vec![
+            vec![(typed("Primitive(U8)"), StreamRole::Producer)],
+            vec![(typed("Primitive(U8)"), StreamRole::Consumer)],
+        ];
+        assert_eq!(
+            pair_streams(&prim_roles, &[(0, 1)], StreamMemoryMode::CrossMemory).len(),
+            1,
+            "primitive stream element types remain pairable"
+        );
     }
 
     /// ADR-3 gating fixture: a producer and a consumer of the same

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -1711,6 +1711,72 @@ loss-scenarios:
       post-fix match arms of both walkers descend into and skip the
       identical variant sets.
 
+  - id: LS-R-16
+    title: Cross-component stream pairing matches non-primitive element types by local type index
+    uca: UCA-R-5
+    hazards: [H-1, H-3.1]
+    type: inadequate-control-algorithm
+    scenario: >
+      The cross-component stream-pair detector (`p3_stream.rs::pair_streams`)
+      pairs a producer's `stream<T>` write endpoint with a consumer's read
+      endpoint when their element-type DESCRIPTORS are equal. For a
+      PRIMITIVE element the descriptor is the globally-stable `Primitive(..)`.
+      But for any NON-primitive element (record/list/tuple/variant/resource/
+      aliased type) the parser records `stream<Type(N)>` where N is a
+      COMPONENT-LOCAL type index — and `pair_streams` compared those strings
+      literally across two different components, exactly the "match on a raw
+      local index, not a cross-component key" pattern the module's own header
+      warns against (component A's `Type(5)` ≠ component B's `Type(5)`). Two
+      failure modes: (A) UNDER-MATCH — the same real type T at different
+      local indices in producer vs consumer fails to pair (benign: the
+      bridge is simply not emitted, streams stay host-routed); (B)
+      OVER-MATCH — two DIFFERENT element types that collide on the same
+      local index N (e.g. each component's `Type(0)`) string-match and
+      manufacture a false pair, which then drives `p3_bridge::emit_stream_bridge`
+      to rewire the producer's writes directly into the consumer's reads,
+      bypassing the host with TWO DIFFERENT on-wire element layouts →
+      type confusion / semantic drift / potential OOB on variable-width T
+      [H-1 fused output differs from composed input / H-3.1 misrouted data
+      with wrong layout]. `validate_stream_pair_graph` cannot catch (B)
+      because it compares the same local-index descriptor strings. Finding
+      (B) confirmed at API level; end-to-end execution divergence
+      plausible-but-unproven (requires two distinct types colliding on the
+      same local index across the two fused components). Surfaced by a
+      Mythos discovery pass on p3_stream.rs.
+    causal-factors:
+      - >-
+        Non-primitive stream element types are keyed by a component-local
+        `Type(N)` index, not a cross-component-stable structural descriptor
+      - >-
+        pair_streams (and validate_stream_pair_graph) compare these
+        local-index strings literally across components
+      - >-
+        existing tests exercise only primitive descriptors (U8/S32), never
+        the `Type(N)` form the parser actually emits for aggregate elements
+    process-model-flaw: >
+      The pairing model assumed the element-type descriptor is a stable
+      cross-component identity; for aggregate/handle element types it is a
+      component-local index — the same false-key class as #245 (cabi_realloc)
+      and #256 (resource_graph definer).
+    status: approved
+    priority: high
+    fix: >
+      Conservative first increment (this change): `pair_streams` declines to
+      pair when the element descriptor is a local-index `Type(N)` form
+      (`StreamElement::is_cross_component_pairable` = false for `Typed`
+      strings containing `Type(`). This ELIMINATES the over-match (B) safety
+      hazard — incompatible aggregate streams stay host-routed rather than
+      driving the emitter — with NO regression to correct primitive-stream
+      pairing (primitives serialise as the stable `Primitive(..)`). The
+      benign under-match (A) for aggregate streams remains (they stay
+      host-routed, their current behaviour). Pinned by
+      p3_stream::tests::local_index_element_descriptors_do_not_pair (two
+      colliding `Type(0)` descriptors → 0 pairs; primitive control → 1
+      pair). The COMPLETE fix — canonicalising `Type(N)` to a structural
+      cross-component descriptor so aggregate-element streams pair correctly
+      (and handling resource-element identity, which overlaps the
+      resource_graph attribution work) — is tracked as follow-up.
+
   # ==========================================================================
   # Merger scenarios
   # ==========================================================================


### PR DESCRIPTION
Found by a Mythos discovery pass on `p3_stream.rs`. Conservative fix for the safety-relevant over-match (Finding B); the complete structural-canonicalization is tracked in #264.

## Bug
`pair_streams` matched producer/consumer stream endpoints by element-type descriptor. Primitives serialise as the stable `Primitive(..)`, but non-primitive elements are `stream<Type(N)>` with N a **component-local** type index — compared literally across components. Two different element types colliding on the same local index N would string-match → false pair → drives `p3_bridge::emit_stream_bridge` to wire incompatible streams (H-3.1 type confusion). Confirmed at API level; end-to-end plausible-but-unproven.

## Fix (conservative increment)
Decline to pair when the element descriptor is a local-index `Type(N)` form (`is_cross_component_pairable`). Eliminates the over-match (incompatible aggregate streams stay host-routed) with **no regression** to correct primitive-stream pairing. The benign under-match (aggregate streams not paired) remains; the complete fix (canonicalize `Type(N)` to a structural cross-component descriptor, incl. resource-element identity overlapping #256) is **#264**.

## Verification
- `local_index_element_descriptors_do_not_pair`: two colliding `Type(0)` descriptors → 0 pairs; primitive control → 1 pair.
- p3_stream 28/28; workspace exit 0; clippy/fmt clean. The guard is safe-by-construction (only adds a `continue` — can never create a pair).
- **Mythos clean-room pass: pending** (next comment).

## Tier-5
`p3_stream.rs` → Mythos pass to follow + `mythos-pass-done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)