### PR TITLE
feat(adapter): spec-faithful latin1+utf16 (CompactUTF16) transcoding (#253)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -122,6 +122,54 @@ pub(crate) fn emit_overflow_guard(body: &mut Function, len_local: u32, k: u32) {
     body.instruction(&Instruction::End);
 }
 
+/// Push the byte length of a copied string/list buffer onto the stack.
+///
+/// For a `latin1+utf16` string (the `Latin1` encoding, `byte_mult == 1`) the
+/// `(ptr, len)` length operand is **tagged** (see [`UTF16_TAG`]): tag set ⇒ the
+/// payload is UTF-16, so the byte length is `(len & !UTF16_TAG) * 2`; tag clear
+/// ⇒ Latin-1, byte length `len`. A same-encoding cross-memory copy
+/// ([`generate_memory_copy_adapter`]) must use this tag-aware byte count for
+/// both the `cabi_realloc` size and the `memory.copy` length — copying the raw
+/// tagged operand would copy `count | 0x8000_0000` bytes (~2 GiB OOB read).
+/// The length operand FORWARDED to the callee stays tagged; only the internal
+/// byte count is masked here.
+///
+/// For every other buffer (`byte_mult != 1`, or a non-Latin1 encoding) the
+/// length is an untagged element count, byte length `len * byte_mult`. A plain
+/// `list<u8>` (also `byte_mult == 1`) is unaffected: a legitimate byte count is
+/// `< 2^31` (the [`emit_overflow_guard`] bound), so the tag bit is clear and
+/// the tag-aware path returns `len` unchanged.
+fn emit_copy_byte_count(
+    func: &mut Function,
+    len_local: u32,
+    byte_mult: u32,
+    is_compact_utf16: bool,
+) {
+    if is_compact_utf16 {
+        // bytes = (len & UTF16_TAG) ? (len & !UTF16_TAG) * 2 : len
+        func.instruction(&Instruction::LocalGet(len_local));
+        func.instruction(&Instruction::I32Const(UTF16_TAG));
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Result(
+            wasm_encoder::ValType::I32,
+        )));
+        func.instruction(&Instruction::LocalGet(len_local));
+        func.instruction(&Instruction::I32Const(!UTF16_TAG));
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::I32Const(2));
+        func.instruction(&Instruction::I32Mul);
+        func.instruction(&Instruction::Else);
+        func.instruction(&Instruction::LocalGet(len_local));
+        func.instruction(&Instruction::End);
+    } else {
+        func.instruction(&Instruction::LocalGet(len_local));
+        if byte_mult > 1 {
+            func.instruction(&Instruction::I32Const(byte_mult as i32));
+            func.instruction(&Instruction::I32Mul);
+        }
+    }
+}
+
 /// Emit the hardened UTF-8 → code-point decoder for one code point.
 ///
 /// Reads the lead byte at `mem8[ptr_local + src_idx_local]`, decodes a full
