### PR TITLE
docs(safety): SR-41 for async cross-encoding transcoding; de-stale LS-F-27 (#272)

### DIFF
--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1211,3 +1211,56 @@ artifacts:
         (proofs/STATUS.md); these harnesses target
         the parser-layer gap STATUS.md marks as placeholder.
       milestone: v0.30.0
+
+  - id: SR-41
+    type: requirement
+    title: Async cross-encoding string transcoding
+    description: >
+      Async-lift FACT adapters shall transcode string params and results
+      that cross a string-encoding boundary, rather than raw-copying them
+      under the wrong encoding. Coverage: all six ordered encoding-pair
+      directions over utf8 / utf16 / latin1+utf16 (CompactUTF16, the
+      UTF16_TAG = 1<<31 tagged-length form), at the top level and one level
+      of list / record / tuple nesting, in both the callback and stackful
+      async variants. A nested `list<u8>` shall be deep-copied verbatim,
+      never transcoded (string-vs-byte-list disambiguation via the WIT type).
+      Any not-yet-supported shape — deeper-than-one-level list nesting
+      (`list<list<string>>`, #286) — shall fail loud (the LS-F-27 guard),
+      never silently mis-transcode. Extends SR-17 (sync transcoding) to the
+      async-lift adapter path.
+    status: verified
+    tags: [roadmap, async, transcoding]
+    links:
+      - type: derives-from
+        target: SR-17
+      - type: tracked-by
+        target: "#272"
+      - type: mitigates
+        target: LS-F-27
+    fields:
+      implementation:
+        - meld-core/src/adapter/fact.rs
+      verification-method: test
+      verification-description: >
+        Runtime-differential oracles in tests/async_cross_encoding.rs
+        (inc1..inc5c-b) drive the production transcode emitters
+        (emit_<dir>_transcode_param, wired into emit_param_copy_step /
+        emit_ptr_pair_result_writeback / emit_param_nested_indirections /
+        emit_patch_nested_indirections) under wasmtime via synthetic
+        two-memory modules, asserting correct transcoded bytes + (for the
+        latin1+utf16 directions) the tagged length, for both latin1-fitting
+        and utf16-requiring strings, including the nested cases and the
+        nested-list<u8>-not-transcoded guarantee. The async-lift trampoline
+        INTEGRATION (the real callback/stackful adapter) is verified by the
+        inc*_{callback,stackful}_*_within_budget tests, which generate the
+        REAL adapter and assert local-index addressability — the
+        compensating control for the full async-lift e2e, which is gated on
+        the kiln runtime (out of scope for this repo's tests, per the
+        existing async-lift fuse-only/structural posture). Each increment
+        passed an adversarial Mythos delta-pass; the passes caught four real
+        silent-corruption bugs before merge (callback budget overflow; the
+        nested list<u8> corruption blocker; the param_wit_types
+        per-pointer-pair index misalignment; the same-encoding UTF-16 nested
+        deep-copy under-copy). #281 (async nested-param pointers dangling
+        into caller memory) was closed in the same work.
+      milestone: post-v0.31.0

--- a/safety/requirements/traceability.yaml
+++ b/safety/requirements/traceability.yaml
@@ -562,6 +562,47 @@ verification-status:
       do not converge in CBMC against the current ParsedComponent
       shape; that contract stays pinned by the exhaustive unit tests.
 
+  SR-41:
+    implementation-files: [meld-core/src/adapter/fact.rs]
+    tests:
+      # Param side — all 6 directions (runtime-differential under wasmtime)
+      - async_cross_encoding::inc1_async_utf8_to_utf16_param_transcodes_hello
+      - async_cross_encoding::inc1_async_utf8_to_utf16_param_transcodes_supplementary_plane
+      - async_cross_encoding::inc2_async_utf16_to_utf8_param_transcodes_supplementary_plane
+      - async_cross_encoding::inc4a_async_latin1_to_utf16_tag_set_nihon
+      - async_cross_encoding::inc4a_async_latin1_to_utf8_tag_set_nihon
+      - async_cross_encoding::inc4b_async_utf8_to_latin1_emoji_surrogate_pair
+      - async_cross_encoding::inc4b_async_utf16_to_latin1_nihon_utf16
+      # Result side + nested (one level) + the list<u8>-not-transcoded guarantee
+      - adapter::fact::tests::inc3_async_utf8_to_utf16_top_level_string_result_allowed
+      - async_cross_encoding::inc5a_async_nested_list_string_utf8_to_utf16_transcodes
+      - async_cross_encoding::inc5a_async_nested_list_u8_result_not_transcoded
+      - async_cross_encoding::inc5b_nested_list_string_utf16_to_latin1
+      - async_cross_encoding::inc5c_a_async_nested_list_string_param_utf8_to_utf16_transcodes
+      - async_cross_encoding::inc5c_b_same_encoding_utf16_nested_param_deep_copies_full_codeunits
+      # Integration: the REAL callback+stackful adapter local-bounds (the async-lift
+      # integration compensating control; full e2e is kiln-gated)
+      - adapter::fact::tests::inc1_callback_adapter_transcode_locals_within_budget
+      - adapter::fact::tests::inc5c_b_callback_adapter_nested_param_dest_latin1_locals_within_budget
+      # The fail-loud guard (LS-F-27) for the not-yet-supported deeper-nesting edge
+      - adapter::fact::tests::inc5c_b_async_deeper_list_nesting_param_fails_loud_all_directions
+    proofs: []
+    status: verified
+    note: >-
+      The #272 campaign (PRs #273–#285, 2026-06-15). Async-lift adapters
+      transcode cross-encoding strings for all 6 directions × {param, result}
+      × {flat, one-level-nested}, both callback and stackful; nested list<u8>
+      deep-copied verbatim; #281 closed (async nested-param pointers were
+      dangling into caller memory). Each increment passed an adversarial
+      Mythos delta-pass that caught 4 real silent-corruption bugs before
+      merge. Verification posture: the transcode loops are runtime-verified
+      under wasmtime via synthetic two-memory modules; the async-lift
+      trampoline integration is verified by the *_within_budget real-adapter
+      tests (full async-lift e2e is kiln-gated, out of scope per the repo's
+      existing async-lift fuse-only posture). Remaining gap: deeper list
+      nesting (list<list<string>>) — fail-loud-safe, tracked as #286 (a
+      recursive-copy restructure, not a bounded increment).
+
 # wit-bindgen fixture coverage (14 fixtures × 3 levels = 42 integration tests)
 wit-bindgen-fixtures:
   passing-all-3-levels:

