### PR TITLE
test(ls-gate): wire 10 sweep regression tests to the LS-N gate prefix

### DIFF
--- a/meld-core/src/component_wrap.rs
+++ b/meld-core/src/component_wrap.rs
@@ -4006,7 +4006,7 @@ mod tests {
     /// [Global(comp 0), Func(comp 1)]`, the lone func import is ordinal 0; its
     /// true `component_idx` is 1 (it lives at position 1 in the mixed vector).
     #[test]
-    fn func_import_comp_idx_skips_non_func_imports() {
+    fn ls_w_2_func_import_comp_idx_skips_non_func_imports() {
         use wasm_encoder::{EntityType, GlobalType, ValType};
         let imports = vec![
             mk_import(

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -4526,7 +4526,7 @@ mod tests {
     /// two components' assignments (which feed `global_index_map`) must point
     /// at DIFFERENT positions. Pre-fix this collapsed to a single slot.
     #[test]
-    fn test_global_import_type_mismatch_not_deduped() {
+    fn ls_m_10_test_global_import_type_mismatch_not_deduped() {
         use crate::resolver::{DependencyGraph, UnresolvedImport};
 
         let graph = DependencyGraph {

--- a/meld-core/src/p3_stream.rs
+++ b/meld-core/src/p3_stream.rs
@@ -1002,7 +1002,7 @@ mod tests {
     /// local-index descriptor would manufacture a false pair that drives the
     /// bridge emitter to wire incompatible streams. They stay host-routed.
     #[test]
-    fn local_index_element_descriptors_do_not_pair() {
+    fn ls_r_16_local_index_element_descriptors_do_not_pair() {
         // Producer's element is its local Type(0); consumer's element is a
         // DIFFERENT type that happens to also sit at its local Type(0).
         let roles = vec![

--- a/meld-core/src/parser.rs
+++ b/meld-core/src/parser.rs
@@ -5473,7 +5473,7 @@ mod tests {
     /// `list<option<borrow<R>>>` → Elements with exactly one inner resource,
     /// guarded by the option's Some discriminant (value=1).
     #[test]
-    fn uca_a16_list_of_option_borrow_emits_guarded_inner_resource() {
+    fn ls_a_23_uca_a16_list_of_option_borrow_emits_guarded_inner_resource() {
         use crate::resolver::CopyLayout;
         let pc = empty_parsed_component();
         let ty = ComponentValType::List(Box::new(ComponentValType::Option(Box::new(

--- a/meld-core/src/resolver.rs
+++ b/meld-core/src/resolver.rs
@@ -5506,7 +5506,7 @@ mod tests {
     /// layouts, so the adapter zipped them misaligned and fell back to
     /// byte_multiplier=1 (undersized alloc + truncated cross-memory copy).
     #[test]
-    fn test_lsr12_fixed_size_list_copy_layout_alignment() {
+    fn ls_r_15_test_lsr12_fixed_size_list_copy_layout_alignment() {
         use crate::parser::{ComponentValType as V, PrimitiveValType as P};
         let comp = empty_parsed_component();
         // list<list<u64>, 2>

--- a/meld-core/src/segments.rs
+++ b/meld-core/src/segments.rs
@@ -1005,7 +1005,7 @@ mod tests {
     /// so the re-emitted module was rejected ("type mismatch: expected
     /// externref, found (ref $type)").
     #[test]
-    fn test_typed_ref_element_segment_roundtrips_and_validates() {
+    fn ls_a_21_test_typed_ref_element_segment_roundtrips_and_validates() {
         let src = r#"(module (type (func)) (func) (elem (ref null 0) (ref.func 0)))"#;
         let module_bytes = wat::parse_str(src).expect("wat compiles");
 

--- a/meld-core/tests/adapter_safety.rs
+++ b/meld-core/tests/adapter_safety.rs
@@ -2928,7 +2928,7 @@ fn test_sr17_utf16_to_utf8_malformed_surrogate_matrix() {
 /// several cases emit MORE than one U+FFFD; the per-case derivations spell
 /// out the exact count.
 #[test]
-fn test_sr17_utf8_to_utf16_malformed_matrix() {
+fn ls_p_20_test_sr17_utf8_to_utf16_malformed_matrix() {
     // (input UTF-8 bytes, expected callee code-unit-sum, label)
     //
     // Hand-derivations for the malformed cases (FFFD = 65533):

--- a/meld-core/tests/p3_async_lowering.rs
+++ b/meld-core/tests/p3_async_lowering.rs
@@ -736,7 +736,7 @@ fn elem_expr_ref_func_indices(fused: &[u8]) -> Vec<u32> {
 }
 
 #[test]
-fn p3_shift_relocates_expr_form_elem_ref_func() {
+fn ls_m_9_p3_shift_relocates_expr_form_elem_ref_func() {
     let wat_src = build_stream_u8_component_with_expr_elem_wat();
     let bytes = match wat::parse_str(wat_src) {
         Ok(b) => b,

--- a/meld-core/tests/reftype_fidelity.rs
+++ b/meld-core/tests/reftype_fidelity.rs
@@ -171,7 +171,7 @@ fn case1_typed_ref_table_element_preserved() {
 // or collapsed element type causes a validation failure here.
 // ---------------------------------------------------------------------------
 #[test]
-fn case2_typed_ref_table_used_by_call_indirect() {
+fn ls_a_22_case2_typed_ref_table_used_by_call_indirect() {
     let wat = r#"
 (component
   (core module $m

--- a/meld-core/tests/segidx_remap.rs
+++ b/meld-core/tests/segidx_remap.rs
@@ -340,7 +340,7 @@ fn build_elem_probe_component(marker: i32, export_name: &str) -> Vec<u8> {
 }
 
 #[test]
-fn segidx_elem_two_modules_distinct_segments() {
+fn ls_m_8_segidx_elem_two_modules_distinct_segments() {
     // Module A's elem segment references its konst (returns 0x0A0A);
     // module B's references its konst (returns 0x0B0B). After fusion the
     // element sections concatenate; without elem-index remap, B's


### PR DESCRIPTION
## What

Renames 10 existing regression tests so the **LS-N verification gate** (`tools/run_ls_verification.py`) can discover them by its `ls_<id>_` prefix convention. **Rename-only — no test body, assertion, or non-test code changed** (10 files, one `fn` signature line each).

## Why

The Tier-5 missing-sibling-guard sweep added genuine regression tests for these approved scenarios — but under *descriptive* names the gate can't match:

| LS-id | file | renamed test |
|---|---|---|
| LS-W-2 | component_wrap.rs | `ls_w_2_func_import_comp_idx_skips_non_func_imports` |
| LS-R-15 | resolver.rs | `ls_r_15_test_lsr12_fixed_size_list_copy_layout_alignment` |
| LS-R-16 | p3_stream.rs | `ls_r_16_local_index_element_descriptors_do_not_pair` |
| LS-A-21 | segments.rs | `ls_a_21_test_typed_ref_element_segment_roundtrips_and_validates` |
| LS-A-22 | tests/reftype_fidelity.rs | `ls_a_22_case2_typed_ref_table_used_by_call_indirect` |
| LS-A-23 | parser.rs | `ls_a_23_uca_a16_list_of_option_borrow_emits_guarded_inner_resource` |
| LS-M-8 | tests/segidx_remap.rs | `ls_m_8_segidx_elem_two_modules_distinct_segments` |
| LS-M-9 | tests/p3_async_lowering.rs | `ls_m_9_p3_shift_relocates_expr_form_elem_ref_func` |
| LS-M-10 | merger.rs | `ls_m_10_test_global_import_type_mismatch_not_deduped` |
| LS-P-20 | tests/adapter_safety.rs | `ls_p_20_test_sr17_utf8_to_utf16_malformed_matrix` |

That had regressed the gate from the v0.31.0 audit's **45/45, 0-missing** to **45 passed / 10 missing** (advisory). The regressions were still caught by the normal Test job; this restores LS-N *attribution* so each approved scenario is gate-tracked again.

## Verification

- LS-N gate: **55 passed / 0 failed / 0 missing** (exit 0), independently re-run.
- Renamed tests still pass: lib 74/0, integration 0 failed.
- `git diff` confirmed every changed line is a `fn X` → `fn ls_<id>_X` rename — bodies byte-identical.

## Tier-5 note

Touches 6 Tier-5 source files (rename-only), so the Mythos gate applies. The fusion logic is **byte-identical to `main`** (already Mythos-passed when each fix originally merged); a rename emits no bytes and changes no control flow. Mythos disposition posted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)