### PR TITLE
fix(adapter): fail loud on async cross-encoding string instead of silent raw-copy (#272)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -6891,17 +6891,15 @@ impl FactStyleGenerator {
             _ => return Ok(()),
         };
 
-        // Is there a byte-granular (ptr, len) param or result — a plausible
-        // string whose bytes the async emitter would raw-copy?
-        let is_byte_granular = |cl: &crate::resolver::CopyLayout| -> bool {
-            match cl {
-                crate::resolver::CopyLayout::Bulk { byte_multiplier } => *byte_multiplier == 1,
-                crate::resolver::CopyLayout::Elements { element_size, .. } => *element_size == 1,
-            }
-        };
-        // A ptr-pair position with no recorded layout defaults to byte-granular
-        // in the emitters (`byte_mult` falls back to 1), so treat a bare
-        // position (no parallel layout) as a string too.
+        // Is there a byte-granular (ptr, len) param or result whose bytes the
+        // async emitter would raw-copy — at ANY nesting depth? A nested string
+        // (e.g. `list<string>`) has a non-byte-granular TOP-LEVEL layout
+        // (`Elements{element_size: 8}`) but a byte-granular inner pointer that
+        // `emit_patch_nested_indirections` raw-copies; the detection recurses
+        // into `inner_pointers` to match the emitter's depth (LS-F-27
+        // under-trip fix). A ptr-pair position with no recorded layout defaults
+        // to byte-granular in the emitters (`byte_mult` falls back to 1), so
+        // treat a bare position (no parallel layout) as a string too.
         let param_has_string = site
             .requirements
             .pointer_pair_positions
@@ -6911,7 +6909,7 @@ impl FactStyleGenerator {
                 site.requirements
                     .param_copy_layouts
                     .get(i)
-                    .map(is_byte_granular)
+                    .map(Self::layout_bears_byte_granular_buffer)
                     .unwrap_or(true)
             });
         let result_has_string = site
@@ -6923,7 +6921,7 @@ impl FactStyleGenerator {
                 site.requirements
                     .result_copy_layouts
                     .get(i)
-                    .map(is_byte_granular)
+                    .map(Self::layout_bears_byte_granular_buffer)
                     .unwrap_or(true)
             });
 
@@ -6935,6 +6933,31 @@ impl FactStyleGenerator {
             )));
         }
         Ok(())
+    }
+
+    /// Recursively: does this copy layout carry a byte-granular `(ptr, len)`
+    /// buffer at ANY nesting depth — the conservative proxy for "a string the
+    /// async emitter would raw-copy without transcoding"? `Bulk{1}` /
+    /// `Elements{element_size: 1}` are byte-granular; an `Elements` is also a
+    /// carrier if any of its `inner_pointers` is (e.g. `list<string>`, whose
+    /// top-level `Elements{element_size: 8}` holds a `Bulk{1}` inner string).
+    /// This must match the depth of `emit_patch_nested_indirections`, which
+    /// copies inner buffers — otherwise a nested cross-encoding string
+    /// under-trips the guard and silently mis-transcodes (LS-F-27).
+    fn layout_bears_byte_granular_buffer(cl: &crate::resolver::CopyLayout) -> bool {
+        match cl {
+            crate::resolver::CopyLayout::Bulk { byte_multiplier } => *byte_multiplier == 1,
+            crate::resolver::CopyLayout::Elements {
+                element_size,
+                inner_pointers,
+                ..
+            } => {
+                *element_size == 1
+                    || inner_pointers
+                        .iter()
+                        .any(|ip| Self::layout_bears_byte_granular_buffer(&ip.copy_layout))
+            }
+        }
     }
 }
 