--- a/safety/stpa/loss-scenarios.yaml
+++ b/safety/stpa/loss-scenarios.yaml
@@ -1286,9 +1286,14 @@ loss-scenarios:
       The async adapter emission path assumes both components share a string
       encoding (true for same-encoding fusions) and has no branch for the
       cross-encoding case — neither a transcoding emitter nor a loud rejection.
-      Full async transcoding is a larger tracked capability (#272); until it
-      lands the only safe behaviour is to fail loud rather than emit a
-      silently-corrupting raw copy.
+      RESOLVED (#272 campaign, SR-41): async cross-encoding transcoding is now
+      implemented for all 6 directions × {param, result} × {flat, one-level
+      list/record/tuple nesting}. This guard remains as the RESIDUAL fallback:
+      it now fails loud ONLY for shapes still unsupported — currently deeper
+      list nesting (`list<list<string>>`, #286, a recursive-copy restructure) —
+      so any not-yet-transcodable cross-encoding string still fails loud rather
+      than silently raw-copying. The original blanket fail-loud (the safe
+      interim before #272) has been narrowed to exactly the unimplemented set.
     status: approved
     priority: high
     fix: >
@@ -1312,9 +1317,12 @@ loss-scenarios:
       `ls_f_27_cross_encoding_async_no_string_ok`,
       `ls_f_27_cross_encoding_async_same_memory_ok`, and
       `ls_f_27_generate_dispatch_rejects_cross_encoding_async_string` (drives
-      the real `generate` dispatch). Full async cross-encoding TRANSCODING
-      (versus this fail-loud guard) remains the tracked #272 capability
-      follow-up.
+      the real `generate` dispatch). Full async cross-encoding TRANSCODING is
+      now IMPLEMENTED (#272 / SR-41) — the guard's allow-set was narrowed in
+      lockstep across inc 1–5c-b so it permits every transcodable shape and
+      fails loud only on the residual deeper-nesting edge (#286). The guard's
+      allow-set ≡ the emitter's transcode-set at every increment (verified by
+      the inc*/ls_f_27 gate tests), so there is no allow-but-raw-copy gap.
 
   - id: LS-P-17
     title: Caller-encoding match filters on Func only, miscalibrates mixed-encoding callers


### PR DESCRIPTION
## What
Closes the #272 campaign's **traceability** gap (doc-only — no code).

The async cross-encoding string transcoding capability (PRs #273–#285, 44 `async_cross_encoding` tests) shipped without a requirement covering it: **SR-17** links only the *sync* `adapter_safety` tests, and **LS-F-27**'s text still said async transcoding was "a larger tracked capability (#272); until it lands, fail loud" — but #272 is done.

## Changes
- **SR-41 "Async cross-encoding string transcoding"** (verified): all 6 directions × {param, result} × {flat, one-level-nested}, both async variants; nested `list<u8>` deep-copied verbatim; #281 closed. `derives-from SR-17`, `mitigates LS-F-27`, `tracked-by #272`. Honest verification posture recorded (transcode loops runtime-verified under wasmtime; async-lift integration via the real-adapter `*_within_budget` tests; full e2e kiln-gated; each increment adversarially Mythos-passed — 4 silent-corruption bugs caught before merge).
- **SR-41 traceability entry** links a representative set of the `async_cross_encoding` + integration local-bounds + LS-F-27 gate tests (all verified to exist).
- **De-stales LS-F-27**: the guard is now the *residual* fallback for the only remaining unsupported shape (`list<list<string>>`, #286), allow-set narrowed in lockstep to ≡ the emitter's transcode-set.

## Verification
- YAML parses; all 10 SR-41-linked test fns exist; rivet **0 broken cross-refs**.
- LS-N gate **57/0/0** (LS-F-27 8 pass — text edit didn't change the ID→test mapping).
- rivet error count +2 = SR-41 joining the pre-existing every-SR-lacks-design-decision/feature backlog (systemic, not new-class, not the required gate).

Non-Tier-5 (safety YAML only) → no Mythos delta-pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)