@@ -858,6 +906,12 @@ fn emit_patch_nested_indirections(
     realloc_func: u32,
     caller_memory: u32,
     callee_memory: u32,
+    // True when the *callee* string encoding (this is a result-side,
+    // callee → caller copy) is `latin1+utf16` (CompactUtf16). A byte-granular
+    // inner buffer (`sub_elem_size == 1`) is then a tag-encoded string whose
+    // byte count must be masked/doubled. The inner (ptr, len) header keeps its
+    // original (tagged) length — this function rewrites only the pointer.
+    callee_compact_utf16: bool,
 ) {
     let indirections = collect_indirections(elem_ty, 0);
     if indirections.is_empty() {
@@ -945,8 +999,13 @@ fn emit_patch_nested_indirections(
         // side bulk-copy of the outer (ptr, len) keeps the original large
         // `len` — silent truncation and semantic drift between the fused
         // and composed executions.
+        let inner_compact_utf16 = callee_compact_utf16 && *sub_elem_size == 1;
         emit_overflow_guard(body, l_buf_len, *sub_elem_size);
-        if *sub_elem_size != 1 {
+        if inner_compact_utf16 {
+            // #253: byte count is tag-aware — (len & TAG) ? (len & !TAG)*2 : len.
+            emit_copy_byte_count(body, l_buf_len, 1, true);
+            body.instruction(&Instruction::LocalSet(l_buf_len));
+        } else if *sub_elem_size != 1 {
             body.instruction(&Instruction::LocalGet(l_buf_len));
             body.instruction(&Instruction::I32Const(*sub_elem_size as i32));
             body.instruction(&Instruction::I32Mul);
@@ -2107,26 +2166,31 @@ impl FactStyleGenerator {
                     })
                     .unwrap_or(1);
 
-                // Allocate: dest = cabi_realloc(0, 0, 1, len * byte_mult)
+                // A param-side buffer carries a latin1+utf16 (CompactUTF16,
+                // modelled as Latin1) string when the *caller* encoding is
+                // Latin1 and the data is byte-granular (byte_mult == 1). Its
+                // length operand is tag-encoded (UTF16_TAG): the byte count
+                // must be masked/doubled (`emit_copy_byte_count`) for the
+                // realloc size and the memory.copy length, while the length
+                // FORWARDED to the callee stays tagged. A plain list<u8>
+                // (also byte_mult == 1) is unaffected: its count is < 2^31,
+                // so the tag bit is clear and the tag-aware path returns `len`.
+                let is_compact_utf16 =
+                    options.caller_string_encoding == StringEncoding::Latin1 && byte_mult == 1;
+                let realloc_align = if is_compact_utf16 { 2 } else { 1 };
+
+                // Allocate: dest = cabi_realloc(0, 0, align, <byte count>)
                 emit_overflow_guard(&mut func, len_pos, byte_mult);
                 func.instruction(&Instruction::I32Const(0));
                 func.instruction(&Instruction::I32Const(0));
-                func.instruction(&Instruction::I32Const(1));
-                func.instruction(&Instruction::LocalGet(len_pos));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                func.instruction(&Instruction::I32Const(realloc_align));
+                emit_copy_byte_count(&mut func, len_pos, byte_mult, is_compact_utf16);
                 emit_checked_realloc(&mut func, callee_realloc, dest_local);
 
-                // Copy: memory.copy callee_mem caller_mem (dest, src, len * byte_mult)
+                // Copy: memory.copy callee_mem caller_mem (dest, src, <byte count>)
                 func.instruction(&Instruction::LocalGet(dest_local));
                 func.instruction(&Instruction::LocalGet(ptr_pos));
-                func.instruction(&Instruction::LocalGet(len_pos));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                emit_copy_byte_count(&mut func, len_pos, byte_mult, is_compact_utf16);
                 func.instruction(&Instruction::MemoryCopy {
                     src_mem: options.caller_memory,
                     dst_mem: options.callee_memory,
@@ -2152,6 +2216,8 @@ impl FactStyleGenerator {
                         options.callee_memory,
                         callee_realloc,
                         fixup_base,
+                        // Param-side: governed by the caller's string encoding.
+                        options.caller_string_encoding == StringEncoding::Latin1,
                     );
                 }
             } // end for each pointer pair
@@ -2261,6 +2327,11 @@ impl FactStyleGenerator {
                     crate::resolver::CopyLayout::Bulk { byte_multiplier } => *byte_multiplier,
                     crate::resolver::CopyLayout::Elements { element_size, .. } => *element_size,
                 };
+                // Param-side (caller → callee) tagged latin1+utf16 string: see
+                // the unconditional param-copy loop above.
+                let is_compact_utf16 =
+                    options.caller_string_encoding == StringEncoding::Latin1 && byte_mult == 1;
+                let realloc_align = if is_compact_utf16 { 2 } else { 1 };
 
                 // if (all guards in chain hold) { copy and replace ptr }
                 // — outer-guard ANDing matters for nested option/result/variant
@@ -2269,27 +2340,19 @@ impl FactStyleGenerator {
                 emit_conditional_guard_chain_flat(&mut func, cond, 0);
                 func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
 
-                // Allocate: new_ptr = cabi_realloc(0, 0, 1, len * byte_mult)
+                // Allocate: new_ptr = cabi_realloc(0, 0, align, <byte count>)
                 emit_overflow_guard(&mut func, len_local, byte_mult);
                 func.instruction(&Instruction::I32Const(0));
                 func.instruction(&Instruction::I32Const(0));
-                func.instruction(&Instruction::I32Const(1));
-                func.instruction(&Instruction::LocalGet(len_local));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                func.instruction(&Instruction::I32Const(realloc_align));
+                emit_copy_byte_count(&mut func, len_local, byte_mult, is_compact_utf16);
                 // Save as dest_ptr (reuse a scratch local)
                 emit_checked_realloc(&mut func, callee_realloc, dest_ptr_local);
 
-                // Copy: memory.copy callee caller (dest, src, len * byte_mult)
+                // Copy: memory.copy callee caller (dest, src, <byte count>)
                 func.instruction(&Instruction::LocalGet(dest_ptr_local));
                 func.instruction(&Instruction::LocalGet(ptr_local));
-                func.instruction(&Instruction::LocalGet(len_local));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                emit_copy_byte_count(&mut func, len_local, byte_mult, is_compact_utf16);
                 func.instruction(&Instruction::MemoryCopy {
                     src_mem: options.caller_memory,
                     dst_mem: options.callee_memory,
@@ -2331,19 +2394,29 @@ impl FactStyleGenerator {
             func.instruction(&Instruction::LocalSet(callee_ret_len_local));
             func.instruction(&Instruction::LocalSet(callee_ret_ptr_local));
 
+            // The returned (ptr, len) pair was produced BY THE CALLEE in the
+            // callee's string encoding, so its tag-encoding is governed by
+            // `callee_string_encoding`. byte_mult is 1 here (bulk string /
+            // list<u8> return). A latin1+utf16 return has its length tagged
+            // with UTF16_TAG; copying the raw operand would copy
+            // `count | 0x8000_0000` bytes (~2 GiB OOB). The length pushed back
+            // to the caller stays tagged; only the byte count is masked.
+            let result_is_compact_utf16 = options.callee_string_encoding == StringEncoding::Latin1;
+            let result_realloc_align = if result_is_compact_utf16 { 2 } else { 1 };
+
             // Allocate in caller's memory:
-            //   caller_new_ptr = cabi_realloc(0, 0, 1, callee_ret_len)
+            //   caller_new_ptr = cabi_realloc(0, 0, align, <byte count>)
             func.instruction(&Instruction::I32Const(0)); // original_ptr
             func.instruction(&Instruction::I32Const(0)); // original_size
-            func.instruction(&Instruction::I32Const(1)); // alignment
-            func.instruction(&Instruction::LocalGet(callee_ret_len_local));
+            func.instruction(&Instruction::I32Const(result_realloc_align)); // alignment
+            emit_copy_byte_count(&mut func, callee_ret_len_local, 1, result_is_compact_utf16);
             emit_checked_realloc(&mut func, caller_realloc, caller_new_ptr_local);
 
             // Copy data from callee's memory to caller's memory:
-            //   memory.copy $caller_mem $callee_mem (caller_new_ptr, callee_ret_ptr, len)
+            //   memory.copy $caller_mem $callee_mem (caller_new_ptr, callee_ret_ptr, <byte count>)
             func.instruction(&Instruction::LocalGet(caller_new_ptr_local)); // dst
             func.instruction(&Instruction::LocalGet(callee_ret_ptr_local)); // src
-            func.instruction(&Instruction::LocalGet(callee_ret_len_local)); // size
+            emit_copy_byte_count(&mut func, callee_ret_len_local, 1, result_is_compact_utf16);
             func.instruction(&Instruction::MemoryCopy {
                 src_mem: options.callee_memory,
                 dst_mem: options.caller_memory,
@@ -2412,6 +2485,12 @@ impl FactStyleGenerator {
                         crate::resolver::CopyLayout::Bulk { byte_multiplier } => *byte_multiplier,
                         crate::resolver::CopyLayout::Elements { element_size, .. } => *element_size,
                     };
+                    // Result-side (callee → caller) string: tag-encoding is
+                    // governed by `callee_string_encoding` (the callee produced
+                    // it). See the unconditional result-copy above.
+                    let is_compact_utf16 =
+                        options.callee_string_encoding == StringEncoding::Latin1 && byte_mult == 1;
+                    let realloc_align = if is_compact_utf16 { 2 } else { 1 };
 
                     // if (all guards in chain hold) { allocate in caller,
                     // copy, replace ptr } — outer-guard ANDing per LS-P-10.
@@ -2422,22 +2501,14 @@ impl FactStyleGenerator {
                     emit_overflow_guard(&mut func, len_local, byte_mult);
                     func.instruction(&Instruction::I32Const(0));
                     func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::I32Const(1));
-                    func.instruction(&Instruction::LocalGet(len_local));
-                    if byte_mult > 1 {
-                        func.instruction(&Instruction::I32Const(byte_mult as i32));
-                        func.instruction(&Instruction::I32Mul);
-                    }
+                    func.instruction(&Instruction::I32Const(realloc_align));
+                    emit_copy_byte_count(&mut func, len_local, byte_mult, is_compact_utf16);
                     emit_checked_realloc(&mut func, caller_realloc, dest_ptr_local);
 
                     // Copy from callee memory to caller memory
                     func.instruction(&Instruction::LocalGet(dest_ptr_local));
                     func.instruction(&Instruction::LocalGet(ptr_local));
-                    func.instruction(&Instruction::LocalGet(len_local));
-                    if byte_mult > 1 {
-                        func.instruction(&Instruction::I32Const(byte_mult as i32));
-                        func.instruction(&Instruction::I32Mul);
-                    }
+                    emit_copy_byte_count(&mut func, len_local, byte_mult, is_compact_utf16);
                     func.instruction(&Instruction::MemoryCopy {
                         src_mem: options.callee_memory,
                         dst_mem: options.caller_memory,
@@ -2590,19 +2661,23 @@ impl FactStyleGenerator {
             }));
             func.instruction(&Instruction::LocalSet(pair_len_local));
 
-            // Allocate: new_ptr = cabi_realloc(0, 0, 1, len * byte_mult)
+            // The params buffer was lowered by the caller, so a latin1+utf16
+            // string inside it has its length tagged per the *caller* encoding.
+            // byte_mult == 1 selects the byte-granular (string / list<u8>)
+            // case; a plain list<u8> stays unaffected (count < 2^31 ⇒ tag clear).
+            let is_compact_utf16 =
+                options.caller_string_encoding == StringEncoding::Latin1 && byte_mult == 1;
+            let realloc_align = if is_compact_utf16 { 2 } else { 1 };
+
+            // Allocate: new_ptr = cabi_realloc(0, 0, align, <byte count>)
             emit_overflow_guard(&mut func, pair_len_local, byte_mult);
             func.instruction(&Instruction::I32Const(0));
             func.instruction(&Instruction::I32Const(0));
-            func.instruction(&Instruction::I32Const(1));
-            func.instruction(&Instruction::LocalGet(pair_len_local));
-            if byte_mult > 1 {
-                func.instruction(&Instruction::I32Const(byte_mult as i32));
-                func.instruction(&Instruction::I32Mul);
-            }
+            func.instruction(&Instruction::I32Const(realloc_align));
+            emit_copy_byte_count(&mut func, pair_len_local, byte_mult, is_compact_utf16);
             emit_checked_realloc(&mut func, callee_realloc, dest_local);
 
-            // Copy data: memory.copy callee caller (new_ptr, old_ptr, len * byte_mult)
+            // Copy data: memory.copy callee caller (new_ptr, old_ptr, <byte count>)
             func.instruction(&Instruction::LocalGet(dest_local)); // dst (in callee mem)
             // Load old_ptr from callee's buffer (this was copied from caller's buffer,
             // so it points into caller's memory)
@@ -2612,17 +2687,8 @@ impl FactStyleGenerator {
                 align: 2,
                 memory_index: options.callee_memory,
             })); // src (in caller mem)
-            // Load len from callee's buffer
-            func.instruction(&Instruction::LocalGet(callee_ptr_local));
-            func.instruction(&Instruction::I32Load(wasm_encoder::MemArg {
-                offset: (byte_offset + 4) as u64,
-                align: 2,
-                memory_index: options.callee_memory,
-            }));
-            if byte_mult > 1 {
-                func.instruction(&Instruction::I32Const(byte_mult as i32));
-                func.instruction(&Instruction::I32Mul);
-            }
+            // Byte count from the stashed (still-tagged) length operand.
+            emit_copy_byte_count(&mut func, pair_len_local, byte_mult, is_compact_utf16);
             func.instruction(&Instruction::MemoryCopy {
                 src_mem: options.caller_memory,
                 dst_mem: options.callee_memory,
@@ -2865,26 +2931,26 @@ impl FactStyleGenerator {
                     })
                     .unwrap_or(1);
 
-                // Allocate: dest = cabi_realloc(0, 0, 1, len * byte_mult)
+                // Param-side (caller → callee) tagged latin1+utf16 string —
+                // governed by the caller encoding; byte_mult == 1 selects the
+                // byte-granular string / list<u8> case. See the memory-copy
+                // adapter's param-copy loop for the full reasoning.
+                let is_compact_utf16 =
+                    options.caller_string_encoding == StringEncoding::Latin1 && byte_mult == 1;
+                let realloc_align = if is_compact_utf16 { 2 } else { 1 };
+
+                // Allocate: dest = cabi_realloc(0, 0, align, <byte count>)
                 emit_overflow_guard(&mut func, len_pos, byte_mult);
                 func.instruction(&Instruction::I32Const(0));
                 func.instruction(&Instruction::I32Const(0));
-                func.instruction(&Instruction::I32Const(1));
-                func.instruction(&Instruction::LocalGet(len_pos));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                func.instruction(&Instruction::I32Const(realloc_align));
+                emit_copy_byte_count(&mut func, len_pos, byte_mult, is_compact_utf16);
                 emit_checked_realloc(&mut func, callee_realloc, dest_local);
 
-                // Copy: memory.copy callee_mem caller_mem (dest, src, len * byte_mult)
+                // Copy: memory.copy callee_mem caller_mem (dest, src, <byte count>)
                 func.instruction(&Instruction::LocalGet(dest_local));
                 func.instruction(&Instruction::LocalGet(ptr_pos));
-                func.instruction(&Instruction::LocalGet(len_pos));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                emit_copy_byte_count(&mut func, len_pos, byte_mult, is_compact_utf16);
                 func.instruction(&Instruction::MemoryCopy {
                     src_mem: options.caller_memory,
                     dst_mem: options.callee_memory,
@@ -2909,6 +2975,8 @@ impl FactStyleGenerator {
                         options.callee_memory,
                         callee_realloc,
                         fixup_locals_base,
+                        // Param-side: governed by the caller's string encoding.
+                        options.caller_string_encoding == StringEncoding::Latin1,
                     );
                 }
 
@@ -2992,6 +3060,10 @@ impl FactStyleGenerator {
                     crate::resolver::CopyLayout::Bulk { byte_multiplier } => *byte_multiplier,
                     crate::resolver::CopyLayout::Elements { element_size, .. } => *element_size,
                 };
+                // Param-side (caller → callee) tagged latin1+utf16 string.
+                let is_compact_utf16 =
+                    options.caller_string_encoding == StringEncoding::Latin1 && byte_mult == 1;
+                let realloc_align = if is_compact_utf16 { 2 } else { 1 };
 
                 // Outer-guard AND-chain (LS-P-10) before firing the copy.
                 emit_conditional_guard_chain_flat(&mut func, cond, 0);
@@ -3001,22 +3073,14 @@ impl FactStyleGenerator {
                 emit_overflow_guard(&mut func, len_local, byte_mult);
                 func.instruction(&Instruction::I32Const(0));
                 func.instruction(&Instruction::I32Const(0));
-                func.instruction(&Instruction::I32Const(1));
-                func.instruction(&Instruction::LocalGet(len_local));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                func.instruction(&Instruction::I32Const(realloc_align));
+                emit_copy_byte_count(&mut func, len_local, byte_mult, is_compact_utf16);
                 emit_checked_realloc(&mut func, callee_realloc, cond_dest_ptr_local);
 
                 // Copy from caller to callee memory
                 func.instruction(&Instruction::LocalGet(cond_dest_ptr_local));
                 func.instruction(&Instruction::LocalGet(ptr_local));
-                func.instruction(&Instruction::LocalGet(len_local));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                emit_copy_byte_count(&mut func, len_local, byte_mult, is_compact_utf16);
                 func.instruction(&Instruction::MemoryCopy {
                     src_mem: options.caller_memory,
                     dst_mem: options.callee_memory,
@@ -3098,26 +3162,27 @@ impl FactStyleGenerator {
                     }));
                     func.instruction(&Instruction::LocalSet(data_len_local));
 
-                    // Allocate in caller's memory: data_len * byte_mult bytes
+                    // Result-side (callee → caller): a returned latin1+utf16
+                    // string has its length tagged per the *callee* encoding.
+                    // byte_mult == 1 selects the byte-granular string / list<u8>
+                    // case; the length stored back into the caller's return area
+                    // stays tagged (only the byte count is masked here).
+                    let is_compact_utf16 =
+                        options.callee_string_encoding == StringEncoding::Latin1 && byte_mult == 1;
+                    let realloc_align = if is_compact_utf16 { 2 } else { 1 };
+
+                    // Allocate in caller's memory: <byte count> bytes
                     emit_overflow_guard(&mut func, data_len_local, byte_mult);
                     func.instruction(&Instruction::I32Const(0));
                     func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::I32Const(1));
-                    func.instruction(&Instruction::LocalGet(data_len_local));
-                    if byte_mult > 1 {
-                        func.instruction(&Instruction::I32Const(byte_mult as i32));
-                        func.instruction(&Instruction::I32Mul);
-                    }
+                    func.instruction(&Instruction::I32Const(realloc_align));
+                    emit_copy_byte_count(&mut func, data_len_local, byte_mult, is_compact_utf16);
                     emit_checked_realloc(&mut func, caller_realloc, caller_new_ptr_local);
 
                     // Copy data bytes from callee → caller
                     func.instruction(&Instruction::LocalGet(caller_new_ptr_local));
                     func.instruction(&Instruction::LocalGet(data_ptr_local));
-                    func.instruction(&Instruction::LocalGet(data_len_local));
-                    if byte_mult > 1 {
-                        func.instruction(&Instruction::I32Const(byte_mult as i32));
-                        func.instruction(&Instruction::I32Mul);
-                    }
+                    emit_copy_byte_count(&mut func, data_len_local, byte_mult, is_compact_utf16);
                     func.instruction(&Instruction::MemoryCopy {
                         src_mem: options.callee_memory,
                         dst_mem: options.caller_memory,
@@ -3142,6 +3207,8 @@ impl FactStyleGenerator {
                             options.caller_memory,
                             caller_realloc,
                             fixup_locals_base,
+                            // Result-side: governed by the callee's string encoding.
+                            options.callee_string_encoding == StringEncoding::Latin1,
                         );
                     }
 
@@ -3270,26 +3337,25 @@ impl FactStyleGenerator {
                 }));
                 func.instruction(&Instruction::LocalSet(data_len_local));
 
+                // Result-side (callee → caller) conditional string: tagged per
+                // the *callee* encoding. byte_mult == 1 ⇒ byte-granular string /
+                // list<u8>; the length written back to the retptr stays tagged.
+                let is_compact_utf16 =
+                    options.callee_string_encoding == StringEncoding::Latin1 && byte_mult == 1;
+                let realloc_align = if is_compact_utf16 { 2 } else { 1 };
+
                 // Allocate in caller memory
                 emit_overflow_guard(&mut func, data_len_local, byte_mult);
                 func.instruction(&Instruction::I32Const(0));
                 func.instruction(&Instruction::I32Const(0));
-                func.instruction(&Instruction::I32Const(1));
-                func.instruction(&Instruction::LocalGet(data_len_local));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                func.instruction(&Instruction::I32Const(realloc_align));
+                emit_copy_byte_count(&mut func, data_len_local, byte_mult, is_compact_utf16);
                 emit_checked_realloc(&mut func, caller_realloc, caller_new_ptr_local);
 
                 // Copy data from callee → caller
                 func.instruction(&Instruction::LocalGet(caller_new_ptr_local));
                 func.instruction(&Instruction::LocalGet(data_ptr_local));
-                func.instruction(&Instruction::LocalGet(data_len_local));
-                if byte_mult > 1 {
-                    func.instruction(&Instruction::I32Const(byte_mult as i32));
-                    func.instruction(&Instruction::I32Mul);
-                }
+                emit_copy_byte_count(&mut func, data_len_local, byte_mult, is_compact_utf16);
                 func.instruction(&Instruction::MemoryCopy {
                     src_mem: options.callee_memory,
                     dst_mem: options.caller_memory,
@@ -3421,6 +3487,18 @@ impl FactStyleGenerator {
         dst_mem: u32,
         realloc_func: u32,
         locals_base: u32,
+        // True when the governing canonical-ABI string encoding (caller's for
+        // param-side copies, callee's for result-side copies) is `latin1+utf16`
+        // (modelled as `StringEncoding::Latin1`). When set, a byte-granular
+        // inner buffer (`byte_mult == 1`) is treated as a tag-encoded string:
+        // its byte count is masked/doubled via `emit_copy_byte_count`. The
+        // pointer-pair length stored back into the destination element is the
+        // ORIGINAL (still-tagged) operand, so the callee/caller decoder still
+        // sees the tag. `CopyLayout` cannot distinguish a nested `string` from
+        // a nested `list<u8>`, but the latter is unaffected: a legitimate
+        // list<u8> count is < 2^31, so its tag bit is clear and the tag-aware
+        // path returns `len` unchanged (see `emit_copy_byte_count`).
+        is_compact_utf16: bool,
     ) {
         if inner_pointers.is_empty() {
             return;
@@ -3531,27 +3609,28 @@ impl FactStyleGenerator {
             }));
             func.instruction(&Instruction::LocalSet(inner_len));
 
-            // Allocate inner data in dst memory: new_ptr = realloc(0, 0, 1, inner_len * byte_mult)
+            // A byte-granular inner buffer in a latin1+utf16 component is a
+            // tag-encoded string; mask/double its byte count. Non-byte-granular
+            // inner buffers and list<u8> are handled by the plain path.
+            let inner_is_compact_utf16 = is_compact_utf16 && byte_mult == 1;
+
+            // Allocate inner data in dst memory: new_ptr = realloc(0, 0, align, <byte count>)
             emit_overflow_guard(func, inner_len, byte_mult);
             func.instruction(&Instruction::I32Const(0));
             func.instruction(&Instruction::I32Const(0));
-            func.instruction(&Instruction::I32Const(1));
-            func.instruction(&Instruction::LocalGet(inner_len));
-            if byte_mult > 1 {
-                func.instruction(&Instruction::I32Const(byte_mult as i32));
-                func.instruction(&Instruction::I32Mul);
-            }
+            func.instruction(&Instruction::I32Const(if inner_is_compact_utf16 {
+                2
+            } else {
+                1
+            }));
+            emit_copy_byte_count(func, inner_len, byte_mult, inner_is_compact_utf16);
             emit_checked_realloc(func, realloc_func, new_ptr);
 
             // Copy data from src memory to dst memory
-            // memory.copy dst_mem src_mem (new_ptr, inner_ptr, inner_len * byte_mult)
+            // memory.copy dst_mem src_mem (new_ptr, inner_ptr, <byte count>)
             func.instruction(&Instruction::LocalGet(new_ptr));
             func.instruction(&Instruction::LocalGet(inner_ptr));
-            func.instruction(&Instruction::LocalGet(inner_len));
-            if byte_mult > 1 {
-                func.instruction(&Instruction::I32Const(byte_mult as i32));
-                func.instruction(&Instruction::I32Mul);
-            }
+            emit_copy_byte_count(func, inner_len, byte_mult, inner_is_compact_utf16);
             func.instruction(&Instruction::MemoryCopy { src_mem, dst_mem });
 
             // Recursively fix up inner-inner pointers if the inner layout
@@ -3575,6 +3654,7 @@ impl FactStyleGenerator {
                     dst_mem,
                     realloc_func,
                     locals_base + 4, // next level gets next 4 scratch locals
+                    is_compact_utf16,
                 );
             }
 
@@ -6123,6 +6203,11 @@ impl FactStyleGenerator {
                         caller_memory,
                         callee_memory,
                         l_p2 + 1,
+                        // Result-side: governed by the callee's string encoding.
+                        matches!(
+                            site.requirements.callee_encoding,
+                            Some(crate::parser::CanonStringEncoding::CompactUtf16)
+                        ),
                     );
                 } else {
                     // Non-pointer results: write globals directly to retptr
@@ -6252,26 +6337,31 @@ impl FactStyleGenerator {
                 })
                 .unwrap_or(1);
 
-            // Allocate: cabi_realloc(0, 0, 1, len * byte_mult)
+            // Param-side (caller → callee) async copy. This path has no
+            // `AdapterOptions`, but the governing caller string encoding is
+            // carried by `site.requirements.caller_encoding`; CompactUtf16 is
+            // the `latin1+utf16` encoding (mapped to `StringEncoding::Latin1`
+            // by `canon_to_string_encoding`). A byte-granular buffer
+            // (byte_mult == 1) in such a component is a tag-encoded string,
+            // so mask/double its byte count; the forwarded length stays tagged.
+            let is_compact_utf16 = matches!(
+                site.requirements.caller_encoding,
+                Some(crate::parser::CanonStringEncoding::CompactUtf16)
+            ) && byte_mult == 1;
+            let realloc_align = if is_compact_utf16 { 2 } else { 1 };
+
+            // Allocate: cabi_realloc(0, 0, align, <byte count>)
             emit_overflow_guard(body, len_local, byte_mult);
             body.instruction(&Instruction::I32Const(0));
             body.instruction(&Instruction::I32Const(0));
-            body.instruction(&Instruction::I32Const(1));
-            body.instruction(&Instruction::LocalGet(len_local));
-            if byte_mult > 1 {
-                body.instruction(&Instruction::I32Const(byte_mult as i32));
-                body.instruction(&Instruction::I32Mul);
-            }
+            body.instruction(&Instruction::I32Const(realloc_align));
+            emit_copy_byte_count(body, len_local, byte_mult, is_compact_utf16);
             emit_checked_realloc(body, realloc, l_new_ptr);
 
-            // Copy: memory.copy new_ptr <- old_ptr, len * byte_mult
+            // Copy: memory.copy new_ptr <- old_ptr, <byte count>
             body.instruction(&Instruction::LocalGet(l_new_ptr));
             body.instruction(&Instruction::LocalGet(ptr_local));
-            body.instruction(&Instruction::LocalGet(len_local));
-            if byte_mult > 1 {
-                body.instruction(&Instruction::I32Const(byte_mult as i32));
-                body.instruction(&Instruction::I32Mul);
-            }
+            emit_copy_byte_count(body, len_local, byte_mult, is_compact_utf16);
             body.instruction(&Instruction::MemoryCopy {
                 dst_mem: callee_memory,
                 src_mem: caller_memory,
@@ -6319,6 +6409,12 @@ impl FactStyleGenerator {
         caller_memory: u32,
         callee_memory: u32,
         scratch_base: u32,
+        // True when the *callee* string encoding is `latin1+utf16`
+        // (CompactUtf16). A byte-granular result buffer (`elem_size == 1`,
+        // i.e. a top-level `string`) then carries a tag-encoded length whose
+        // byte count must be masked/doubled. The len written back to the
+        // retptr stays tagged. #253.
+        callee_compact_utf16: bool,
     ) {
         let (ptr_global, _) = info.result_globals[0];
         let (len_global, _) = info.result_globals[1];
@@ -6349,19 +6445,20 @@ impl FactStyleGenerator {
         body.instruction(&Instruction::GlobalGet(len_global));
         body.instruction(&Instruction::LocalSet(l_src_len));
 
-        // byte_count = len * elem_size, with LS-A-7 overflow guard
+        // A top-level byte-granular result (elem_size == 1) in a latin1+utf16
+        // callee is a tag-encoded string; its byte count must be masked/doubled.
+        let top_compact_utf16 = callee_compact_utf16 && elem_size == 1;
+        // byte_count = <tag-aware byte count> | len * elem_size, with LS-A-7 guard
         emit_overflow_guard(body, l_src_len, elem_size);
-        body.instruction(&Instruction::LocalGet(l_src_len));
-        if elem_size != 1 {
-            body.instruction(&Instruction::I32Const(elem_size as i32));
-            body.instruction(&Instruction::I32Mul);
-        }
+        emit_copy_byte_count(body, l_src_len, elem_size, top_compact_utf16);
         body.instruction(&Instruction::LocalSet(l_byte_count));
 
-        // Allocate in caller memory: cabi_realloc(0, 0, align, byte_count)
+        // Allocate in caller memory: cabi_realloc(0, 0, align, byte_count).
+        // A utf16 payload needs 2-byte alignment.
+        let realloc_align = if top_compact_utf16 { 2 } else { elem_align };
         body.instruction(&Instruction::I32Const(0)); // old_ptr
         body.instruction(&Instruction::I32Const(0)); // old_size
-        body.instruction(&Instruction::I32Const(elem_align as i32));
+        body.instruction(&Instruction::I32Const(realloc_align as i32));
         body.instruction(&Instruction::LocalGet(l_byte_count));
         emit_checked_realloc(body, caller_realloc_func, l_dst_ptr);
 
@@ -6388,6 +6485,7 @@ impl FactStyleGenerator {
                 caller_realloc_func,
                 caller_memory,
                 callee_memory,
+                callee_compact_utf16,
             );
         }
 
@@ -6675,6 +6773,11 @@ impl FactStyleGenerator {
                         caller_memory,
                         callee_memory,
                         l_scratch + 1,
+                        // Result-side: governed by the callee's string encoding.
+                        matches!(
+                            site.requirements.callee_encoding,
+                            Some(crate::parser::CanonStringEncoding::CompactUtf16)
+                        ),
                     );
                 } else {
                     // Non-pointer results: write globals directly to retptr
@@ -6942,6 +7045,7 @@ mod tests {
             /* elem_size = */ 8, // record { ptr:i32, len:i32 } = 8 bytes
             /* l_first_scratch = */ 3, /* realloc_func = */ 99,
             /* caller_memory = */ 0, /* callee_memory = */ 1,
+            /* callee_compact_utf16 = */ false,
         );
 
         // wasm_encoder::Function has no public bytes() accessor on stable;

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -50,16 +50,35 @@ fn canon_to_string_encoding(enc: CanonStringEncoding) -> StringEncoding {
     match enc {
         CanonStringEncoding::Utf8 => StringEncoding::Utf8,
         CanonStringEncoding::Utf16 => StringEncoding::Utf16,
-        // CompactUTF16 is latin1+utf16 — treat as Latin1 for adapter purposes
+        // CompactUTF16 is latin1+utf16 — modelled as `Latin1`, which in meld
+        // means the canonical-ABI `latin1+utf16` encoding (the length operand
+        // is tag-bit encoded; see [`UTF16_TAG`]). It is NOT a pure-Latin-1
+        // encoding: a tag-set string carries UTF-16 payload.
         CanonStringEncoding::CompactUtf16 => StringEncoding::Latin1,
     }
 }
 
+/// The canonical-ABI `latin1+utf16` length-operand tag bit (`1 << 31`).
+///
+/// A `latin1+utf16` string's length operand is *tagged*:
+/// - tag **clear** → the payload is Latin-1 (1 byte per char); the byte length
+///   equals the operand.
+/// - tag **set** → the payload is UTF-16; the *code-unit count* is
+///   `operand & !UTF16_TAG`, and the byte length is that count × 2.
+///
+/// meld models `latin1+utf16` as [`StringEncoding::Latin1`]; the transcoders
+/// that have `Latin1` as a source must branch on this bit, and those that
+/// produce `Latin1` set it when they fall back to UTF-16.
+pub(crate) const UTF16_TAG: i32 = 1 << 31;
+
 /// Return the required alignment for a cabi_realloc call for the given string encoding
 fn alignment_for_encoding(encoding: StringEncoding) -> i32 {
     match encoding {
-        StringEncoding::Utf8 | StringEncoding::Latin1 => 1,
-        StringEncoding::Utf16 => 2,
+        StringEncoding::Utf8 => 1,
+        // latin1+utf16: the destination buffer may hold UTF-16 code units, so
+        // the canonical ABI requires 2-byte alignment for the string pointer
+        // (the realloc backing the tag-set fallback writes i16s).
+        StringEncoding::Latin1 | StringEncoding::Utf16 => 2,
     }
 }
 
@@ -101,6 +120,522 @@ pub(crate) fn emit_overflow_guard(body: &mut Function, len_local: u32, k: u32) {
     body.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
     body.instruction(&Instruction::Unreachable);
     body.instruction(&Instruction::End);
+}
+
+/// Emit the hardened UTF-8 → code-point decoder for one code point.
+///
+/// Reads the lead byte at `mem8[ptr_local + src_idx_local]`, decodes a full
+/// UTF-8 sequence into `cp_local`, and advances `src_idx_local` past the bytes
+/// consumed. `len_local` bounds the buffer. Malformed input (truncation,
+/// invalid continuation, overlong, surrogate, out-of-range, lone continuation)
+/// is replaced with U+FFFD, consuming only the lead byte (the #251/#249/LS-P-19
+/// Canonical-ABI lossy-replacement convention). `byte_local` and `cont_local`
+/// are scratch. `ptr_local` is the local holding the source base pointer
+/// (param 0 for the standard caller-string layout).
+///
+/// Extracted from `emit_utf8_to_utf16_transcode` (#253) so the UTF-8 → Latin-1
+/// scan/write phases share the exact same validated decoder rather than a
+/// re-derived copy that could drift.
+#[allow(clippy::too_many_arguments)]
+fn emit_utf8_decode_codepoint(
+    func: &mut Function,
+    src_mem8: wasm_encoder::MemArg,
+    ptr_local: u32,
+    src_idx_local: u32,
+    len_local: u32,
+    byte_local: u32,
+    cp_local: u32,
+    cont_local: u32,
+) {
+    // Read lead byte from source memory.
+    func.instruction(&Instruction::LocalGet(ptr_local));
+    func.instruction(&Instruction::LocalGet(src_idx_local));
+    func.instruction(&Instruction::I32Add);
+    func.instruction(&Instruction::I32Load8U(src_mem8));
+    func.instruction(&Instruction::LocalSet(byte_local));
+
+    // Emit: cp = U+FFFD; src_idx += 1 (replacement, consume lead only).
+    let emit_fffd_consume_lead = |func: &mut Function| {
+        func.instruction(&Instruction::I32Const(0xFFFD));
+        func.instruction(&Instruction::LocalSet(cp_local));
+        func.instruction(&Instruction::LocalGet(src_idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::LocalSet(src_idx_local));
+    };
+    // Push mem8[ptr + src_idx + off] onto the stack (a continuation byte).
+    let push_byte_at = |func: &mut Function, off: i32| {
+        func.instruction(&Instruction::LocalGet(ptr_local));
+        func.instruction(&Instruction::LocalGet(src_idx_local));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::I32Const(off));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::I32Load8U(src_mem8));
+    };
+    // Push: (cont_local & 0xC0) != 0x80  (true => NOT a continuation byte).
+    let push_not_continuation = |func: &mut Function| {
+        func.instruction(&Instruction::LocalGet(cont_local));
+        func.instruction(&Instruction::I32Const(0xC0));
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::I32Const(0x80));
+        func.instruction(&Instruction::I32Ne);
+    };
+
+    // if byte < 0x80: 1-byte ASCII
+    func.instruction(&Instruction::LocalGet(byte_local));
+    func.instruction(&Instruction::I32Const(0x80));
+    func.instruction(&Instruction::I32LtU);
+    func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+    {
+        func.instruction(&Instruction::LocalGet(byte_local));
+        func.instruction(&Instruction::LocalSet(cp_local));
+        func.instruction(&Instruction::LocalGet(src_idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::LocalSet(src_idx_local));
+    }
+    func.instruction(&Instruction::Else);
+    {
+        // if byte < 0xC2: invalid lead → U+FFFD, consume lead only.
+        func.instruction(&Instruction::LocalGet(byte_local));
+        func.instruction(&Instruction::I32Const(0xC2));
+        func.instruction(&Instruction::I32LtU);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        {
+            emit_fffd_consume_lead(func);
+        }
+        func.instruction(&Instruction::Else);
+        {
+            // if byte < 0xE0: 2-byte sequence (lead 0xC2–0xDF).
+            func.instruction(&Instruction::LocalGet(byte_local));
+            func.instruction(&Instruction::I32Const(0xE0));
+            func.instruction(&Instruction::I32LtU);
+            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+            {
+                // Truncation guard.
+                func.instruction(&Instruction::LocalGet(src_idx_local));
+                func.instruction(&Instruction::I32Const(1));
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::LocalGet(len_local));
+                func.instruction(&Instruction::I32GeU);
+                func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                {
+                    emit_fffd_consume_lead(func);
+                }
+                func.instruction(&Instruction::Else);
+                {
+                    push_byte_at(func, 1);
+                    func.instruction(&Instruction::LocalSet(cont_local));
+                    push_not_continuation(func);
+                    func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                    {
+                        emit_fffd_consume_lead(func);
+                    }
+                    func.instruction(&Instruction::Else);
+                    {
+                        // cp = (byte & 0x1F) << 6 | (b1 & 0x3F)
+                        func.instruction(&Instruction::LocalGet(byte_local));
+                        func.instruction(&Instruction::I32Const(0x1F));
+                        func.instruction(&Instruction::I32And);
+                        func.instruction(&Instruction::I32Const(6));
+                        func.instruction(&Instruction::I32Shl);
+                        func.instruction(&Instruction::LocalGet(cont_local));
+                        func.instruction(&Instruction::I32Const(0x3F));
+                        func.instruction(&Instruction::I32And);
+                        func.instruction(&Instruction::I32Or);
+                        func.instruction(&Instruction::LocalSet(cp_local));
+                        func.instruction(&Instruction::LocalGet(src_idx_local));
+                        func.instruction(&Instruction::I32Const(2));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::LocalSet(src_idx_local));
+                    }
+                    func.instruction(&Instruction::End);
+                }
+                func.instruction(&Instruction::End);
+            }
+            func.instruction(&Instruction::Else);
+            {
+                // if byte < 0xF0: 3-byte sequence (lead 0xE0–0xEF).
+                func.instruction(&Instruction::LocalGet(byte_local));
+                func.instruction(&Instruction::I32Const(0xF0));
+                func.instruction(&Instruction::I32LtU);
+                func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                {
+                    func.instruction(&Instruction::LocalGet(src_idx_local));
+                    func.instruction(&Instruction::I32Const(2));
+                    func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::LocalGet(len_local));
+                    func.instruction(&Instruction::I32GeU);
+                    func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                    {
+                        emit_fffd_consume_lead(func);
+                    }
+                    func.instruction(&Instruction::Else);
+                    {
+                        push_byte_at(func, 1);
+                        func.instruction(&Instruction::LocalSet(cont_local));
+                        push_not_continuation(func);
+                        push_byte_at(func, 2);
+                        func.instruction(&Instruction::LocalSet(cont_local));
+                        push_not_continuation(func);
+                        func.instruction(&Instruction::I32Or);
+                        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                        {
+                            emit_fffd_consume_lead(func);
+                        }
+                        func.instruction(&Instruction::Else);
+                        {
+                            func.instruction(&Instruction::LocalGet(byte_local));
+                            func.instruction(&Instruction::I32Const(0x0F));
+                            func.instruction(&Instruction::I32And);
+                            func.instruction(&Instruction::I32Const(12));
+                            func.instruction(&Instruction::I32Shl);
+                            push_byte_at(func, 1);
+                            func.instruction(&Instruction::I32Const(0x3F));
+                            func.instruction(&Instruction::I32And);
+                            func.instruction(&Instruction::I32Const(6));
+                            func.instruction(&Instruction::I32Shl);
+                            func.instruction(&Instruction::I32Or);
+                            push_byte_at(func, 2);
+                            func.instruction(&Instruction::I32Const(0x3F));
+                            func.instruction(&Instruction::I32And);
+                            func.instruction(&Instruction::I32Or);
+                            func.instruction(&Instruction::LocalSet(cp_local));
+                            // reject overlong (< 0x800) and surrogate.
+                            func.instruction(&Instruction::LocalGet(cp_local));
+                            func.instruction(&Instruction::I32Const(0x800));
+                            func.instruction(&Instruction::I32LtU);
+                            func.instruction(&Instruction::LocalGet(cp_local));
+                            func.instruction(&Instruction::I32Const(0xD800));
+                            func.instruction(&Instruction::I32GeU);
+                            func.instruction(&Instruction::LocalGet(cp_local));
+                            func.instruction(&Instruction::I32Const(0xE000));
+                            func.instruction(&Instruction::I32LtU);
+                            func.instruction(&Instruction::I32And);
+                            func.instruction(&Instruction::I32Or);
+                            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                            {
+                                emit_fffd_consume_lead(func);
+                            }
+                            func.instruction(&Instruction::Else);
+                            {
+                                func.instruction(&Instruction::LocalGet(src_idx_local));
+                                func.instruction(&Instruction::I32Const(3));
+                                func.instruction(&Instruction::I32Add);
+                                func.instruction(&Instruction::LocalSet(src_idx_local));
+                            }
+                            func.instruction(&Instruction::End);
+                        }
+                        func.instruction(&Instruction::End);
+                    }
+                    func.instruction(&Instruction::End);
+                }
+                func.instruction(&Instruction::Else);
+                {
+                    // 4-byte sequence (byte >= 0xF0).
+                    func.instruction(&Instruction::LocalGet(byte_local));
+                    func.instruction(&Instruction::I32Const(0xF5));
+                    func.instruction(&Instruction::I32GeU);
+                    func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                    {
+                        emit_fffd_consume_lead(func);
+                    }
+                    func.instruction(&Instruction::Else);
+                    {
+                        func.instruction(&Instruction::LocalGet(src_idx_local));
+                        func.instruction(&Instruction::I32Const(3));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::LocalGet(len_local));
+                        func.instruction(&Instruction::I32GeU);
+                        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                        {
+                            emit_fffd_consume_lead(func);
+                        }
+                        func.instruction(&Instruction::Else);
+                        {
+                            push_byte_at(func, 1);
+                            func.instruction(&Instruction::LocalSet(cont_local));
+                            push_not_continuation(func);
+                            push_byte_at(func, 2);
+                            func.instruction(&Instruction::LocalSet(cont_local));
+                            push_not_continuation(func);
+                            func.instruction(&Instruction::I32Or);
+                            push_byte_at(func, 3);
+                            func.instruction(&Instruction::LocalSet(cont_local));
+                            push_not_continuation(func);
+                            func.instruction(&Instruction::I32Or);
+                            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                            {
+                                emit_fffd_consume_lead(func);
+                            }
+                            func.instruction(&Instruction::Else);
+                            {
+                                func.instruction(&Instruction::LocalGet(byte_local));
+                                func.instruction(&Instruction::I32Const(0x07));
+                                func.instruction(&Instruction::I32And);
+                                func.instruction(&Instruction::I32Const(18));
+                                func.instruction(&Instruction::I32Shl);
+                                push_byte_at(func, 1);
+                                func.instruction(&Instruction::I32Const(0x3F));
+                                func.instruction(&Instruction::I32And);
+                                func.instruction(&Instruction::I32Const(12));
+                                func.instruction(&Instruction::I32Shl);
+                                func.instruction(&Instruction::I32Or);
+                                push_byte_at(func, 2);
+                                func.instruction(&Instruction::I32Const(0x3F));
+                                func.instruction(&Instruction::I32And);
+                                func.instruction(&Instruction::I32Const(6));
+                                func.instruction(&Instruction::I32Shl);
+                                func.instruction(&Instruction::I32Or);
+                                push_byte_at(func, 3);
+                                func.instruction(&Instruction::I32Const(0x3F));
+                                func.instruction(&Instruction::I32And);
+                                func.instruction(&Instruction::I32Or);
+                                func.instruction(&Instruction::LocalSet(cp_local));
+                                // reject overlong (< 0x10000) and oor (> 0x10FFFF).
+                                func.instruction(&Instruction::LocalGet(cp_local));
+                                func.instruction(&Instruction::I32Const(0x10000));
+                                func.instruction(&Instruction::I32LtU);
+                                func.instruction(&Instruction::LocalGet(cp_local));
+                                func.instruction(&Instruction::I32Const(0x10FFFF));
+                                func.instruction(&Instruction::I32GtU);
+                                func.instruction(&Instruction::I32Or);
+                                func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+                                {
+                                    emit_fffd_consume_lead(func);
+                                }
+                                func.instruction(&Instruction::Else);
+                                {
+                                    func.instruction(&Instruction::LocalGet(src_idx_local));
+                                    func.instruction(&Instruction::I32Const(4));
+                                    func.instruction(&Instruction::I32Add);
+                                    func.instruction(&Instruction::LocalSet(src_idx_local));
+                                }
+                                func.instruction(&Instruction::End);
+                            }
+                            func.instruction(&Instruction::End);
+                        }
+                        func.instruction(&Instruction::End);
+                    }
+                    func.instruction(&Instruction::End);
+                }
+                func.instruction(&Instruction::End); // end 3-byte vs 4-byte
+            }
+            func.instruction(&Instruction::End); // end 2-byte vs 3+byte
+        }
+        func.instruction(&Instruction::End); // end invalid-lead vs valid-multibyte
+    }
+    func.instruction(&Instruction::End); // end 1-byte vs 2+byte
+}
+
+/// Emit the UTF-16 → code-point decoder for one code point.
+///
+/// Reads the code unit at `mem16[ptr_local + src_idx_local*2]`, decodes a full
+/// scalar value into `cp_local`, and advances `src_idx_local` (by 1 for a BMP
+/// scalar / replaced lone surrogate, by 2 for a valid surrogate pair).
+/// `len_local` bounds the buffer (code-unit count). Lone surrogates (high at
+/// EOF, high not followed by low, or lone low) are replaced with U+FFFD per the
+/// Canonical ABI, mirroring `emit_utf16_to_utf8_transcode`. `cu2_local` is
+/// scratch. Extracted for #253 so the UTF-16 → Latin-1 scan/write phases share
+/// one validated decoder.
+#[allow(clippy::too_many_arguments)]
+fn emit_utf16_decode_codepoint(
+    func: &mut Function,
+    src_mem16: wasm_encoder::MemArg,
+    ptr_local: u32,
+    src_idx_local: u32,
+    len_local: u32,
+    cu_local: u32,
+    cp_local: u32,
+    cu2_local: u32,
+) {
+    // cu = mem16[ptr + src_idx*2]
+    func.instruction(&Instruction::LocalGet(ptr_local));
+    func.instruction(&Instruction::LocalGet(src_idx_local));
+    func.instruction(&Instruction::I32Const(1));
+    func.instruction(&Instruction::I32Shl);
+    func.instruction(&Instruction::I32Add);
+    func.instruction(&Instruction::I32Load16U(src_mem16));
+    func.instruction(&Instruction::LocalSet(cu_local));
+
+    // if cu is a high surrogate (0xD800..0xDC00)
+    func.instruction(&Instruction::LocalGet(cu_local));
+    func.instruction(&Instruction::I32Const(0xD800_u32 as i32));
+    func.instruction(&Instruction::I32GeU);
+    func.instruction(&Instruction::LocalGet(cu_local));
+    func.instruction(&Instruction::I32Const(0xDC00_u32 as i32));
+    func.instruction(&Instruction::I32LtU);
+    func.instruction(&Instruction::I32And);
+    func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+    {
+        // High surrogate. If it's the last unit → U+FFFD, consume 1.
+        func.instruction(&Instruction::LocalGet(src_idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::LocalGet(len_local));
+        func.instruction(&Instruction::I32GeU);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        {
+            func.instruction(&Instruction::I32Const(0xFFFD));
+            func.instruction(&Instruction::LocalSet(cp_local));
+            func.instruction(&Instruction::LocalGet(src_idx_local));
+            func.instruction(&Instruction::I32Const(1));
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::LocalSet(src_idx_local));
+        }
+        func.instruction(&Instruction::Else);
+        {
+            // cu2 = mem16[ptr + (src_idx+1)*2]
+            func.instruction(&Instruction::LocalGet(ptr_local));
+            func.instruction(&Instruction::LocalGet(src_idx_local));
+            func.instruction(&Instruction::I32Const(1));
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::I32Const(1));
+            func.instruction(&Instruction::I32Shl);
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::I32Load16U(src_mem16));
+            func.instruction(&Instruction::LocalSet(cu2_local));
+            // is cu2 a low surrogate?
+            func.instruction(&Instruction::LocalGet(cu2_local));
+            func.instruction(&Instruction::I32Const(0xDC00_u32 as i32));
+            func.instruction(&Instruction::I32GeU);
+            func.instruction(&Instruction::LocalGet(cu2_local));
+            func.instruction(&Instruction::I32Const(0xE000_u32 as i32));
+            func.instruction(&Instruction::I32LtU);
+            func.instruction(&Instruction::I32And);
+            func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+            {
+                // cp = 0x10000 + ((cu-0xD800)<<10) + (cu2-0xDC00); consume 2.
+                func.instruction(&Instruction::I32Const(0x10000));
+                func.instruction(&Instruction::LocalGet(cu_local));
+                func.instruction(&Instruction::I32Const(0xD800_u32 as i32));
+                func.instruction(&Instruction::I32Sub);
+                func.instruction(&Instruction::I32Const(10));
+                func.instruction(&Instruction::I32Shl);
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::LocalGet(cu2_local));
+                func.instruction(&Instruction::I32Const(0xDC00_u32 as i32));
+                func.instruction(&Instruction::I32Sub);
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::LocalSet(cp_local));
+                func.instruction(&Instruction::LocalGet(src_idx_local));
+                func.instruction(&Instruction::I32Const(2));
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::LocalSet(src_idx_local));
+            }
+            func.instruction(&Instruction::Else);
+            {
+                // Mid-string lone high surrogate → U+FFFD, consume 1.
+                func.instruction(&Instruction::I32Const(0xFFFD));
+                func.instruction(&Instruction::LocalSet(cp_local));
+                func.instruction(&Instruction::LocalGet(src_idx_local));
+                func.instruction(&Instruction::I32Const(1));
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::LocalSet(src_idx_local));
+            }
+            func.instruction(&Instruction::End);
+        }
+        func.instruction(&Instruction::End);
+    }
+    func.instruction(&Instruction::Else);
+    {
+        // Not a high surrogate. Lone low surrogate → U+FFFD, else cp = cu.
+        func.instruction(&Instruction::LocalGet(cu_local));
+        func.instruction(&Instruction::I32Const(0xDC00_u32 as i32));
+        func.instruction(&Instruction::I32GeU);
+        func.instruction(&Instruction::LocalGet(cu_local));
+        func.instruction(&Instruction::I32Const(0xE000_u32 as i32));
+        func.instruction(&Instruction::I32LtU);
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        {
+            func.instruction(&Instruction::I32Const(0xFFFD));
+            func.instruction(&Instruction::LocalSet(cp_local));
+        }
+        func.instruction(&Instruction::Else);
+        {
+            func.instruction(&Instruction::LocalGet(cu_local));
+            func.instruction(&Instruction::LocalSet(cp_local));
+        }
+        func.instruction(&Instruction::End);
+        func.instruction(&Instruction::LocalGet(src_idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::LocalSet(src_idx_local));
+    }
+    func.instruction(&Instruction::End);
+}
+
+/// Emit the code-point → UTF-16 encoder for one code point.
+///
+/// Writes `cp_local` to `mem16[out_ptr_local + dst_idx_local*2]` as one BMP
+/// code unit, or as a surrogate pair for cp >= 0x10000, advancing
+/// `dst_idx_local` by 1 or 2 code units. Mirrors the encoder in
+/// `emit_utf8_to_utf16_transcode`. Extracted for #253.
+fn emit_utf16_encode_codepoint(
+    func: &mut Function,
+    dst_mem16: wasm_encoder::MemArg,
+    out_ptr_local: u32,
+    dst_idx_local: u32,
+    cp_local: u32,
+) {
+    func.instruction(&Instruction::LocalGet(cp_local));
+    func.instruction(&Instruction::I32Const(0x10000));
+    func.instruction(&Instruction::I32LtU);
+    func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+    {
+        // BMP: one code unit.
+        func.instruction(&Instruction::LocalGet(out_ptr_local));
+        func.instruction(&Instruction::LocalGet(dst_idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Shl);
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::LocalGet(cp_local));
+        func.instruction(&Instruction::I32Store16(dst_mem16));
+        func.instruction(&Instruction::LocalGet(dst_idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::LocalSet(dst_idx_local));
+    }
+    func.instruction(&Instruction::Else);
+    {
+        // Supplementary: surrogate pair.
+        // high = 0xD800 + ((cp - 0x10000) >> 10)
+        func.instruction(&Instruction::LocalGet(out_ptr_local));
+        func.instruction(&Instruction::LocalGet(dst_idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Shl);
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::I32Const(0xD800));
+        func.instruction(&Instruction::LocalGet(cp_local));
+        func.instruction(&Instruction::I32Const(0x10000));
+        func.instruction(&Instruction::I32Sub);
+        func.instruction(&Instruction::I32Const(10));
+        func.instruction(&Instruction::I32ShrU);
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::I32Store16(dst_mem16));
+        // low = 0xDC00 + ((cp - 0x10000) & 0x3FF)
+        func.instruction(&Instruction::LocalGet(out_ptr_local));
+        func.instruction(&Instruction::LocalGet(dst_idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Shl);
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::I32Const(2));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::I32Const(0xDC00));
+        func.instruction(&Instruction::LocalGet(cp_local));
+        func.instruction(&Instruction::I32Const(0x10000));
+        func.instruction(&Instruction::I32Sub);
+        func.instruction(&Instruction::I32Const(0x3FF));
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::I32Store16(dst_mem16));
+        func.instruction(&Instruction::LocalGet(dst_idx_local));
+        func.instruction(&Instruction::I32Const(2));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::LocalSet(dst_idx_local));
+    }
+    func.instruction(&Instruction::End);
 }
 
 /// Emit a chain of `(disc == value)` checks for a [`ConditionalPointerPair`]'s