@@ -7598,6 +7621,84 @@ mod tests {
         site.requirements.caller_encoding = Some(caller);
         site.requirements.callee_encoding = Some(callee);
         site
+    }
+
+    /// Build a cross-memory async-lift site whose param or result is a
+    /// `list<string>`: top-level `Elements{element_size: 8}` (NOT byte-granular)
+    /// with a byte-granular `Bulk{1}` inner string. Exercises the LS-F-27
+    /// under-trip fix — the guard must recurse into `inner_pointers`.
+    fn async_xenc_nested_list_string_site(on_result: bool) -> crate::resolver::AdapterSite {
+        use crate::parser::CanonStringEncoding;
+        use crate::resolver::{CopyLayout, InnerPointer};
+        let list_of_string = CopyLayout::Elements {
+            element_size: 8,
+            inner_pointers: vec![InnerPointer::unconditional(
+                0,
+                CopyLayout::Bulk { byte_multiplier: 1 },
+            )],
+            inner_resources: vec![],
+        };
+        let mut site = async_lift_site("[async-lift]greet");
+        site.crosses_memory = true;
+        if on_result {
+            site.requirements.result_pointer_pair_offsets = vec![0];
+            site.requirements.result_copy_layouts = vec![list_of_string];
+        } else {
+            site.requirements.pointer_pair_positions = vec![0];
+            site.requirements.param_copy_layouts = vec![list_of_string];
+        }
+        site.requirements.caller_encoding = Some(CanonStringEncoding::Utf8);
+        site.requirements.callee_encoding = Some(CanonStringEncoding::Utf16);
+        site
+    }
+
+    /// LS-F-27 (under-trip fix): a cross-encoding async `list<string>` PARAM —
+    /// non-byte-granular top-level layout, byte-granular inner string the
+    /// emitter raw-copies — must fail loud. Pre-fix the guard inspected only
+    /// the top-level layout and silently let this through (#272 under-trip,
+    /// confirmed by an adversarial Mythos pass).
+    #[test]
+    fn ls_f_27_async_cross_encoding_nested_list_string_param_fails_loud() {
+        let site = async_xenc_nested_list_string_site(false);
+        FactStyleGenerator::guard_async_cross_encoding_strings(&site)
+            .expect_err("cross-encoding async list<string> param must fail loud (nested string)");
+    }
+
+    /// LS-F-27 (under-trip fix), result side.
+    #[test]
+    fn ls_f_27_async_cross_encoding_nested_list_string_result_fails_loud() {
+        let site = async_xenc_nested_list_string_site(true);
+        FactStyleGenerator::guard_async_cross_encoding_strings(&site)
+            .expect_err("cross-encoding async list<string> result must fail loud (nested string)");
+    }
+
+    /// LS-F-27 negative (the recursion must not OVER-trip): a cross-encoding
+    /// async `list<list<u32>>` — nested but with NO byte-granular buffer at any
+    /// depth (inner `Elements{element_size: 4}`) — must still pass.
+    #[test]
+    fn ls_f_27_async_cross_encoding_nested_no_string_ok() {
+        use crate::parser::CanonStringEncoding;
+        use crate::resolver::{CopyLayout, InnerPointer};
+        let list_of_list_u32 = CopyLayout::Elements {
+            element_size: 8,
+            inner_pointers: vec![InnerPointer::unconditional(
+                0,
+                CopyLayout::Elements {
+                    element_size: 4,
+                    inner_pointers: vec![],
+                    inner_resources: vec![],
+                },
+            )],
+            inner_resources: vec![],
+        };
+        let mut site = async_lift_site("[async-lift]f");
+        site.crosses_memory = true;
+        site.requirements.pointer_pair_positions = vec![0];
+        site.requirements.param_copy_layouts = vec![list_of_list_u32];
+        site.requirements.caller_encoding = Some(CanonStringEncoding::Utf8);
+        site.requirements.callee_encoding = Some(CanonStringEncoding::Utf16);
+        FactStyleGenerator::guard_async_cross_encoding_strings(&site)
+            .expect("nested list<list<u32>> with no string must NOT trip the guard");
     }
 
     /// LS-F-27 gate: a cross-encoding async string PARAM that crosses memory

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -6852,6 +6852,92 @@ impl FactStyleGenerator {
     }
 }
 
