### PR TITLE
fix(component_wrap): map func-import ordinal to mixed-kind import slot (LS-W-2)

### DIFF
--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -938,14 +938,41 @@ fn assemble_component(
     // -----------------------------------------------------------------------
     let instance_map = build_instance_func_map(source);
 
+    // `fused_info.func_imports` is a FUNC-ONLY ordinal list, but
+    // `merged.imports` is a MIXED-KIND vector (Function/Global/Table/Memory
+    // interleaved in declaration order). Precompute the positions of the
+    // Function-kind entries in `merged.imports` so a func ordinal maps to the
+    // correct slot. Without this, a non-func import preceding a func import
+    // shifts every subsequent func's metadata (component_idx) to the wrong
+    // entry, mis-routing resource ops (H-8/H-2 class). This is the inverse of
+    // the position→func-ordinal mapping in `lib.rs` (`merged_func_idx`).
+    let func_import_positions: Vec<usize> = merged
+        .imports
+        .iter()
+        .enumerate()
+        .filter(|(_, i)| matches!(i.entity_type, EntityType::Function(_)))
+        .map(|(p, _)| p)
+        .collect();
+    // The count of Function entries in `merged.imports` must equal the
+    // func-import count; otherwise the ordinal→position mapping is unsound.
+    debug_assert_eq!(
+        func_import_positions.len(),
+        fused_info.func_imports.len(),
+        "func-import count mismatch: {} Function entries in merged.imports vs \
+         {} fused func_imports",
+        func_import_positions.len(),
+        fused_info.func_imports.len()
+    );
+
     let mut import_resolutions: Vec<ImportResolution> = Vec::new();
     for (import_idx, (module_name, field_name, _type_idx)) in
         fused_info.func_imports.iter().enumerate()
     {
-        // Look up the source component_idx from the merged import metadata
-        let comp_idx = merged
-            .imports
+        // Look up the source component_idx from the merged import metadata.
+        // Map the func ordinal to its position in the mixed-kind import vector.
+        let comp_idx = func_import_positions
             .get(import_idx)
+            .and_then(|&p| merged.imports.get(p))
             .and_then(|imp| imp.component_idx);
 
         // Category A: [export]-prefixed modules provide canon resource operations
@@ -3946,5 +3973,103 @@ mod tests {
             source_string_encoding_option(parser::CanonStringEncoding::CompactUtf16),
             CanonicalOption::CompactUTF16
         ));
+    }
+
+    /// Build a `MergedImport` of the given entity kind, carrying a source
+    /// component index, for the func-import position mapping tests below.
+    fn mk_import(kind: wasm_encoder::EntityType, comp: usize) -> crate::merger::MergedImport {
+        crate::merger::MergedImport {
+            module: "m".to_string(),
+            name: "n".to_string(),
+            entity_type: kind,
+            component_idx: Some(comp),
+        }
+    }
+
+    /// Compute the same func-ordinal → import-position mapping that
+    /// `assemble_component` precomputes, so the routing logic is testable
+    /// without driving the private assembly path.
+    fn func_import_positions(imports: &[crate::merger::MergedImport]) -> Vec<usize> {
+        imports
+            .iter()
+            .enumerate()
+            .filter(|(_, i)| matches!(i.entity_type, wasm_encoder::EntityType::Function(_)))
+            .map(|(p, _)| p)
+            .collect()
+    }
+
+    /// Regression for the func-import / component-idx desync (H-8/H-2 class).
+    ///
+    /// `merged.imports` is a MIXED-KIND vector while `fused_info.func_imports`
+    /// is FUNC-ONLY. A non-func import preceding a func import shifts every
+    /// later func's `component_idx` lookup. With `merged.imports =
+    /// [Global(comp 0), Func(comp 1)]`, the lone func import is ordinal 0; its
+    /// true `component_idx` is 1 (it lives at position 1 in the mixed vector).
+    #[test]
+    fn func_import_comp_idx_skips_non_func_imports() {
+        use wasm_encoder::{EntityType, GlobalType, ValType};
+        let imports = vec![
+            mk_import(
+                EntityType::Global(GlobalType {
+                    val_type: ValType::I32,
+                    mutable: false,
+                    shared: false,
+                }),
+                0,
+            ),
+            mk_import(EntityType::Function(0), 1),
+        ];
+
+        let positions = func_import_positions(&imports);
+        // The single func import maps to position 1, not 0.
+        assert_eq!(positions, vec![1]);
+
+        // Corrected lookup: func ordinal 0 → position 1 → comp_idx 1.
+        let func_ordinal = 0usize;
+        let comp_idx = positions
+            .get(func_ordinal)
+            .and_then(|&p| imports.get(p))
+            .and_then(|imp| imp.component_idx);
+        assert_eq!(
+            comp_idx,
+            Some(1),
+            "func import must route to its own component, not the preceding global's"
+        );
+
+        // Non-vacuity: the OLD buggy logic (`merged.imports.get(import_idx)`)
+        // would read position 0 (the Global) and yield comp_idx 0 — the wrong
+        // component. Demonstrate the two disagree precisely where the bug bit.
+        let old_buggy = imports.get(func_ordinal).and_then(|imp| imp.component_idx);
+        assert_eq!(old_buggy, Some(0), "sanity: old logic indexes the Global");
+        assert_ne!(
+            old_buggy, comp_idx,
+            "fix must change behavior on the mixed-kind case"
+        );
+    }
+
+    /// The common all-func-imports case must be the identity mapping, so the
+    /// fix introduces NO behavior change for the overwhelmingly common shape
+    /// (every import is a function — positions == [0, 1, 2, ...]).
+    #[test]
+    fn func_import_positions_identity_for_all_func_imports() {
+        use wasm_encoder::EntityType;
+        let imports: Vec<_> = (0..4)
+            .map(|i| mk_import(EntityType::Function(0), i))
+            .collect();
+
+        let positions = func_import_positions(&imports);
+        assert_eq!(positions, vec![0, 1, 2, 3], "must be identity");
+
+        // Every func ordinal resolves to its own component, and the corrected
+        // lookup is bit-for-bit identical to the old `get(import_idx)` path.
+        for ordinal in 0..imports.len() {
+            let new = positions
+                .get(ordinal)
+                .and_then(|&p| imports.get(p))
+                .and_then(|imp| imp.component_idx);
+            let old = imports.get(ordinal).and_then(|imp| imp.component_idx);
+            assert_eq!(new, old, "identity case: no behavior change at {ordinal}");
+            assert_eq!(new, Some(ordinal));
+        }
     }
 }

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -3020,6 +3020,72 @@ loss-scenarios:
       Multi-memory WASI import lowering (PR #20). Per-import Memory(N)
       and Realloc(N) via import_memory_indices/import_realloc_indices.
 
+  - id: LS-W-2
+    title: Wrapper reads func-import source component from the wrong mixed-kind import slot
+    uca: UCA-W-2
+    hazards: [H-2, H-8]
+    type: inadequate-control-algorithm
+    scenario: >
+      `assemble_component` (component_wrap.rs) iterates the func-only
+      `fused_info.func_imports` with an enumeration index `import_idx` and
+      read each func import's source-component identity via
+      `merged.imports.get(import_idx)`. But `merged.imports` is a
+      MIXED-KIND vector (Function/Global/Table/Memory imports interleaved
+      in declaration order), so `import_idx` (a func ORDINAL) does not
+      index the matching entry when any non-func import precedes a func
+      import. The func import's `comp_idx` was then taken from the wrong
+      slot (e.g. with `merged.imports = [Global(comp 0), Func(comp 1)]`
+      the lone func read `comp_idx = Some(0)` instead of `1`). That wrong
+      component identity feeds (i) `find_task_return_for_import` (P3
+      task-return result-type search — has an all-components fallback,
+      partially self-healing) and (ii) `ImportResolution::LocalResource
+      { component_idx }` → `ht_export_suffix(cidx, ..)`, so a resource
+      handle op (drop/new/rep) is routed using the WRONG component's
+      handle-table suffix: the direct lookup misses and the op falls back
+      / mis-routes [UCA-W-2 / H-8 wrong-table handle deref / H-2]. Same
+      "guard present in one site, missing in its sibling" shape as the
+      rest of this sweep — the sibling `lib.rs:1119` handles the same
+      mixed-kind vector correctly by counting Function entries. The index
+      desync is confirmed end-to-end (real Merger::merge output; the line
+      executes for every func import); an OBSERVABLE miscompile requires
+      an UNRESOLVED non-func import (external global/table, or the
+      shared-memory Memory import) ordered before an unresolved
+      resource-op/task-return func import — reachable but not in the
+      standard wit-bindgen fixtures (whose non-func core imports resolve
+      internally and don't survive into merged.imports). Surfaced by a
+      Mythos discovery pass on component_wrap.rs.
+    causal-factors:
+      - >-
+        A func-only ordinal was used to index the mixed-kind
+        `merged.imports` vector (the sibling lib.rs:1119 filters to
+        Function entries; this site did not)
+      - >-
+        No test placed an unresolved non-func import before a func import
+        in merged.imports (standard fixtures resolve non-func imports
+        internally, hiding the desync)
+    process-model-flaw: >
+      The wrapper's model assumed `fused_info.func_imports` and
+      `merged.imports` share an index space; they do not — merged.imports
+      is mixed-kind. The func index → import-vector slot must be mapped by
+      Function-entry position, the same correction lib.rs:1119 already
+      applies in the inverse direction.
+    status: approved
+    priority: high
+    fix: >
+      Precompute `func_import_positions` (the positions of Function-kind
+      entries in `merged.imports`) and read `merged.imports[
+      func_import_positions[import_idx]]`, mirroring lib.rs:1119. The
+      output import section is emitted from `merged.imports` IN ORDER
+      (lib.rs:1538) and re-parsed in order into `fused_info.func_imports`,
+      so the i-th Function entry corresponds 1:1 to func_imports[i] —
+      verified by reading the emit/parse paths; `debug_assert_eq!` guards
+      the count equality (equal by construction). The all-func-imports
+      common case is the identity mapping (no behaviour change). Pinned by
+      func_import_comp_idx_skips_non_func_imports (mixed-kind
+      [Global(c0), Func(c1)] → comp_idx Some(1), with the old `.get(0)`
+      path asserted to yield the wrong Some(0) — non-vacuity) and
+      func_import_positions_identity_for_all_func_imports.
+
   - id: LS-M-5
     title: Multiply-instantiated module produces corrupt merged output
     uca: UCA-M-9


### PR DESCRIPTION
Found by a Mythos discovery pass on `component_wrap.rs` — the final Tier-5 file in the sweep. Same asymmetry shape as the rest: a guard present in one site, missing in its sibling.

## Bug
`assemble_component` indexed the func-only `fused_info.func_imports` with `import_idx` but read `merged.imports.get(import_idx)` — and `merged.imports` is a **mixed-kind** vector (Function/Global/Table/Memory interleaved). When a non-func import precedes a func import, the func's source-component `comp_idx` is read from the wrong slot. E.g. `merged.imports = [Global(comp 0), Func(comp 1)]` → the func read `comp_idx = Some(0)` instead of `1`. The wrong identity feeds `find_task_return_for_import` (self-healing fallback) and `LocalResource{component_idx}` → `ht_export_suffix` → resource op mis-routed to the wrong component's handle table (H-8/H-2). The sibling `lib.rs:1119` already handles the same vector correctly.

## Fix
Precompute `func_import_positions` (positions of Function entries in `merged.imports`) and read `merged.imports[func_import_positions[import_idx]]`, mirroring lib.rs:1119. The output import section is emitted from `merged.imports` in order (lib.rs:1538) and re-parsed in order, so the i-th Function entry ↔ `func_imports[i]` 1:1 (verified by reading the emit/parse paths); `debug_assert_eq!` guards count-equality. All-func-imports common case is identity (no behaviour change).

## Verification
- `func_import_comp_idx_skips_non_func_imports` (mixed-kind → comp_idx Some(1); old `.get(0)` asserted to yield wrong Some(0) — non-vacuity) + `func_import_positions_identity_for_all_func_imports`. clippy 0; full suite exit 0; wit_bindgen_runtime 73 + golden_e2e + LS-CP-6 green.
- **Order-correspondence (the load-bearing correctness question) verified by reading the code**: `lib.rs:1538` emits the output import section iterating `merged.imports` in order (no filter/reorder); `parse_fused_module` reads it back in order → `fused_info.func_imports[i]` is the i-th Function in `merged.imports`. Count-equality holds the same way.
- Full adversarial Mythos clean-room pass: re-running (the first attempt hit a transient server rate-limit); result will be posted before merge.

## Tier-5
`component_wrap.rs` → Mythos pass to follow as comment + `mythos-pass-done` label before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)