@@ -3132,6 +3667,24 @@ impl FactStyleGenerator {
         // Phase 0: Convert borrow resource handles
         emit_resource_borrow_phase0(&mut func, &options.resource_rep_calls);
 
+        // The #253 latin1+utf16 transcoders dispatch on the length tag with an
+        // `If`/`Else` whose two legs each call the target and leave the
+        // function's result on the stack. The block must therefore carry the
+        // function's result type so the value isn't trapped inside the block.
+        // Flat string-call results are 0 or 1 value (multi-value returns go
+        // through a retptr param); we only need Empty / single-result here.
+        let transcode_block_ty = match result_types.as_slice() {
+            [] => wasm_encoder::BlockType::Empty,
+            [ty] => wasm_encoder::BlockType::Result(*ty),
+            _ => {
+                return Err(crate::Error::AdapterGeneration(format!(
+                    "string transcoding with {} flat results is unsupported \
+                     (expected 0 or 1; multi-value returns use a retptr) — see #253",
+                    result_types.len()
+                )));
+            }
+        };
+
         // Generate transcoding logic based on encoding pair
 
         match (
@@ -3158,14 +3711,54 @@ impl FactStyleGenerator {
             }
 
             (StringEncoding::Latin1, StringEncoding::Utf8) => {
-                // Latin-1 to UTF-8 is straightforward (single byte to potentially multi-byte)
-                self.emit_latin1_to_utf8_transcode(&mut func, param_count, target_func, options);
+                // latin1+utf16 → UTF-8. Branches on the source length tag
+                // (#253): tag-clear takes the 1-byte Latin-1 path; tag-set
+                // re-reads the source as UTF-16 and transcodes to UTF-8.
+                self.emit_latin1_to_utf8_transcode(
+                    &mut func,
+                    param_count,
+                    target_func,
+                    options,
+                    transcode_block_ty,
+                );
             }
 
             (StringEncoding::Latin1, StringEncoding::Utf16) => {
-                // #253 inc 2: Latin-1 to UTF-16 is total and unambiguous — each
-                // byte 0x00–0xFF zero-extends to one code unit U+0000–U+00FF.
-                self.emit_latin1_to_utf16_transcode(&mut func, param_count, target_func, options);
+                // #253: latin1+utf16 → UTF-16. Branches on the source length
+                // tag: tag-clear zero-extends each Latin-1 byte; tag-set does a
+                // verbatim UTF-16 code-unit copy.
+                self.emit_latin1_to_utf16_transcode(
+                    &mut func,
+                    param_count,
+                    target_func,
+                    options,
+                    transcode_block_ty,
+                );
+            }
+
+            (StringEncoding::Utf8, StringEncoding::Latin1) => {
+                // #253: UTF-8 → latin1+utf16. Two-phase encoder: if every code
+                // point ≤ 0xFF, write Latin-1 (tag clear); else write UTF-16
+                // (tag set).
+                self.emit_utf8_to_latin1_transcode(
+                    &mut func,
+                    param_count,
+                    target_func,
+                    options,
+                    transcode_block_ty,
+                );
+            }
+
+            (StringEncoding::Utf16, StringEncoding::Latin1) => {
+                // #253: UTF-16 → latin1+utf16. Two-phase encoder mirroring the
+                // UTF-8 case but scanning UTF-16 code units / surrogate pairs.
+                self.emit_utf16_to_latin1_transcode(
+                    &mut func,
+                    param_count,
+                    target_func,
+                    options,
+                    transcode_block_ty,
+                );
             }
 
             (caller_enc, callee_enc) if caller_enc == callee_enc => {
@@ -4189,14 +4782,67 @@ impl FactStyleGenerator {
         func.instruction(&Instruction::Call(target_func));
     }
 
-    /// Emit Latin-1 to UTF-8 transcoding
+    /// Emit `latin1+utf16` → UTF-8 transcoding.
+    ///
+    /// meld models the canonical-ABI `latin1+utf16` encoding as
+    /// [`StringEncoding::Latin1`]. The length operand (local 1) is **tagged**
+    /// (see [`UTF16_TAG`]):
+    /// - tag **clear** → the source is Latin-1 (1 byte/char); decode each byte
+    ///   0x00–0xFF as code point U+0000–U+00FF and re-encode as UTF-8. This is
+    ///   the path the pre-#253 implementation always took.
+    /// - tag **set** → the source is UTF-16 (`count = len & !UTF16_TAG` code
+    ///   units); the correct behaviour is a full UTF-16 → UTF-8 transcode
+    ///   (surrogate pairs, lossy U+FFFD for malformed units — the exact
+    ///   semantics of [`Self::emit_utf16_to_utf8_transcode`]).
+    ///
+    /// We dispatch at runtime on the tag. The two arms share the destination
+    /// target call: each inner emitter reads the (now-masked) code count from
+    /// local 1 and emits its own `Call(target_func)`, so the `If`/`Else` is two
+    /// complete, self-contained sub-programs.
+    fn emit_latin1_to_utf8_transcode(
+        &self,
+        func: &mut Function,
+        param_count: usize,
+        target_func: u32,
+        options: &AdapterOptions,
+        block_ty: wasm_encoder::BlockType,
+    ) {
+        // Decode the tag, then rewrite local 1 to the *masked* count so the
+        // inner emitters (which read local 1) see the untagged code/byte count.
+        // tag_set := (len & UTF16_TAG) != 0 ; len := len & !UTF16_TAG
+        let tag_local = param_count as u32; // reuse first scratch local
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32Const(UTF16_TAG));
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::LocalSet(tag_local));
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32Const(!UTF16_TAG));
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::LocalSet(1));
+
+        func.instruction(&Instruction::LocalGet(tag_local));
+        func.instruction(&Instruction::If(block_ty));
+        {
+            // Tag set: the latin1+utf16 source is UTF-16 — transcode as such.
+            self.emit_utf16_to_utf8_transcode(func, param_count, target_func, options);
+        }
+        func.instruction(&Instruction::Else);
+        {
+            // Tag clear: pure Latin-1 source — the original 1-byte path.
+            self.emit_latin1_pure_to_utf8_transcode(func, param_count, target_func, options);
+        }
+        func.instruction(&Instruction::End);
+    }
+
+    /// The tag-clear (pure Latin-1) leg of `latin1+utf16` → UTF-8.
     ///
     /// Latin-1 (ISO 8859-1) maps 1:1 to Unicode code points 0x00-0xFF.
     /// UTF-8 encoding: 0x00-0x7F → 1 byte, 0x80-0xFF → 2 bytes.
     /// Max output size = 2 * input length.
     ///