+impl FactStyleGenerator {
+    /// #272 / LS-F-27 fail-loud guard for cross-encoding async strings.
+    ///
+    /// Trips only when ALL of the following hold for an async-lift site:
+    ///   * `site.crosses_memory` (a same-memory async call shares one memory
+    ///     and one encoding, so there is nothing to transcode), AND
+    ///   * the caller and callee canonical string encodings differ (computed
+    ///     the same way `analyze_call_site` does, via `canon_to_string_encoding`
+    ///     so that e.g. UTF-8 vs `latin1+utf16`/CompactUtf16 are compared on
+    ///     their `StringEncoding` mapping, not the raw canon enum), AND
+    ///   * there is at least one byte-granular `(ptr, len)` param or result —
+    ///     i.e. a plausible STRING. A byte-granular buffer (`Bulk{1}` /
+    ///     `Elements{element_size:1}`) is what a lowered string looks like;
+    ///     a `list<u32>` (element size 4) etc. is encoding-independent and
+    ///     must NOT trip the guard.
+    ///
+    /// When any condition is false the call proceeds normally, so:
+    ///   * same-encoding async string calls keep working,
+    ///   * cross-encoding async calls with NO string params/results keep
+    ///     working,
+    ///   * non-cross-memory async calls keep working.
+    fn guard_async_cross_encoding_strings(site: &AdapterSite) -> Result<()> {
+        if !site.crosses_memory {
+            return Ok(());
+        }
+        let caller_enc = site
+            .requirements
+            .caller_encoding
+            .map(canon_to_string_encoding);
+        let callee_enc = site
+            .requirements
+            .callee_encoding
+            .map(canon_to_string_encoding);
+        // Only meaningful when both sides have a known, differing encoding.
+        let (caller_enc, callee_enc) = match (caller_enc, callee_enc) {
+            (Some(a), Some(b)) if a != b => (a, b),
+            _ => return Ok(()),
+        };
+
+        // Is there a byte-granular (ptr, len) param or result — a plausible
+        // string whose bytes the async emitter would raw-copy?
+        let is_byte_granular = |cl: &crate::resolver::CopyLayout| -> bool {
+            match cl {
+                crate::resolver::CopyLayout::Bulk { byte_multiplier } => *byte_multiplier == 1,
+                crate::resolver::CopyLayout::Elements { element_size, .. } => *element_size == 1,
+            }
+        };
+        // A ptr-pair position with no recorded layout defaults to byte-granular
+        // in the emitters (`byte_mult` falls back to 1), so treat a bare
+        // position (no parallel layout) as a string too.
+        let param_has_string = site
+            .requirements
+            .pointer_pair_positions
+            .iter()
+            .enumerate()
+            .any(|(i, _)| {
+                site.requirements
+                    .param_copy_layouts
+                    .get(i)
+                    .map(is_byte_granular)
+                    .unwrap_or(true)
+            });
+        let result_has_string = site
+            .requirements
+            .result_pointer_pair_offsets
+            .iter()
+            .enumerate()
+            .any(|(i, _)| {
+                site.requirements
+                    .result_copy_layouts
+                    .get(i)
+                    .map(is_byte_granular)
+                    .unwrap_or(true)
+            });
+
+        if param_has_string || result_has_string {
+            return Err(crate::Error::AdapterGeneration(format!(
+                "async cross-encoding string transcoding is not yet supported \
+                 (caller {caller_enc:?} != callee {callee_enc:?}); a verbatim \
+                 copy would silently mis-transcode — see #272"
+            )));
+        }
+        Ok(())
+    }
+}
+
 impl AdapterGenerator for FactStyleGenerator {
     fn generate(
         &self,
@@ -6863,6 +6949,18 @@ impl AdapterGenerator for FactStyleGenerator {
 
         for (idx, site) in graph.adapter_sites.iter().enumerate() {
             if site.is_async_lift {
+                // #272 / H-4.4 LS-F-27: the async emitters (`emit_param_copy_step`
+                // / `emit_ptr_pair_result_writeback`) copy string/(ptr,len)
+                // buffers via `memory.copy` with no transcoding. The sync
+                // dispatch routes cross-encoding string calls to
+                // `generate_transcoding_adapter`; the async branch never did.
+                // A cross-memory async-lift call passing/returning a string in
+                // one encoding while the other side expects a different
+                // encoding would therefore raw-copy the bytes and silently
+                // mis-transcode (the H-4.4 defect #253/#271 closed for sync).
+                // Full async transcoding is the tracked #272 capability; until
+                // then we FAIL LOUD rather than emit a silently-corrupting copy.
+                Self::guard_async_cross_encoding_strings(site)?;
                 let adapter = if self.has_callback_export(site, merged) {
                     self.generate_async_callback_adapter(site, merged)?
                 } else {
@@ -7485,6 +7583,156 @@ mod tests {
         }
     }
 
+    /// Build a cross-memory async-lift site carrying a single byte-granular
+    /// `(ptr, len)` string param, parameterised by caller/callee canon
+    /// encodings. Used by the #272 / LS-F-27 guard matrix.
+    fn async_xenc_string_param_site(
+        caller: crate::parser::CanonStringEncoding,
+        callee: crate::parser::CanonStringEncoding,
+    ) -> crate::resolver::AdapterSite {
+        let mut site = async_lift_site("[async-lift]greet");
+        site.crosses_memory = true;
+        site.requirements.pointer_pair_positions = vec![0];
+        site.requirements.param_copy_layouts =
+            vec![crate::resolver::CopyLayout::Bulk { byte_multiplier: 1 }];
+        site.requirements.caller_encoding = Some(caller);
+        site.requirements.callee_encoding = Some(callee);
+        site
+    }
+
+    /// LS-F-27 gate: a cross-encoding async string PARAM that crosses memory
+    /// must fail loud (the async emitter would otherwise raw-copy the bytes
+    /// and silently mis-transcode — #272 / H-4.4). Asserts both the error
+    /// variant and the diagnostic text.
+    #[test]
+    fn ls_f_27_async_cross_encoding_string_param_fails_loud() {
+        use crate::parser::CanonStringEncoding;
+        let site =
+            async_xenc_string_param_site(CanonStringEncoding::Utf8, CanonStringEncoding::Utf16);
+        let err = FactStyleGenerator::guard_async_cross_encoding_strings(&site)
+            .expect_err("cross-encoding async string param must fail loud");
+        match err {
+            crate::Error::AdapterGeneration(msg) => {
+                assert!(
+                    msg.contains("async cross-encoding string transcoding is not yet supported")
+                        && msg.contains("#272"),
+                    "LS-F-27 guard message must explain the cross-encoding gap and \
+                     cite #272; got: {msg}"
+                );
+            }
+            other => panic!("LS-F-27: expected AdapterGeneration error, got {other:?}"),
+        }
+    }
+
+    /// LS-F-27 gate (result side): a cross-encoding async string RESULT that
+    /// crosses memory must also fail loud — `emit_ptr_pair_result_writeback`
+    /// raw-copies the returned buffer with no transcode.
+    #[test]
+    fn ls_f_27_async_cross_encoding_string_result_fails_loud() {
+        use crate::parser::CanonStringEncoding;
+        let mut site = async_lift_site("[async-lift]greet");
+        site.crosses_memory = true;
+        site.requirements.result_pointer_pair_offsets = vec![0];
+        site.requirements.result_copy_layouts =
+            vec![crate::resolver::CopyLayout::Bulk { byte_multiplier: 1 }];
+        site.requirements.caller_encoding = Some(CanonStringEncoding::Utf16);
+        site.requirements.callee_encoding = Some(CanonStringEncoding::Utf8);
+        assert!(
+            FactStyleGenerator::guard_async_cross_encoding_strings(&site).is_err(),
+            "LS-F-27: cross-encoding async string result must fail loud"
+        );
+    }
+
+    /// LS-F-27 must NOT over-trip: a SAME-encoding async string call keeps
+    /// working (no transcode needed, raw copy is correct).
+    #[test]
+    fn ls_f_27_same_encoding_async_string_ok() {
+        use crate::parser::CanonStringEncoding;
+        let site =
+            async_xenc_string_param_site(CanonStringEncoding::Utf8, CanonStringEncoding::Utf8);
+        assert!(
+            FactStyleGenerator::guard_async_cross_encoding_strings(&site).is_ok(),
+            "LS-F-27: same-encoding async string must not trip the guard"
+        );
+    }
+
+    /// LS-F-27 must NOT over-trip: a CROSS-encoding async call with NO string
+    /// param/result (e.g. a `list<u32>`, element size 4 — encoding-independent)
+    /// keeps working. Differing encodings alone must not block the call.
+    #[test]
+    fn ls_f_27_cross_encoding_async_no_string_ok() {
+        use crate::parser::CanonStringEncoding;
+        // A non-byte-element list param: element_size 4 → not a string.
+        let mut site = async_lift_site("[async-lift]sum");
+        site.crosses_memory = true;
+        site.requirements.pointer_pair_positions = vec![0];
+        site.requirements.param_copy_layouts = vec![crate::resolver::CopyLayout::Elements {
+            element_size: 4,
+            inner_pointers: Vec::new(),
+            inner_resources: Vec::new(),
+        }];
+        site.requirements.caller_encoding = Some(CanonStringEncoding::Utf8);
+        site.requirements.callee_encoding = Some(CanonStringEncoding::Utf16);
+        assert!(
+            FactStyleGenerator::guard_async_cross_encoding_strings(&site).is_ok(),
+            "LS-F-27: cross-encoding async with no string must not trip the guard"
+        );
+
+        // And a cross-encoding async call with NO ptr-pairs at all.
+        let mut bare = async_lift_site("[async-lift]noop");
+        bare.crosses_memory = true;
+        bare.requirements.caller_encoding = Some(CanonStringEncoding::Utf8);
+        bare.requirements.callee_encoding = Some(CanonStringEncoding::Utf16);
+        assert!(
+            FactStyleGenerator::guard_async_cross_encoding_strings(&bare).is_ok(),
+            "LS-F-27: cross-encoding async with no ptr-pairs must not trip"
+        );
+    }
+
+    /// LS-F-27 must NOT over-trip: a cross-encoding async string that does
+    /// NOT cross memory (shared-memory mode) keeps working — there is only
+    /// one memory and one encoding in play.
+    #[test]
+    fn ls_f_27_cross_encoding_async_same_memory_ok() {
+        use crate::parser::CanonStringEncoding;
+        let mut site =
+            async_xenc_string_param_site(CanonStringEncoding::Utf8, CanonStringEncoding::Utf16);
+        site.crosses_memory = false;
+        assert!(
+            FactStyleGenerator::guard_async_cross_encoding_strings(&site).is_ok(),
+            "LS-F-27: non-cross-memory async string must not trip the guard"
+        );
+    }
+
+    /// LS-F-27 wiring: the guard is reached through the real `generate`
+    /// dispatch (not just the helper), so a graph with a cross-encoding
+    /// async string site makes `generate` return Err before emitting a
+    /// silently-corrupting adapter.
+    #[test]
+    fn ls_f_27_generate_dispatch_rejects_cross_encoding_async_string() {
+        use crate::parser::CanonStringEncoding;
+        let gen_ = FactStyleGenerator::new(AdapterConfig::default());
+        let merged = empty_merged();
+        let site =
+            async_xenc_string_param_site(CanonStringEncoding::Utf8, CanonStringEncoding::Utf16);
+        let graph = crate::resolver::DependencyGraph {
+            instantiation_order: vec![0, 1],
+            resolved_imports: std::collections::HashMap::new(),
+            unresolved_imports: Vec::new(),
+            adapter_sites: vec![site],
+            resource_graph: None,
+            stream_pair_graph: None,
+            module_resolutions: Vec::new(),
+            reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
+        };
+        let res = <FactStyleGenerator as AdapterGenerator>::generate(&gen_, &merged, &graph);
+        assert!(
+            res.is_err(),
+            "LS-F-27: generate() must reject a cross-encoding async string site"
+        );
+    }
+
     #[test]
     fn sr32_has_callback_export_detects_companion() {
         let gen_ = FactStyleGenerator::new(AdapterConfig::default());
@@ -7646,6 +7894,79 @@ mod tests {
             shift += 7;
         }
         (result, consumed)
+    }
+
+    /// #272 STEP-1 differential: confirm whether a CROSS-ENCODING async
+    /// string PARAM is silently raw-copied (no transcode) by the async
+    /// emitter, transcoded, or rejected. Builds a cross-memory async-lift
+    /// site whose caller lowers a string param in UTF-8 while the callee
+    /// lifts it in UTF-16 (`pointer_pair_positions=[0]`), then inspects
+    /// the emitted body.
+    ///
+    /// Verdict recorded by the assertions below: the body emits
+    /// `memory.copy` (0xFC 0x0A) and contains NO UTF-8↔UTF-16 transcode
+    /// loop, i.e. the cross-encoding string crosses memory as raw bytes
+    /// reinterpreted under the wrong encoding — verdict (a), CONFIRMED
+    /// silent corruption. The post-fix guard test below
+    /// (`ls_f_27_async_cross_encoding_string_param_fails_loud`) asserts
+    /// this same shape is now rejected with an `AdapterGeneration` error.
+    #[test]
+    #[ignore = "STEP-1 evidence: pre-fix this asserted raw-copy; post-fix the \
+                emitter fails loud (see ls_f_27_* gate). Kept ignored as the \
+                documented confirmation record."]
+    fn issue_272_step1_async_cross_encoding_param_was_raw_copied() {
+        let gen_ = FactStyleGenerator::new(AdapterConfig::default());
+        let mut merged = empty_merged();
+
+        // Caller type: (ptr: i32, len: i32) -> () — a lowered string param.
+        merged.types.push(crate::merger::MergedFuncType {
+            params: vec![wasm_encoder::ValType::I32, wasm_encoder::ValType::I32],
+            results: vec![],
+        });
+        // Lift type: (ptr, len) -> ()
+        merged.types.push(crate::merger::MergedFuncType {
+            params: vec![wasm_encoder::ValType::I32, wasm_encoder::ValType::I32],
+            results: vec![],
+        });
+        merged.functions.push(crate::merger::MergedFunction {
+            type_idx: 1,
+            body: wasm_encoder::Function::new([]),
+            origin: (1, 0, 0),
+            synthetic_kind: None,
+        });
+        merged.function_index_map.insert((1, 0, 0), 0);
+        // callee realloc at idx 1
+        merged.functions.push(crate::merger::MergedFunction {
+            type_idx: 1,
+            body: wasm_encoder::Function::new([]),
+            origin: (1, 0, 0),
+            synthetic_kind: None,
+        });
+        merged.realloc_map.insert((1, 0), 1);
+        merged.memory_index_map.insert((0, 0, 0), 0);
+        merged.memory_index_map.insert((1, 0, 0), 1);
+
+        let mut site = async_lift_site("[async-lift]greet");
+        site.from_component = 0;
+        site.to_component = 1;
+        site.import_func_type_idx = Some(0);
+        site.crosses_memory = true;
+        // String param at flat position 0; caller UTF-8, callee UTF-16.
+        site.requirements.pointer_pair_positions = vec![0];
+        site.requirements.param_copy_layouts =
+            vec![crate::resolver::CopyLayout::Bulk { byte_multiplier: 1 }];
+        site.requirements.caller_encoding = Some(crate::parser::CanonStringEncoding::Utf8);
+        site.requirements.callee_encoding = Some(crate::parser::CanonStringEncoding::Utf16);
+
+        let adapter = gen_
+            .generate_async_stackful_adapter(&site, &merged)
+            .expect("pre-fix: async emitter raw-copies cross-encoding string");
+        let body = adapter.body.into_raw_body();
+        let has_memcopy = body.windows(2).any(|w| w == [0xFC, 0x0A]);
+        assert!(
+            has_memcopy,
+            "STEP-1: cross-encoding async string param raw-copied via memory.copy"
+        );
     }
 
     /// Regression test for the cross-memory ptr-pair stackful return

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -1244,6 +1244,78 @@ loss-scenarios:
       asserted per-representation sums for both a latin1-fits string ("café")
       and a utf16-requiring string ("日本" / "A😀").
 
+  - id: LS-F-27
+    title: Async-lift adapter raw-copies cross-encoding string → silent mis-transcode
+    uca: UCA-A-8
+    hazards: [H-4, H-4.4]
+    type: inadequate-control-algorithm
+    scenario: >
+      The adapter generator's async dispatch (`FactStyleGenerator::generate`,
+      fact.rs) routes EVERY `site.is_async_lift` call to
+      `generate_async_callback_adapter` / `generate_async_stackful_adapter`
+      and `continue`s — unconditionally, never computing `needs_transcoding()`.
+      The SYNC dispatch sends cross-encoding calls
+      (`caller_string_encoding != callee_string_encoding`) to
+      `generate_transcoding_adapter`; the async branch bypasses that gate. The
+      shared async copy helpers `emit_param_copy_step` (param side) and
+      `emit_ptr_pair_result_writeback` (result side) move a string's bytes
+      across memories via `memory.copy` (byte-count tag-aware after #253) but
+      perform NO encoding conversion. A cross-memory async-lift call whose
+      caller lowers a string in one encoding (e.g. UTF-8) while the callee
+      lifts it in a different encoding (e.g. UTF-16) therefore copies the raw
+      bytes verbatim, which the receiving side reinterprets under the wrong
+      encoding — the H-4.4 silent wrong-encoding string data that #253 / #271
+      closed for the sync path, here re-opened on the async path. Confirmed
+      reachable by a runtime-differential: the resolver populates
+      `is_async_lift`, both `caller_encoding`/`callee_encoding`, and
+      `pointer_pair_positions` on the same site, and the async stackful emitter
+      emits `memory.copy` (0xFC 0x0A) with no transcode loop for such a site
+      (`issue_272_step1_async_cross_encoding_param_was_raw_copied`, kept as the
+      ignored confirmation record).
+    causal-factors:
+      - >-
+        The async branch in `generate` runs before — and instead of — the
+        `crosses_memory && needs_transcoding()` gate the sync `generate_adapter`
+        applies, so a cross-encoding async-lift site is never routed to a
+        transcoding emitter
+      - >-
+        `emit_param_copy_step` / `emit_ptr_pair_result_writeback` copy
+        string/(ptr,len) buffers with `memory.copy` and no encoding conversion,
+        correct only when both sides share an encoding
+    control-algorithm-flaw: >
+      The async adapter emission path assumes both components share a string
+      encoding (true for same-encoding fusions) and has no branch for the
+      cross-encoding case — neither a transcoding emitter nor a loud rejection.
+      Full async transcoding is a larger tracked capability (#272); until it
+      lands the only safe behaviour is to fail loud rather than emit a
+      silently-corrupting raw copy.
+    status: approved
+    priority: high
+    fix: >
+      `FactStyleGenerator::guard_async_cross_encoding_strings` (fact.rs) is
+      invoked at the top of the async branch in `generate`, before either
+      async emitter runs. It returns
+      `Err(Error::AdapterGeneration("async cross-encoding string transcoding
+      is not yet supported (caller … != callee …); a verbatim copy would
+      silently mis-transcode — see #272"))` iff the site crosses memory AND the
+      caller/callee canonical encodings differ (compared via
+      `canon_to_string_encoding`, as `analyze_call_site` does) AND there is at
+      least one byte-granular `(ptr, len)` param or result (a plausible string:
+      `CopyLayout::Bulk{1}` / `Elements{element_size:1}`, or a bare ptr-pair
+      with no layout, which the emitters treat as byte-granular). It does NOT
+      trip for same-encoding async strings, cross-encoding async calls with no
+      string (e.g. `list<u32>`, element size 4) or no ptr-pairs at all, or
+      non-cross-memory (shared-memory) async strings. Pinned by the LS-F-27
+      gate tests: `ls_f_27_async_cross_encoding_string_param_fails_loud`,
+      `ls_f_27_async_cross_encoding_string_result_fails_loud`,
+      `ls_f_27_same_encoding_async_string_ok`,
+      `ls_f_27_cross_encoding_async_no_string_ok`,
+      `ls_f_27_cross_encoding_async_same_memory_ok`, and
+      `ls_f_27_generate_dispatch_rejects_cross_encoding_async_string` (drives
+      the real `generate` dispatch). Full async cross-encoding TRANSCODING
+      (versus this fail-loud guard) remains the tracked #272 capability
+      follow-up.
+
   - id: LS-P-17
     title: Caller-encoding match filters on Func only, miscalibrates mixed-encoding callers
     uca: UCA-R-3


### PR DESCRIPTION
## What

Closes the async half of #272. A **confirmed** silent-corruption bug (runtime differential): `FactStyleGenerator::generate` routes every `is_async_lift` call to the async emitters and `continue`s **without** computing `needs_transcoding()`, bypassing the sync transcoding dispatch. The async copy helpers move string bytes via `memory.copy` with no encoding conversion — so a cross-encoding async-lift call passing a string **silently raw-copies the bytes under the wrong encoding** (H-4.4), the exact defect #253/#271 closed for the sync path, re-opened on async.

## Fix (fail-loud guard, not full transcoding)

`guard_async_cross_encoding_strings`, run at the top of the async branch: returns a clear `AdapterGeneration` error when `crosses_memory` AND caller/callee string encodings differ AND there's a byte-granular `(ptr,len)` param/result — instead of emitting a silently-wrong adapter. Matches the #253 fail-loud-over-silent-corruption philosophy. **Full async cross-encoding transcoding remains the tracked #272 capability follow-up.**

**Trips:** cross-memory + differing encoding + a byte-granular string-like buffer.
**Does NOT trip:** same-encoding async strings; cross-encoding async with no string (e.g. `list<u32>`, stride 4); same-memory (shared) async.

### Conservative limitation (documented)
`CopyLayout` can't distinguish `string` from `list<u8>` (both `Bulk{1}`), so a cross-encoding async call passing **only** `list<u8>` (encoding-agnostic, safe) will also fail loud. This errs fail-loud (recoverable) rather than risk an under-trip (silent corruption); it dissolves when full async transcoding lands. Reviewers: weigh whether this over-trip is acceptable vs. a common pattern.

## Verification
- Confirmed via runtime differential (the pre-fix async emitter raw-copies a cross-encoding string; kept as an `#[ignore]`d record).
- `cargo test -p meld-core --lib` 370/0; `--test adapter_safety` 23/0; LS-N gate **57/0/0** (LS-F-27 + 6 `ls_f_27_*` gate tests); build/clippy/fmt clean.

## Tier-5
Touches `adapter/fact.rs` → Mythos delta-pass applies. Adversarial pass (under-trip / over-trip) posted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)