-    /// Assumes params start with (ptr: i32, len: i32), followed by other params.
-    fn emit_latin1_to_utf8_transcode(
+    /// Assumes params start with (ptr: i32, len: i32) where `len` is the
+    /// (already tag-masked) Latin-1 byte count.
+    fn emit_latin1_pure_to_utf8_transcode(
         &self,
         func: &mut Function,
         param_count: usize,
@@ -4363,7 +5009,166 @@ impl FactStyleGenerator {
         func.instruction(&Instruction::Call(target_func));
     }
 
-    /// Emit Latin-1 to UTF-16 transcoding (#253 increment 2).
+    /// Emit `latin1+utf16` → UTF-16 transcoding (#253).
+    ///
+    /// The source length operand (local 1) is **tagged** (see [`UTF16_TAG`]):
+    /// - tag **clear** → the source is Latin-1; zero-extend each byte
+    ///   0x00–0xFF to one UTF-16 code unit U+0000–U+00FF (the #253 increment-2
+    ///   path, total and unambiguous).
+    /// - tag **set** → the source is *already* UTF-16 (`count = len &
+    ///   !UTF16_TAG` code units); the destination is UTF-16, so this is a
+    ///   verbatim code-unit copy (2 bytes per unit, preserving surrogate pairs
+    ///   byte-for-byte).
+    ///
+    /// We dispatch at runtime on the tag, masking local 1 to the code count
+    /// first so the inner emitters see the untagged count.
+    fn emit_latin1_to_utf16_transcode(
+        &self,
+        func: &mut Function,
+        param_count: usize,
+        target_func: u32,
+        options: &AdapterOptions,
+        block_ty: wasm_encoder::BlockType,
+    ) {
+        let tag_local = param_count as u32; // reuse first scratch local
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32Const(UTF16_TAG));
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::LocalSet(tag_local));
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32Const(!UTF16_TAG));
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::LocalSet(1));
+
+        func.instruction(&Instruction::LocalGet(tag_local));
+        func.instruction(&Instruction::If(block_ty));
+        {
+            // Tag set: source is UTF-16 already → verbatim code-unit copy.
+            self.emit_utf16_verbatim_copy(func, param_count, target_func, options);
+        }
+        func.instruction(&Instruction::Else);
+        {
+            // Tag clear: pure Latin-1 → zero-extend each byte.
+            self.emit_latin1_pure_to_utf16_transcode(func, param_count, target_func, options);
+        }
+        func.instruction(&Instruction::End);
+    }
+
+    /// Verbatim UTF-16 → UTF-16 code-unit copy across memories.
+    ///
+    /// Used by the `latin1+utf16` → UTF-16 transcoder when the source's tag
+    /// bit is set (the source is already UTF-16). Copies `count` (local 1)
+    /// code units = `2 * count` bytes from caller to callee memory, preserving
+    /// surrogate pairs byte-for-byte. Calls target with (out_ptr, count,
+    /// ...rest).
+    fn emit_utf16_verbatim_copy(
+        &self,
+        func: &mut Function,
+        param_count: usize,
+        target_func: u32,
+        options: &AdapterOptions,
+    ) {
+        let callee_realloc = match options.callee_realloc {
+            Some(idx) => idx,
+            None => {
+                log::warn!("UTF-16 verbatim copy: no callee realloc, falling back to direct call");
+                for i in 0..param_count {
+                    func.instruction(&Instruction::LocalGet(i as u32));
+                }
+                func.instruction(&Instruction::Call(target_func));
+                return;
+            }
+        };
+
+        // Scratch (after params): +1 = idx (code unit), +2 = out_ptr, +3 = cu.
+        // (+0 holds the tag flag, set by the caller; do not reuse it.)
+        let idx_local = param_count as u32 + 1;
+        let out_ptr_local = param_count as u32 + 2;
+        let cu_local = param_count as u32 + 3;
+
+        let src_mem16 = wasm_encoder::MemArg {
+            offset: 0,
+            align: 1,
+            memory_index: options.caller_memory,
+        };
+        let dst_mem16 = wasm_encoder::MemArg {
+            offset: 0,
+            align: 1,
+            memory_index: options.callee_memory,
+        };
+
+        // Allocate 2 * count bytes (LS-A-7: wrap guard + OOM guard).
+        let callee_align = alignment_for_encoding(options.callee_string_encoding);
+        func.instruction(&Instruction::LocalGet(1)); // count
+        func.instruction(&Instruction::I32Const((u32::MAX / 2) as i32));
+        func.instruction(&Instruction::I32GtU);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::Unreachable);
+        func.instruction(&Instruction::End);
+
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::I32Const(callee_align));
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32Const(2));
+        func.instruction(&Instruction::I32Mul);
+        func.instruction(&Instruction::Call(callee_realloc));
+        func.instruction(&Instruction::LocalSet(out_ptr_local));
+
+        func.instruction(&Instruction::LocalGet(out_ptr_local));
+        func.instruction(&Instruction::I32Eqz);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::Unreachable);
+        func.instruction(&Instruction::End);
+
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::LocalSet(idx_local));
+
+        func.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+
+        func.instruction(&Instruction::LocalGet(idx_local));
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32GeU);
+        func.instruction(&Instruction::BrIf(1));
+
+        // cu = mem16[src_ptr + idx*2]
+        func.instruction(&Instruction::LocalGet(0));
+        func.instruction(&Instruction::LocalGet(idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Shl);
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::I32Load16U(src_mem16));
+        func.instruction(&Instruction::LocalSet(cu_local));
+
+        // mem16[out_ptr + idx*2] = cu
+        func.instruction(&Instruction::LocalGet(out_ptr_local));
+        func.instruction(&Instruction::LocalGet(idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Shl);
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::LocalGet(cu_local));
+        func.instruction(&Instruction::I32Store16(dst_mem16));
+
+        func.instruction(&Instruction::LocalGet(idx_local));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::I32Add);
+        func.instruction(&Instruction::LocalSet(idx_local));
+
+        func.instruction(&Instruction::Br(0));
+        func.instruction(&Instruction::End); // loop
+        func.instruction(&Instruction::End); // block
+
+        // Call target with (out_ptr, count, ...rest).
+        func.instruction(&Instruction::LocalGet(out_ptr_local));
+        func.instruction(&Instruction::LocalGet(1));
+        for i in 2..param_count {
+            func.instruction(&Instruction::LocalGet(i as u32));
+        }
+        func.instruction(&Instruction::Call(target_func));
+    }
+
+    /// The tag-clear (pure Latin-1) leg of `latin1+utf16` → UTF-16.
     ///
     /// This direction is **total and unambiguous**: every Latin-1 byte
     /// 0x00–0xFF maps to exactly one UTF-16 code unit U+0000–U+00FF by
@@ -4373,10 +5178,10 @@ impl FactStyleGenerator {
     /// (1:1), and the output buffer is exactly `2 * byte_len` bytes.
     ///
     /// Assumes params start with (ptr: i32, byte_len: i32) where byte_len is
-    /// the Latin-1 byte count (== char count). Calls target with
+    /// the (tag-masked) Latin-1 byte count (== char count). Calls target with
     /// (out_ptr: i32, code_unit_count: i32, ...rest); code_unit_count ==
     /// byte_len.
-    fn emit_latin1_to_utf16_transcode(
+    fn emit_latin1_pure_to_utf16_transcode(
         &self,
         func: &mut Function,
         param_count: usize,
@@ -4499,6 +5304,438 @@ impl FactStyleGenerator {
             func.instruction(&Instruction::LocalGet(i as u32));
         }
         func.instruction(&Instruction::Call(target_func));
+    }
+
+    /// Emit UTF-8 → `latin1+utf16` transcoding (#253).
+    ///
+    /// `latin1+utf16` (meld's [`StringEncoding::Latin1`]) is the Component
+    /// Model's compact representation: each string is EITHER pure Latin-1 (1
+    /// byte/char, length operand tag-clear) OR UTF-16 (2 bytes/code-unit,
+    /// length operand tagged with [`UTF16_TAG`]). This is therefore an
+    /// *encoder*, not a lossy down-conversion — it represents every input.
+    ///
+    /// Two-phase:
+    /// - **Phase A (scan):** decode the UTF-8 source; set `needs_utf16` if any
+    ///   decoded code point exceeds 0xFF (malformed input decodes to U+FFFD,
+    ///   which is > 0xFF, so it forces the UTF-16 representation).
+    /// - **Phase B (write):**
+    ///   - tag clear: decode again, write each code point as one Latin-1 byte;
+    ///     length = char count (no tag).
+    ///   - tag set: decode again, write UTF-16 (surrogate pairs for > 0xFFFF);
+    ///     length = `code_units | UTF16_TAG`.
+    ///
+    /// Output buffer is `2 * byte_len` bytes (the UTF-16 worst case, which also
+    /// bounds the Latin-1 case since char count ≤ byte_len). Mirrors the
+    /// LS-A-7 realloc/OOM/overflow guards.
+    fn emit_utf8_to_latin1_transcode(
+        &self,
+        func: &mut Function,
+        param_count: usize,
+        target_func: u32,
+        options: &AdapterOptions,
+        block_ty: wasm_encoder::BlockType,
+    ) {
+        let callee_realloc = match options.callee_realloc {
+            Some(idx) => idx,
+            None => {
+                log::warn!(
+                    "UTF-8→latin1+utf16 transcode: no callee realloc, falling back to direct call"
+                );
+                for i in 0..param_count {
+                    func.instruction(&Instruction::LocalGet(i as u32));
+                }
+                func.instruction(&Instruction::Call(target_func));
+                return;
+            }
+        };
+
+        // Locals: +0 src_idx, +1 flag/dst_idx, +2 out_ptr, +3 byte, +4 cp,
+        // +5 cont. `flag` (needs_utf16) lives in +1 only during the scan; the
+        // write phases re-use +1 as dst_idx.
+        let src_idx_local = param_count as u32;
+        let flag_local = param_count as u32 + 1;
+        let dst_idx_local = param_count as u32 + 1;
+        let out_ptr_local = param_count as u32 + 2;
+        let byte_local = param_count as u32 + 3;
+        let cp_local = param_count as u32 + 4;
+        let cont_local = param_count as u32 + 5;
+
+        let src_mem8 = wasm_encoder::MemArg {
+            offset: 0,
+            align: 0,
+            memory_index: options.caller_memory,
+        };
+        let dst_mem8 = wasm_encoder::MemArg {
+            offset: 0,
+            align: 0,
+            memory_index: options.callee_memory,
+        };
+        let dst_mem16 = wasm_encoder::MemArg {
+            offset: 0,
+            align: 1,
+            memory_index: options.callee_memory,
+        };
+
+        // Allocate 2 * byte_len bytes (UTF-16 worst case; bounds Latin-1 too).
+        let callee_align = alignment_for_encoding(options.callee_string_encoding);
+        func.instruction(&Instruction::LocalGet(1)); // byte_len
+        func.instruction(&Instruction::I32Const((u32::MAX / 2) as i32));
+        func.instruction(&Instruction::I32GtU);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::Unreachable);
+        func.instruction(&Instruction::End);
+
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::I32Const(callee_align));
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32Const(2));
+        func.instruction(&Instruction::I32Mul);
+        func.instruction(&Instruction::Call(callee_realloc));
+        func.instruction(&Instruction::LocalSet(out_ptr_local));
+
+        func.instruction(&Instruction::LocalGet(out_ptr_local));
+        func.instruction(&Instruction::I32Eqz);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::Unreachable);
+        func.instruction(&Instruction::End);
+
+        // --- Phase A: scan to decide latin1-vs-utf16. ---
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::LocalSet(flag_local)); // needs_utf16 = 0
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::LocalSet(src_idx_local));
+
+        func.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::LocalGet(src_idx_local));
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32GeU);
+        func.instruction(&Instruction::BrIf(1));
+
+        emit_utf8_decode_codepoint(
+            func,
+            src_mem8,
+            0,
+            src_idx_local,
+            1,
+            byte_local,
+            cp_local,
+            cont_local,
+        );
+        // if cp > 0xFF: needs_utf16 = 1
+        func.instruction(&Instruction::LocalGet(cp_local));
+        func.instruction(&Instruction::I32Const(0xFF));
+        func.instruction(&Instruction::I32GtU);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::LocalSet(flag_local));
+        func.instruction(&Instruction::End);
+
+        func.instruction(&Instruction::Br(0));
+        func.instruction(&Instruction::End); // loop
+        func.instruction(&Instruction::End); // block
+
+        // --- Phase B: write, branching on the flag. ---
+        func.instruction(&Instruction::LocalGet(flag_local));
+        func.instruction(&Instruction::If(block_ty));
+        {
+            // UTF-16 representation (tag set).
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::LocalSet(src_idx_local));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::LocalSet(dst_idx_local));
+
+            func.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::LocalGet(src_idx_local));
+            func.instruction(&Instruction::LocalGet(1));
+            func.instruction(&Instruction::I32GeU);
+            func.instruction(&Instruction::BrIf(1));
+
+            emit_utf8_decode_codepoint(
+                func,
+                src_mem8,
+                0,
+                src_idx_local,
+                1,
+                byte_local,
+                cp_local,
+                cont_local,
+            );
+            emit_utf16_encode_codepoint(func, dst_mem16, out_ptr_local, dst_idx_local, cp_local);
+
+            func.instruction(&Instruction::Br(0));
+            func.instruction(&Instruction::End); // loop
+            func.instruction(&Instruction::End); // block
+
+            // Call target with (out_ptr, code_units | UTF16_TAG, ...rest).
+            func.instruction(&Instruction::LocalGet(out_ptr_local));
+            func.instruction(&Instruction::LocalGet(dst_idx_local));
+            func.instruction(&Instruction::I32Const(UTF16_TAG));
+            func.instruction(&Instruction::I32Or);
+            for i in 2..param_count {
+                func.instruction(&Instruction::LocalGet(i as u32));
+            }
+            func.instruction(&Instruction::Call(target_func));
+        }
+        func.instruction(&Instruction::Else);
+        {
+            // Latin-1 representation (tag clear). cp <= 0xFF for all chars.
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::LocalSet(src_idx_local));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::LocalSet(dst_idx_local));
+
+            func.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::LocalGet(src_idx_local));
+            func.instruction(&Instruction::LocalGet(1));
+            func.instruction(&Instruction::I32GeU);
+            func.instruction(&Instruction::BrIf(1));
+
+            emit_utf8_decode_codepoint(
+                func,
+                src_mem8,
+                0,
+                src_idx_local,
+                1,
+                byte_local,
+                cp_local,
+                cont_local,
+            );
+            // out[dst_idx] = cp (one Latin-1 byte)
+            func.instruction(&Instruction::LocalGet(out_ptr_local));
+            func.instruction(&Instruction::LocalGet(dst_idx_local));
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::LocalGet(cp_local));
+            func.instruction(&Instruction::I32Store8(dst_mem8));
+            func.instruction(&Instruction::LocalGet(dst_idx_local));
+            func.instruction(&Instruction::I32Const(1));
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::LocalSet(dst_idx_local));
+
+            func.instruction(&Instruction::Br(0));
+            func.instruction(&Instruction::End); // loop
+            func.instruction(&Instruction::End); // block
+
+            // Call target with (out_ptr, char_count, ...rest) — tag clear.
+            func.instruction(&Instruction::LocalGet(out_ptr_local));
+            func.instruction(&Instruction::LocalGet(dst_idx_local));
+            for i in 2..param_count {
+                func.instruction(&Instruction::LocalGet(i as u32));
+            }
+            func.instruction(&Instruction::Call(target_func));
+        }
+        func.instruction(&Instruction::End); // end flag branch
+    }
+
+    /// Emit UTF-16 → `latin1+utf16` transcoding (#253).
+    ///
+    /// The mirror of [`Self::emit_utf8_to_latin1_transcode`] for a UTF-16
+    /// source. The source length operand (local 1) is a code-unit count.
+    /// Two-phase: scan the UTF-16 code units (decoding surrogate pairs and
+    /// replacing lone surrogates with U+FFFD per the Canonical ABI) to decide
+    /// latin1-vs-utf16; then write the chosen representation. The output buffer
+    /// is `2 * code_units` bytes (the UTF-16-verbatim worst case).
+    fn emit_utf16_to_latin1_transcode(
+        &self,
+        func: &mut Function,
+        param_count: usize,
+        target_func: u32,
+        options: &AdapterOptions,
+        block_ty: wasm_encoder::BlockType,
+    ) {
+        let callee_realloc = match options.callee_realloc {
+            Some(idx) => idx,
+            None => {
+                log::warn!(
+                    "UTF-16→latin1+utf16 transcode: no callee realloc, falling back to direct call"
+                );
+                for i in 0..param_count {
+                    func.instruction(&Instruction::LocalGet(i as u32));
+                }
+                func.instruction(&Instruction::Call(target_func));
+                return;
+            }
+        };
+
+        // Locals: +0 src_idx (code units), +1 flag/dst_idx, +2 out_ptr,
+        // +3 cu, +4 cp, +5 cu2.
+        let src_idx_local = param_count as u32;
+        let flag_local = param_count as u32 + 1;
+        let dst_idx_local = param_count as u32 + 1;
+        let out_ptr_local = param_count as u32 + 2;
+        let cu_local = param_count as u32 + 3;
+        let cp_local = param_count as u32 + 4;
+        let cu2_local = param_count as u32 + 5;
+
+        let src_mem16 = wasm_encoder::MemArg {
+            offset: 0,
+            align: 1,
+            memory_index: options.caller_memory,
+        };
+        let dst_mem8 = wasm_encoder::MemArg {
+            offset: 0,
+            align: 0,
+            memory_index: options.callee_memory,
+        };
+        let dst_mem16 = wasm_encoder::MemArg {
+            offset: 0,
+            align: 1,
+            memory_index: options.callee_memory,
+        };
+
+        // Allocate 2 * code_units bytes.
+        let callee_align = alignment_for_encoding(options.callee_string_encoding);
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32Const((u32::MAX / 2) as i32));
+        func.instruction(&Instruction::I32GtU);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::Unreachable);
+        func.instruction(&Instruction::End);
+
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::I32Const(callee_align));
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32Const(2));
+        func.instruction(&Instruction::I32Mul);
+        func.instruction(&Instruction::Call(callee_realloc));
+        func.instruction(&Instruction::LocalSet(out_ptr_local));
+
+        func.instruction(&Instruction::LocalGet(out_ptr_local));
+        func.instruction(&Instruction::I32Eqz);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::Unreachable);
+        func.instruction(&Instruction::End);
+
+        // --- Phase A: scan to decide latin1-vs-utf16. ---
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::LocalSet(flag_local));
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::LocalSet(src_idx_local));
+
+        func.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::LocalGet(src_idx_local));
+        func.instruction(&Instruction::LocalGet(1));
+        func.instruction(&Instruction::I32GeU);
+        func.instruction(&Instruction::BrIf(1));
+
+        emit_utf16_decode_codepoint(
+            func,
+            src_mem16,
+            0,
+            src_idx_local,
+            1,
+            cu_local,
+            cp_local,
+            cu2_local,
+        );
+        func.instruction(&Instruction::LocalGet(cp_local));
+        func.instruction(&Instruction::I32Const(0xFF));
+        func.instruction(&Instruction::I32GtU);
+        func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::LocalSet(flag_local));
+        func.instruction(&Instruction::End);
+
+        func.instruction(&Instruction::Br(0));
+        func.instruction(&Instruction::End); // loop
+        func.instruction(&Instruction::End); // block
+
+        // --- Phase B: write, branching on the flag. ---
+        func.instruction(&Instruction::LocalGet(flag_local));
+        func.instruction(&Instruction::If(block_ty));
+        {
+            // UTF-16 representation (tag set). Re-decode and re-encode rather
+            // than verbatim-copy so lone surrogates are normalised to U+FFFD
+            // consistently with phase A's decision.
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::LocalSet(src_idx_local));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::LocalSet(dst_idx_local));
+
+            func.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::LocalGet(src_idx_local));
+            func.instruction(&Instruction::LocalGet(1));
+            func.instruction(&Instruction::I32GeU);
+            func.instruction(&Instruction::BrIf(1));
+
+            emit_utf16_decode_codepoint(
+                func,
+                src_mem16,
+                0,
+                src_idx_local,
+                1,
+                cu_local,
+                cp_local,
+                cu2_local,
+            );
+            emit_utf16_encode_codepoint(func, dst_mem16, out_ptr_local, dst_idx_local, cp_local);
+
+            func.instruction(&Instruction::Br(0));
+            func.instruction(&Instruction::End); // loop
+            func.instruction(&Instruction::End); // block
+
+            func.instruction(&Instruction::LocalGet(out_ptr_local));
+            func.instruction(&Instruction::LocalGet(dst_idx_local));
+            func.instruction(&Instruction::I32Const(UTF16_TAG));
+            func.instruction(&Instruction::I32Or);
+            for i in 2..param_count {
+                func.instruction(&Instruction::LocalGet(i as u32));
+            }
+            func.instruction(&Instruction::Call(target_func));
+        }
+        func.instruction(&Instruction::Else);
+        {
+            // Latin-1 representation (tag clear). cp <= 0xFF for all code points.
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::LocalSet(src_idx_local));
+            func.instruction(&Instruction::I32Const(0));
+            func.instruction(&Instruction::LocalSet(dst_idx_local));
+
+            func.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+            func.instruction(&Instruction::LocalGet(src_idx_local));
+            func.instruction(&Instruction::LocalGet(1));
+            func.instruction(&Instruction::I32GeU);
+            func.instruction(&Instruction::BrIf(1));
+
+            emit_utf16_decode_codepoint(
+                func,
+                src_mem16,
+                0,
+                src_idx_local,
+                1,
+                cu_local,
+                cp_local,
+                cu2_local,
+            );
+            func.instruction(&Instruction::LocalGet(out_ptr_local));
+            func.instruction(&Instruction::LocalGet(dst_idx_local));
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::LocalGet(cp_local));
+            func.instruction(&Instruction::I32Store8(dst_mem8));
+            func.instruction(&Instruction::LocalGet(dst_idx_local));
+            func.instruction(&Instruction::I32Const(1));
+            func.instruction(&Instruction::I32Add);
+            func.instruction(&Instruction::LocalSet(dst_idx_local));
+
+            func.instruction(&Instruction::Br(0));
+            func.instruction(&Instruction::End); // loop
+            func.instruction(&Instruction::End); // block
+
+            func.instruction(&Instruction::LocalGet(out_ptr_local));
+            func.instruction(&Instruction::LocalGet(dst_idx_local));
+            for i in 2..param_count {
+                func.instruction(&Instruction::LocalGet(i as u32));
+            }
+            func.instruction(&Instruction::Call(target_func));
+        }
+        func.instruction(&Instruction::End); // end flag branch
     }
 
     /// Resolve the target function index in the merged module
@@ -5834,10 +7071,15 @@ mod tests {
 
     #[test]
     fn test_sr17_alignment_for_latin1() {
+        // #253: `Latin1` is meld's model of the canonical-ABI `latin1+utf16`
+        // encoding. Its string buffer may hold UTF-16 code units (the tag-set
+        // representation), so the canonical ABI requires 2-byte alignment for
+        // the string pointer — NOT 1. (A pure-Latin-1-only encoding would be 1,
+        // but meld has no such encoding; Latin1 IS latin1+utf16.)
         assert_eq!(
             alignment_for_encoding(StringEncoding::Latin1),
-            1,
-            "SR-17: Latin-1 alignment should be 1 (byte-aligned)"
+            2,
+            "#253: latin1+utf16 alignment should be 2 (buffer may hold UTF-16)"
         );
     }
 
@@ -5995,7 +7237,17 @@ mod tests {
         } else if options.caller_string_encoding == StringEncoding::Latin1
             && options.callee_string_encoding == StringEncoding::Utf8
         {
-            gen_.emit_latin1_to_utf8_transcode(&mut f, 2, 0, &options);
+            // The test only inspects the emitted byte patterns (it never
+            // validates or runs the body), so the tag-dispatch block type is
+            // immaterial here; Empty keeps the raw body well-formed for the
+            // structural pattern checks.
+            gen_.emit_latin1_to_utf8_transcode(
+                &mut f,
+                2,
+                0,
+                &options,
+                wasm_encoder::BlockType::Empty,
+            );
         } else {
             panic!("unsupported encoding pair for test");
         }

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -1024,10 +1024,16 @@ fn emit_patch_nested_indirections(
         body.instruction(&Instruction::I32GtU);
         body.instruction(&Instruction::BrIf(0));
 
-        // new_ptr = realloc(0, 0, 1, buf_len) in caller memory
+        // new_ptr = realloc(0, 0, align, buf_len) in caller memory.
+        // align 2 for a compact-utf16 inner string (the buffer may hold a
+        // UTF-16 payload), else 1 — matching the other tag-aware copy sites.
         body.instruction(&Instruction::I32Const(0));
         body.instruction(&Instruction::I32Const(0));
-        body.instruction(&Instruction::I32Const(1));
+        body.instruction(&Instruction::I32Const(if inner_compact_utf16 {
+            2
+        } else {
+            1
+        }));
         body.instruction(&Instruction::LocalGet(l_buf_len));
         emit_checked_realloc(body, realloc_func, l_new_ptr);
 

--- a/meld-core/tests/adapter_safety.rs
+++ b/meld-core/tests/adapter_safety.rs
@@ -3745,3 +3745,48 @@ fn ls_p_21_latin1_utf16_tag_honored_roundtrip() {
         "LS-P-21: latin1-fits UTF-8 must encode as tag-clear Latin-1"
     );
 }
+
+/// LS-P-21 (#253 memory-safety follow-up): a SAME-ENCODING CompactUTF16 →
+/// CompactUTF16 fusion takes the bulk memory-copy adapter path (no transcoding,
+/// since caller and callee encodings match). The caller lowers a tag-SET
+/// (UTF-16-represented) latin1+utf16 string "日本" = [0x65E5, 0x672C] with the
+/// length operand `2 | UTF16_TAG`. Before the fix the copy machinery treated
+/// the length as untagged and issued a `memory.copy` / `cabi_realloc` of
+/// `(2 | 0x8000_0000)` bytes (~2 GiB) — a confirmed wasmtime OOB trap. After
+/// the fix `emit_copy_byte_count` masks the tag and copies `(2)*2 = 4` bytes,
+/// the tag-aware callee reads 2 UTF-16 units and sums them: 0x65E5 + 0x672C =
+/// 52497. The forwarded length stays tagged so the callee decodes correctly.
+#[test]
+fn ls_p_21_same_encoding_compact_tagset_param_copy_roundtrips() {
+    let result = fuse_run_i32(
+        &build_caller_latin1_tagged_lowering_component(&[0x65E5, 0x672C]),
+        &build_callee_compact_decoding_component(),
+        "same-encoding CompactUTF16 tag-set param copy",
+    );
+    assert_eq!(
+        result, 52497,
+        "tag-set latin1+utf16 same-encoding copy must mask the tag (copy 4 bytes), \
+         not OOB-copy 0x8000_0002 bytes; callee sums the 2 UTF-16 units 0x65E5+0x672C"
+    );
+}
+
+/// LS-P-21 (#253) tag-CLEAR control for the same-encoding memory-copy path.
+/// A pure-Latin-1 (tag-clear) latin1+utf16 string "café" Latin-1 bytes
+/// [0x63,0x61,0x66,0xE9], length operand `4` (tag clear), CompactUTF16 →
+/// CompactUTF16. The tag-aware byte count returns `len` unchanged (tag bit
+/// clear), so 4 bytes are copied and the callee's 8-bit path sums them:
+/// 0x63+0x61+0x66+0xE9 = 99+97+102+233 = 531. Proves the tag-aware fix does
+/// not regress the tag-clear path.
+#[test]
+fn ls_p_21_same_encoding_compact_tagclear_param_copy_roundtrips() {
+    let result = fuse_run_i32(
+        &build_caller_latin1_lowering_component(&[0x63, 0x61, 0x66, 0xE9]),
+        &build_callee_compact_decoding_component(),
+        "same-encoding CompactUTF16 tag-clear param copy",
+    );
+    assert_eq!(
+        result, 531,
+        "tag-clear latin1+utf16 same-encoding copy must copy len bytes verbatim; \
+         callee 8-bit path sums café Latin-1 bytes 0x63+0x61+0x66+0xE9"
+    );
+}

--- a/meld-core/tests/adapter_safety.rs
+++ b/meld-core/tests/adapter_safety.rs
@@ -3123,21 +3123,445 @@ fn test_sr17_latin1_to_utf16_transcoding() {
     }
 }
 
-/// #253 fail-loud guard (still-unsupported direction): the down-conversion
-/// directions remain genuinely ambiguous and stay on the unchanged catch-all
-/// `Err` arm. Increment 2 only added (Latin1 → Utf16); (Utf16 → Latin1) is
-/// NOT implemented (code points > 0xFF are unrepresentable in Latin-1), so it
-/// must still FAIL fusion loudly rather than silently emit a wrong adapter.
-///
-/// Fixture: a UTF-16-lowering caller fused into a CompactUTF16-lifting callee
-/// (meld maps CompactUTF16 → Latin1), producing the (Utf16, Latin1) pair.
-/// Fusion must return Err. (The complementary (Utf8 → Latin1) pair shares the
-/// same unchanged catch-all and is not separately fixtured here.)
-#[test]
-fn test_253_utf16_to_latin1_transcode_fails_loud() {
-    let callee = build_callee_codeunit_summing_component(CanonicalOption::CompactUTF16); // → Latin1
-    let caller = build_caller_utf16_lowering_component(&[0x0041]);
+// ===========================================================================
+// #253 (final increment): spec-faithful latin1+utf16 (CompactUTF16) transcoding
+//
+// meld models the canonical-ABI `latin1+utf16` encoding as
+// `StringEncoding::Latin1`. The length operand is TAGGED with
+// UTF16_TAG = 1<<31: tag-clear means the payload is Latin-1 (1 byte/char,
+// byte length == operand); tag-set means the payload is UTF-16 (code-unit
+// count == operand & !UTF16_TAG, byte length == that × 2).
+//
+// The fixtures below exercise both the READ side (Latin1 as the *source*: a
+// tag-clear / tag-set caller into a UTF-8 or UTF-16 callee) and the WRITE side
+// (Latin1 as the *destination*: a UTF-8 / UTF-16 caller into a tag-decoding
+// CompactUTF16 callee that picks the representation + sets the tag).
+// ===========================================================================
 
+const UTF16_TAG: u32 = 1 << 31;
+
+/// A tag-aware decoding callee that lifts with `CompactUTF16` (meld maps it to
+/// `StringEncoding::Latin1`). Its core `process-string(ptr, tagged_len) -> sum`
+/// branches on the canonical-ABI tag:
+///
+/// - tag SET → payload is UTF-16; count = len & !UTF16_TAG; sum 16-bit code
+///   units (`mem16[ptr + i*2]`).
+/// - tag CLEAR → payload is Latin-1; sum 8-bit bytes (`mem8[ptr + i]`).
+///
+/// The differential oracle is the per-representation sum: a wrong tag would
+/// drive the callee to read the wrong element width and produce a wrong sum,
+/// and wrong bytes would also mis-sum — so the sum pins both the tag decision
+/// AND the written bytes. This is the WRITE-side oracle for #253
+/// (`emit_utf8_to_latin1_transcode` / `emit_utf16_to_latin1_transcode`).
+fn build_callee_compact_decoding_component() -> Vec<u8> {
+    let core_module = {
+        let mut types = TypeSection::new();
+        types.ty().function(
+            [
+                wasm_encoder::ValType::I32,
+                wasm_encoder::ValType::I32,
+                wasm_encoder::ValType::I32,
+                wasm_encoder::ValType::I32,
+            ],
+            [wasm_encoder::ValType::I32],
+        );
+        types.ty().function(
+            [wasm_encoder::ValType::I32, wasm_encoder::ValType::I32],
+            [wasm_encoder::ValType::I32],
+        );
+
+        let mut functions = FunctionSection::new();
+        functions.function(0); // cabi_realloc
+        functions.function(1); // process-string
+
+        let mut memory = MemorySection::new();
+        memory.memory(MemoryType {
+            minimum: 1,
+            maximum: None,
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        });
+
+        let mut globals = GlobalSection::new();
+        globals.global(
+            GlobalType {
+                val_type: wasm_encoder::ValType::I32,
+                mutable: true,
+                shared: false,
+            },
+            &ConstExpr::i32_const(1024),
+        );
+
+        let mut exports = ExportSection::new();
+        exports.export("cabi_realloc", ExportKind::Func, 0);
+        exports.export("test:api/api#process-string", ExportKind::Func, 1);
+        exports.export("memory", ExportKind::Memory, 0);
+
+        let mut code = CodeSection::new();
+        {
+            let mut f = Function::new([]);
+            emit_cabi_realloc(&mut f, 0);
+            code.function(&f);
+        }
+        // func 1: process-string(ptr, tagged_len) -> sum.
+        // locals: 0=ptr, 1=tagged_len, 2=sum, 3=index, 4=count, 5=tag_set
+        {
+            let mut f = Function::new(vec![(4, wasm_encoder::ValType::I32)]);
+            // tag_set = (tagged_len & UTF16_TAG) != 0
+            f.instruction(&Instruction::LocalGet(1));
+            f.instruction(&Instruction::I32Const(UTF16_TAG as i32));
+            f.instruction(&Instruction::I32And);
+            f.instruction(&Instruction::LocalSet(5));
+            // count = tagged_len & !UTF16_TAG
+            f.instruction(&Instruction::LocalGet(1));
+            f.instruction(&Instruction::I32Const(!UTF16_TAG as i32));
+            f.instruction(&Instruction::I32And);
+            f.instruction(&Instruction::LocalSet(4));
+
+            f.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+            f.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
+            // if index >= count, break
+            f.instruction(&Instruction::LocalGet(3));
+            f.instruction(&Instruction::LocalGet(4));
+            f.instruction(&Instruction::I32GeU);
+            f.instruction(&Instruction::BrIf(1));
+
+            // if tag_set: sum += mem16[ptr + index*2]; else sum += mem8[ptr + index]
+            f.instruction(&Instruction::LocalGet(5));
+            f.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
+            {
+                f.instruction(&Instruction::LocalGet(0));
+                f.instruction(&Instruction::LocalGet(3));
+                f.instruction(&Instruction::I32Const(1));
+                f.instruction(&Instruction::I32Shl);
+                f.instruction(&Instruction::I32Add);
+                f.instruction(&Instruction::I32Load16U(wasm_encoder::MemArg {
+                    offset: 0,
+                    align: 1,
+                    memory_index: 0,
+                }));
+                f.instruction(&Instruction::LocalGet(2));
+                f.instruction(&Instruction::I32Add);
+                f.instruction(&Instruction::LocalSet(2));
+            }
+            f.instruction(&Instruction::Else);
+            {
+                f.instruction(&Instruction::LocalGet(0));
+                f.instruction(&Instruction::LocalGet(3));
+                f.instruction(&Instruction::I32Add);
+                f.instruction(&Instruction::I32Load8U(wasm_encoder::MemArg {
+                    offset: 0,
+                    align: 0,
+                    memory_index: 0,
+                }));
+                f.instruction(&Instruction::LocalGet(2));
+                f.instruction(&Instruction::I32Add);
+                f.instruction(&Instruction::LocalSet(2));
+            }
+            f.instruction(&Instruction::End);
+
+            // index += 1
+            f.instruction(&Instruction::LocalGet(3));
+            f.instruction(&Instruction::I32Const(1));
+            f.instruction(&Instruction::I32Add);
+            f.instruction(&Instruction::LocalSet(3));
+
+            f.instruction(&Instruction::Br(0));
+            f.instruction(&Instruction::End); // loop
+            f.instruction(&Instruction::End); // block
+
+            f.instruction(&Instruction::LocalGet(2));
+            f.instruction(&Instruction::End);
+            code.function(&f);
+        }
+
+        let mut module = Module::new();
+        module
+            .section(&types)
+            .section(&functions)
+            .section(&memory)
+            .section(&globals)
+            .section(&exports)
+            .section(&code);
+        module
+    };
+
+    let mut component = Component::new();
+    component.section(&ModuleSection(&core_module));
+    {
+        let mut types = ComponentTypeSection::new();
+        types
+            .function()
+            .params([(
+                "s",
+                wasm_encoder::ComponentValType::Primitive(wasm_encoder::PrimitiveValType::String),
+            )])
+            .result(Some(wasm_encoder::ComponentValType::Primitive(
+                wasm_encoder::PrimitiveValType::U32,
+            )));
+        component.section(&types);
+    }
+    {
+        let mut inst = InstanceSection::new();
+        let no_args: Vec<(&str, ModuleArg)> = vec![];
+        inst.instantiate(0, no_args);
+        component.section(&inst);
+    }
+    for name in ["cabi_realloc", "test:api/api#process-string"] {
+        let mut aliases = ComponentAliasSection::new();
+        aliases.alias(Alias::CoreInstanceExport {
+            instance: 0,
+            kind: ExportKind::Func,
+            name,
+        });
+        component.section(&aliases);
+    }
+    {
+        let mut aliases = ComponentAliasSection::new();
+        aliases.alias(Alias::CoreInstanceExport {
+            instance: 0,
+            kind: ExportKind::Memory,
+            name: "memory",
+        });
+        component.section(&aliases);
+    }
+    {
+        let mut canon = CanonicalFunctionSection::new();
+        canon.lift(
+            1,
+            0,
+            [
+                CanonicalOption::CompactUTF16, // meld → Latin1 (latin1+utf16)
+                CanonicalOption::Memory(0),
+                CanonicalOption::Realloc(0),
+            ],
+        );
+        component.section(&canon);
+    }
+    {
+        let mut exp = ComponentExportSection::new();
+        exp.export("test:api/api", ComponentExportKind::Func, 0, None);
+        component.section(&exp);
+    }
+    component.finish()
+}
+
+/// A CompactUTF16-lowering caller (meld → Latin1) whose stored payload is
+/// UTF-16 and whose length operand has the **tag SET** (`code_units |
+/// UTF16_TAG`). This drives the READ-side tag-set path: a latin1+utf16 source
+/// string that is actually UTF-16. Mirrors `build_caller_latin1_lowering_component`
+/// (which is the tag-CLEAR / pure-Latin-1 variant) but stores 2 bytes/code-unit
+/// and tags the length.
+fn build_caller_latin1_tagged_lowering_component(code_units: &[u16]) -> Vec<u8> {
+    let mut data_bytes = Vec::new();
+    for cu in code_units {
+        data_bytes.extend_from_slice(&cu.to_le_bytes());
+    }
+    let tagged_len = (code_units.len() as u32 | UTF16_TAG) as i32;
+
+    let core_module = {
+        let mut types = TypeSection::new();
+        types.ty().function(
+            [wasm_encoder::ValType::I32, wasm_encoder::ValType::I32],
+            [wasm_encoder::ValType::I32],
+        );
+        types.ty().function([], [wasm_encoder::ValType::I32]);
+        types.ty().function(
+            [
+                wasm_encoder::ValType::I32,
+                wasm_encoder::ValType::I32,
+                wasm_encoder::ValType::I32,
+                wasm_encoder::ValType::I32,
+            ],
+            [wasm_encoder::ValType::I32],
+        );
+
+        let mut imports = ImportSection::new();
+        imports.import(
+            "test:api/api",
+            "process-string",
+            wasm_encoder::EntityType::Function(0),
+        );
+
+        let mut functions = FunctionSection::new();
+        functions.function(1); // run
+        functions.function(2); // cabi_realloc
+
+        let mut memory = MemorySection::new();
+        memory.memory(MemoryType {
+            minimum: 1,
+            maximum: None,
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        });
+
+        let mut globals = GlobalSection::new();
+        globals.global(
+            GlobalType {
+                val_type: wasm_encoder::ValType::I32,
+                mutable: true,
+                shared: false,
+            },
+            &ConstExpr::i32_const(1024),
+        );
+
+        let mut exports = ExportSection::new();
+        exports.export("run", ExportKind::Func, 1);
+        exports.export("cabi_realloc", ExportKind::Func, 2);
+        exports.export("memory", ExportKind::Memory, 0);
+
+        let mut code = CodeSection::new();
+        {
+            let mut f = Function::new([]);
+            f.instruction(&Instruction::I32Const(0)); // ptr
+            f.instruction(&Instruction::I32Const(tagged_len)); // tagged code-unit count
+            f.instruction(&Instruction::Call(0));
+            f.instruction(&Instruction::End);
+            code.function(&f);
+        }
+        {
+            let mut f = Function::new([]);
+            emit_cabi_realloc(&mut f, 0);
+            code.function(&f);
+        }
+
+        let mut data = DataSection::new();
+        data.segment(DataSegment {
+            mode: DataSegmentMode::Active {
+                memory_index: 0,
+                offset: &ConstExpr::i32_const(0),
+            },
+            data: data_bytes,
+        });
+
+        let mut module = Module::new();
+        module
+            .section(&types)
+            .section(&imports)
+            .section(&functions)
+            .section(&memory)
+            .section(&globals)
+            .section(&exports)
+            .section(&code)
+            .section(&data);
+        module
+    };
+
+    let mem_provider = {
+        let mut types = TypeSection::new();
+        types.ty().function(
+            [
+                wasm_encoder::ValType::I32,
+                wasm_encoder::ValType::I32,
+                wasm_encoder::ValType::I32,
+                wasm_encoder::ValType::I32,
+            ],
+            [wasm_encoder::ValType::I32],
+        );
+        let mut functions = FunctionSection::new();
+        functions.function(0);
+        let mut memory = MemorySection::new();
+        memory.memory(MemoryType {
+            minimum: 1,
+            maximum: None,
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        });
+        let mut globals = GlobalSection::new();
+        globals.global(
+            GlobalType {
+                val_type: wasm_encoder::ValType::I32,
+                mutable: true,
+                shared: false,
+            },
+            &ConstExpr::i32_const(1024),
+        );
+        let mut exports = ExportSection::new();
+        exports.export("mp_realloc", ExportKind::Func, 0);
+        exports.export("mp_memory", ExportKind::Memory, 0);
+        let mut code = CodeSection::new();
+        {
+            let mut f = Function::new([]);
+            emit_cabi_realloc(&mut f, 0);
+            code.function(&f);
+        }
+        let mut module = Module::new();
+        module
+            .section(&types)
+            .section(&functions)
+            .section(&memory)
+            .section(&globals)
+            .section(&exports)
+            .section(&code);
+        module
+    };
+
+    let mut component = Component::new();
+    {
+        let mut types = ComponentTypeSection::new();
+        types
+            .function()
+            .params([(
+                "s",
+                wasm_encoder::ComponentValType::Primitive(wasm_encoder::PrimitiveValType::String),
+            )])
+            .result(Some(wasm_encoder::ComponentValType::Primitive(
+                wasm_encoder::PrimitiveValType::U32,
+            )));
+        component.section(&types);
+    }
+    {
+        let mut imports = ComponentImportSection::new();
+        imports.import("test:api/api", ComponentTypeRef::Func(0));
+        component.section(&imports);
+    }
+    component.section(&ModuleSection(&mem_provider));
+    {
+        let mut inst = InstanceSection::new();
+        let no_args: Vec<(&str, ModuleArg)> = vec![];
+        inst.instantiate(0, no_args);
+        component.section(&inst);
+    }
+    {
+        let mut aliases = ComponentAliasSection::new();
+        aliases.alias(Alias::CoreInstanceExport {
+            instance: 0,
+            kind: ExportKind::Func,
+            name: "mp_realloc",
+        });
+        component.section(&aliases);
+    }
+    {
+        let mut aliases = ComponentAliasSection::new();
+        aliases.alias(Alias::CoreInstanceExport {
+            instance: 0,
+            kind: ExportKind::Memory,
+            name: "mp_memory",
+        });
+        component.section(&aliases);
+    }
+    {
+        let mut canon = CanonicalFunctionSection::new();
+        canon.lower(
+            0,
+            [
+                CanonicalOption::CompactUTF16, // meld → Latin1
+                CanonicalOption::Memory(0),
+                CanonicalOption::Realloc(0),
+            ],
+        );
+        component.section(&canon);
+    }
+    component.section(&ModuleSection(&core_module));
+    component.finish()
+}
+
+/// Fuse a (caller, callee) pair in MultiMemory mode, validate, run `run`, and
+/// return its i32 result. Shared by the #253 runtime-differential tests.
+fn fuse_run_i32(caller: &[u8], callee: &[u8], label: &str) -> i32 {
     let config = FuserConfig {
         memory_strategy: MemoryStrategy::MultiMemory,
         attestation: false,
@@ -3149,24 +3573,175 @@ fn test_253_utf16_to_latin1_transcode_fails_loud() {
         output_format: meld_core::OutputFormat::CoreModule,
         opaque_resources: Vec::new(),
     };
-
     let mut fuser = Fuser::new(config);
     fuser
-        .add_component_named(&callee, Some("callee-latin1"))
+        .add_component_named(callee, Some("callee"))
         .expect("callee parse");
     fuser
-        .add_component_named(&caller, Some("caller-utf16"))
+        .add_component_named(caller, Some("caller"))
         .expect("caller parse");
+    let (fused, _) = fuser
+        .fuse_with_stats()
+        .unwrap_or_else(|e| panic!("#253 [{label}]: fusion must succeed: {e:?}"));
 
-    let result = fuser.fuse_with_stats();
-    assert!(
-        result.is_err(),
-        "#253: (Utf16 -> Latin1) is a lossy down-conversion with no transcoder; \
-         fusion must fail loudly rather than emit a silently-wrong copy. Got Ok."
+    let mut validator = wasmparser::Validator::new();
+    validator
+        .validate_all(&fused)
+        .unwrap_or_else(|e| panic!("#253 [{label}]: output must validate: {e}"));
+
+    let mut ec = Config::new();
+    ec.wasm_multi_memory(true);
+    let engine = Engine::new(&ec).unwrap();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+    let run = instance
+        .get_typed_func::<(), i32>(&mut store, "run")
+        .unwrap();
+    run.call(&mut store, ()).unwrap()
+}
+
+/// #253 READ side, tag CLEAR (pure Latin-1 source). A CompactUTF16-lowering
+/// caller storing 1 byte/char with an untagged length, fused into a UTF-16
+/// callee: latin1+utf16 → UTF-16. "café" = bytes [0x63,0x61,0x66,0xE9] →
+/// code units [0x0063,0x0061,0x0066,0x00E9], sum 99+97+102+233 = 531. Preserves
+/// the pre-#253 tag-clear behaviour (this is the path the old SR-17 test took).
+#[test]
+fn test_253_read_latin1_tagclear_to_utf16() {
+    let callee = build_callee_utf16_string_component(); // UTF-16 lift, sums code units
+    let caller = build_caller_latin1_lowering_component(&[0x63, 0x61, 0x66, 0xE9]);
+    let result = fuse_run_i32(&caller, &callee, "read latin1 tag-clear → utf16");
+    assert_eq!(result, 531, "café code-unit sum");
+}
+
+/// #253 READ side, tag CLEAR → UTF-8. latin1+utf16 (pure Latin-1) → UTF-8.
+/// "café" Latin-1 bytes [0x63,0x61,0x66,0xE9]; 0xE9 ('é') becomes the 2-byte
+/// UTF-8 sequence 0xC3 0xA9, the ASCII bytes pass through. The UTF-8 callee
+/// sums received bytes: 0x63+0x61+0x66 + 0xC3+0xA9 = 99+97+102+195+169 = 662.
+#[test]
+fn test_253_read_latin1_tagclear_to_utf8() {
+    let callee = build_callee_string_component(); // UTF-8 lift, sums bytes
+    let caller = build_caller_latin1_lowering_component(&[0x63, 0x61, 0x66, 0xE9]);
+    let result = fuse_run_i32(&caller, &callee, "read latin1 tag-clear → utf8");
+    assert_eq!(result, 662, "café UTF-8 byte sum");
+}
+
+/// #253 READ side, tag SET (UTF-16 payload) → UTF-16. The latin1+utf16 source
+/// is actually UTF-16 ("日本" = [0x65E5, 0x672C], tag set). latin1+utf16 →
+/// UTF-16 with the tag set is a verbatim code-unit copy. The UTF-16 callee sums
+/// code units: 0x65E5 + 0x672C = 26085 + 26412 = 52497.
+#[test]
+fn test_253_read_latin1_tagset_to_utf16() {
+    let callee = build_callee_utf16_string_component();
+    let caller = build_caller_latin1_tagged_lowering_component(&[0x65E5, 0x672C]);
+    let result = fuse_run_i32(&caller, &callee, "read latin1 tag-set → utf16");
+    assert_eq!(result, 52497, "日本 code-unit sum (verbatim utf16 copy)");
+}
+
+/// #253 READ side, tag SET (UTF-16 payload) → UTF-8, including a supplementary
+/// code point. Source "A😀" = UTF-16 [0x0041, 0xD83D, 0xDE00] (tag set). When
+/// the tag is set the latin1+utf16 → UTF-8 transcoder treats the source as
+/// UTF-16, so it must decode the surrogate pair to U+1F600 and emit 4-byte
+/// UTF-8. Expected UTF-8 bytes: 0x41, 0xF0,0x9F,0x98,0x80 → byte sum
+/// 65 + 240+159+152+128 = 744.
+#[test]
+fn test_253_read_latin1_tagset_to_utf8_supplementary() {
+    let callee = build_callee_string_component(); // UTF-8, sums bytes
+    let caller = build_caller_latin1_tagged_lowering_component(&[0x0041, 0xD83D, 0xDE00]);
+    let result = fuse_run_i32(&caller, &callee, "read latin1 tag-set → utf8 (supp)");
+    assert_eq!(result, 744, "A😀 UTF-8 byte sum via surrogate decode");
+}
+
+/// #253 WRITE side, UTF-8 → latin1+utf16, latin1-FITS (tag CLEAR). All code
+/// points ≤ 0xFF, so the encoder must pick the Latin-1 representation (1
+/// byte/char, tag clear). Source "café" UTF-8 = [0x63,0x61,0x66,0xC3,0xA9]
+/// (5 bytes); decodes to code points [0x63,0x61,0x66,0xE9], all ≤ 0xFF →
+/// Latin-1 bytes [0x63,0x61,0x66,0xE9]. The tag-decoding callee reads bytes
+/// (tag clear) and sums: 99+97+102+233 = 531.
+#[test]
+fn test_253_write_utf8_to_latin1_fits() {
+    let callee = build_callee_compact_decoding_component();
+    let caller = build_caller_string_component_data("café".as_bytes()); // UTF-8 source
+    let result = fuse_run_i32(&caller, &callee, "write utf8 → latin1 (fits)");
+    assert_eq!(result, 531, "café Latin-1 byte sum, tag clear");
+}
+
+/// #253 WRITE side, UTF-8 → latin1+utf16, UTF-16-REQUIRING (tag SET). "日本"
+/// contains code points > 0xFF, so the encoder must fall back to UTF-16 (tag
+/// set). Source UTF-8 = E6 97 A5 E6 9C AC → code points [0x65E5, 0x672C] →
+/// UTF-16 units [0x65E5, 0x672C]. The tag-decoding callee reads 16-bit units
+/// (tag set) and sums 0x65E5 + 0x672C = 52497.
+#[test]
+fn test_253_write_utf8_to_latin1_needs_utf16() {
+    let callee = build_callee_compact_decoding_component();
+    let caller = build_caller_string_component_data("日本".as_bytes());
+    let result = fuse_run_i32(&caller, &callee, "write utf8 → latin1 (needs utf16)");
+    assert_eq!(result, 52497, "日本 UTF-16 code-unit sum, tag set");
+}
+
+/// #253 WRITE side, UTF-16 → latin1+utf16, latin1-FITS (tag CLEAR). UTF-16
+/// source "café" = [0x0063,0x0061,0x0066,0x00E9], all ≤ 0xFF → Latin-1 bytes,
+/// tag clear. Callee sums bytes: 99+97+102+233 = 531.
+#[test]
+fn test_253_write_utf16_to_latin1_fits() {
+    let callee = build_callee_compact_decoding_component();
+    let caller = build_caller_utf16_lowering_component(&[0x0063, 0x0061, 0x0066, 0x00E9]);
+    let result = fuse_run_i32(&caller, &callee, "write utf16 → latin1 (fits)");
+    assert_eq!(result, 531, "café Latin-1 byte sum, tag clear");
+}
+
+/// #253 WRITE side, UTF-16 → latin1+utf16, UTF-16-REQUIRING with a
+/// supplementary code point (tag SET). Source "A😀" = UTF-16
+/// [0x0041, 0xD83D, 0xDE00]; the encoder decodes the surrogate pair to
+/// U+1F600 (> 0xFF → UTF-16 representation) and re-encodes it as the SAME
+/// surrogate pair, so the stored UTF-16 units are [0x0041, 0xD83D, 0xDE00]
+/// (3 code units, tag set). Callee sums 16-bit units:
+/// 0x0041 + 0xD83D + 0xDE00 = 65 + 55357 + 56832 = 112254.
+#[test]
+fn test_253_write_utf16_to_latin1_needs_utf16_supplementary() {
+    let callee = build_callee_compact_decoding_component();
+    let caller = build_caller_utf16_lowering_component(&[0x0041, 0xD83D, 0xDE00]);
+    let result = fuse_run_i32(&caller, &callee, "write utf16 → latin1 (supp)");
+    assert_eq!(result, 112254, "A😀 UTF-16 code-unit sum, tag set");
+}
+
+/// LS-P-21 regression gate: the latin1+utf16 tag must be honoured end-to-end,
+/// so a tag-SET (UTF-16-represented) latin1+utf16 string is NOT mis-read as
+/// pure Latin-1 (and a latin1-fits string is NOT mis-tagged as UTF-16). This
+/// is the differential guard for the "tag mis-read → wrong-encoding data"
+/// hazard (H-4.4). It pins BOTH directions of the tag:
+///
+/// - a tag-SET read ("日本" as UTF-16 → UTF-16 verbatim copy) must recover the
+///   UTF-16 code units (52497), NOT the byte-wise misread a pure-Latin-1
+///   interpretation would produce;
+/// - a latin1-fits write ("café" UTF-8 → latin1+utf16) must emit Latin-1 with
+///   the tag CLEAR (sum 531 via the callee's 8-bit path), NOT UTF-16.
+///
+/// A regression that ignored the tag (the pre-#253 untagged treatment) would
+/// drive the callee to the wrong element width and fail these equalities.
+#[test]
+fn ls_p_21_latin1_utf16_tag_honored_roundtrip() {
+    // Tag-SET source read correctly (would be byte-misread if the tag were
+    // ignored on the read side).
+    let read = fuse_run_i32(
+        &build_caller_latin1_tagged_lowering_component(&[0x65E5, 0x672C]),
+        &build_callee_utf16_string_component(),
+        "LS-P-21 tag-set read",
     );
-    let msg = format!("{:?}", result.err().unwrap());
-    assert!(
-        msg.contains("transcoding") || msg.contains("#253"),
-        "#253: error should name the unsupported transcoding; got: {msg}"
+    assert_eq!(
+        read, 52497,
+        "LS-P-21: tag-set latin1+utf16 must be read as UTF-16"
+    );
+
+    // latin1-fits write tagged CLEAR (callee's 8-bit path must apply; a
+    // wrongly-set tag would make the callee sum 16-bit units instead).
+    let write = fuse_run_i32(
+        &build_caller_string_component_data("café".as_bytes()),
+        &build_callee_compact_decoding_component(),
+        "LS-P-21 latin1-fits write",
+    );
+    assert_eq!(
+        write, 531,
+        "LS-P-21: latin1-fits UTF-8 must encode as tag-clear Latin-1"
     );
 }

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -196,6 +196,15 @@ verification-status:
       - adapter_safety::test_sr17_utf16_to_utf8_malformed_surrogate_matrix
       - adapter_safety::test_sr17_utf8_to_utf16_malformed_matrix
       - adapter_safety::test_sr17_latin1_to_utf16_transcoding
+      - adapter_safety::test_253_read_latin1_tagclear_to_utf16
+      - adapter_safety::test_253_read_latin1_tagclear_to_utf8
+      - adapter_safety::test_253_read_latin1_tagset_to_utf16
+      - adapter_safety::test_253_read_latin1_tagset_to_utf8_supplementary
+      - adapter_safety::test_253_write_utf8_to_latin1_fits
+      - adapter_safety::test_253_write_utf8_to_latin1_needs_utf16
+      - adapter_safety::test_253_write_utf16_to_latin1_fits
+      - adapter_safety::test_253_write_utf16_to_latin1_needs_utf16_supplementary
+      - adapter_safety::ls_p_21_latin1_utf16_tag_honored_roundtrip
       - resolver::tests::test_sr17_all_encoding_pairs_transcoding_matrix
     proofs: []
     status: verified
@@ -222,6 +231,26 @@ verification-status:
       all four UTF-16 malformity cases (lone-high-at-end,
       mid-string-high+non-low, valid pair, lone-low) have explicit
       arms and runtime oracles.
+      Extended 2026-06-14 (#253 final increment): SR-17 now covers the
+      canonical-ABI `latin1+utf16` (CompactUTF16) TAGGED length form
+      (UTF16_TAG = 1<<31), which meld models as StringEncoding::Latin1.
+      READ side — the Latin1-source transcoders mask
+      `count = len & !UTF16_TAG` and branch on the tag: tag-clear keeps
+      the pure-Latin-1 1-byte path; tag-set transcodes the source as
+      UTF-16 (latin1→utf8 ⇒ utf16→utf8, latin1→utf16 ⇒ verbatim
+      code-unit copy). WRITE side — emit_utf8_to_latin1_transcode /
+      emit_utf16_to_latin1_transcode are a two-phase encoder: scan, then
+      write Latin-1 (length = n, tag clear) if every code point ≤ 0xFF,
+      else UTF-16 with surrogate pairs (length = code_units | UTF16_TAG).
+      alignment_for_encoding(Latin1) corrected from 1 to 2 (the buffer
+      may hold UTF-16). Runtime-differential oracles cover every
+      newly-enabled direction for BOTH a latin1-fits string ("café") and
+      a utf16-requiring string ("日本" / "A😀"), via a tag-aware decoding
+      callee that reads 16-bit units when the tag is set and 8-bit bytes
+      when clear (test_253_read_* / test_253_write_*). The tag-mis-read /
+      mis-write hazard is recorded as approved loss scenario LS-P-21
+      (H-4.4) with the ls_p_21_latin1_utf16_tag_honored_roundtrip gate
+      test.
 
   SR-18:
     implementation-files: [meld-core/src/adapter/fact.rs]

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -1173,6 +1173,77 @@ loss-scenarios:
       lone-continuation lead, overlong, UTF-8 surrogate, out-of-range,
       and valid 1/2/3/4-byte controls incl. boundary code points).
 
+  - id: LS-P-21
+    title: latin1+utf16 length tag mis-read/mis-written → wrong-encoding string data
+    uca: UCA-P-3
+    hazards: [H-4, H-4.4]
+    type: inadequate-process-model
+    scenario: >
+      meld models the Component Model `latin1+utf16` string encoding
+      (`compact-utf16`) as `StringEncoding::Latin1`. In that encoding the
+      string's length operand is TAGGED: `UTF16_TAG = 1 << 31`
+      (0x8000_0000). When the tag bit is SET the payload is UTF-16 and the
+      code-unit count is `len & !UTF16_TAG` (byte length = count × 2); when
+      CLEAR the payload is Latin-1 (1 byte/char, byte length = len). Before
+      #253's final increment, meld treated the operand as an untagged
+      pure-Latin-1 byte count on BOTH the producer and consumer sides:
+      (1) the Latin-1-as-SOURCE transcoders (`emit_latin1_to_utf8_transcode`,
+      `emit_latin1_to_utf16_transcode`) never masked the tag nor branched on
+      it, so a tag-SET (UTF-16-represented) string was mis-read — its huge
+      tagged length either tripped the LS-A-7 overflow guard or, with the
+      high bit retained, drove the loop to read 1-byte Latin-1 units out of
+      what is really a 2-byte UTF-16 buffer, scrambling the data; and
+      (2) the Latin-1-as-DESTINATION pairs (`Utf8→Latin1`, `Utf16→Latin1`)
+      were unimplemented (held safely on the #253 fail-loud arm), so a
+      well-formed source that needed the UTF-16 fallback could not be
+      represented at all. The hazard is silent wrong-encoding string data at
+      a cross-component boundary [UCA-P-3 incorrect string transcoding /
+      H-4.4], distinct from the malformed-input families (LS-P-16/19/20)
+      because it mis-handles WELL-FORMED input solely due to the tag
+      convention. Reachable for any cross-memory fusion where a CompactUTF16
+      (latin1+utf16) component is on either side of a string parameter and
+      the string is UTF-16-represented (any code point > 0xFF) — e.g. a
+      JS/.NET host string ("日本", an emoji) flowing to/from a UTF-8 or
+      UTF-16 peer. Surfaced and closed while completing #253.
+    causal-factors:
+      - >-
+        The Latin-1-source transcoders read the length operand (local 1)
+        verbatim, with no `len & !UTF16_TAG` mask and no branch on the
+        `len & UTF16_TAG` tag bit
+      - >-
+        `alignment_for_encoding(Latin1)` returned 1, but a latin1+utf16
+        buffer may hold UTF-16 code units and the canonical ABI requires
+        2-byte alignment
+      - >-
+        The Latin-1-destination encoders did not exist, so the canonical
+        choose-latin1-else-utf16 representation + tag could not be produced
+    process-model-flaw: >
+      The model was "Latin1 means pure Latin-1, one untagged byte per char",
+      but meld's `Latin1` IS the canonical-ABI `latin1+utf16` encoding whose
+      length is tag-discriminated per string. Producer and consumer must
+      agree on `UTF16_TAG`: the reader masks + branches on it, the writer
+      sets it iff it fell back to UTF-16.
+    status: approved
+    priority: high
+    fix: >
+      #253 final increment makes both sides tag-faithful and they agree on
+      `UTF16_TAG = 1 << 31` (fact.rs). READ side: the Latin1-source
+      transcoders mask `count = len & !UTF16_TAG` and branch on the tag — a
+      tag-SET source is transcoded as UTF-16 (latin1→utf8 becomes
+      utf16→utf8; latin1→utf16 becomes a verbatim code-unit copy), a
+      tag-CLEAR source keeps the original 1-byte Latin-1 path unchanged.
+      WRITE side: `emit_utf8_to_latin1_transcode` / `emit_utf16_to_latin1_transcode`
+      are a two-phase encoder — scan the source; if every code point ≤ 0xFF
+      write Latin-1 (length = n, tag clear); else write UTF-16 with
+      surrogate pairs (length = code_units | UTF16_TAG). `alignment_for_encoding(Latin1)`
+      is corrected to 2. Pinned by the runtime-differential test
+      `ls_p_21_latin1_utf16_tag_honored_roundtrip` plus the full #253 matrix
+      (`test_253_read_*` and `test_253_write_*`): a tag-aware decoding callee
+      sums 16-bit units when the tag is set and 8-bit bytes when clear, so a
+      mis-read or mis-set tag drives the wrong element width and fails the
+      asserted per-representation sums for both a latin1-fits string ("café")
+      and a utf16-requiring string ("日本" / "A😀").
+
   - id: LS-P-17
     title: Caller-encoding match filters on Func only, miscalibrates mixed-encoding callers
     uca: UCA-R-3


### PR DESCRIPTION
## What

Closes #253. meld's `StringEncoding::Latin1` **is** the canonical-ABI `latin1+utf16` encoding (the Component Model has no pure-Latin-1 encoding). The prior untagged pure-Latin-1 treatment was correct only for the tag-clear case; a tag-set (utf16-represented) string was **mis-read**, and encoding *into* it (`Utf8/Utf16 → Latin1`) was unimplemented (fail-loud). This makes the whole path tag-faithful — producer and consumer agree on `UTF16_TAG = 1<<31` on the `(ptr, len)` length operand.

## How

- **Read side** — `emit_latin1_to_utf8` / `emit_latin1_to_utf16` branch on the tag: `count = len & !UTF16_TAG`; tag-set ⇒ source is UTF-16 (latin1→utf8 becomes utf16→utf8; latin1→utf16 a verbatim code-unit copy); tag-clear delegates to renamed `emit_latin1_pure_*` helpers — **byte-for-byte the prior behaviour** (existing SR-17 latin1 tests unchanged).
- **Write side** — `emit_utf8_to_latin1` / `emit_utf16_to_latin1`: two-phase — scan source code points; all ≤ 0xFF ⇒ Latin-1 (`len = n`, tag clear); else UTF-16 with surrogate pairs (`len = code_units | UTF16_TAG`). Decoders extracted from the hardened #251/#249 transcoders (shared, identical logic).
- `alignment_for_encoding(Latin1)` **1 → 2** (latin1+utf16 buffers may hold u16).
- Fail-loud `_` arm kept as the safety net (now unreachable among string encodings).

## Oracle (runtime-differential, under wasmtime)

9 new tests in `tests/adapter_safety.rs` with a **tag-aware callee** that reads u8 vs u16 by the tag — so a mis-set or mis-read tag fails the asserted per-representation sums. Both a **latin1-fits** (`"café"`) and a **utf16-requiring** (`"日本"`, `"A😀"`) string round-trip in every newly-enabled direction (Utf8→Compact, Utf16→Compact, Compact→Utf8/Utf16 with a tag-set source).

- `cargo test -p meld-core --test adapter_safety` → 21/0
- `cargo test -p meld-core --lib` → 364/0 (incl. the 35 SR-17 unit tests)
- LS-N gate → **56/0/0** (LS-P-21 added with its `ls_p_21_*` gate test — no regression)
- build / clippy `-D warnings` / fmt clean

## Traceability

Adds **approved LS-P-21** (latin1+utf16 tag mis-read/mis-write → wrong-encoding data, H-4.4) with the `ls_p_21_*` gate test; SR-17 note extended for the tagged-form coverage.

## Tier-5
Touches `adapter/fact.rs` → Mythos delta-pass applies. Adversarial pass (targeting tag-masking / two-phase-encoder correctness) posted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)