### PR TITLE
docs(safety): de-stale SR-17 — reverse-direction non-BMP + lone-surrogate oracles now exist

### DIFF
--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -425,10 +425,20 @@ artifacts:
         [0x0041, 0xD83D, 0xDE00], proving the supplementary-plane
         surrogate-pair branch of emit_utf8_to_utf16_transcode encodes
         the high/low surrogates correctly and advances the destination
-        cursor by one then two units. Carried gap: the UTF-16 → UTF-8
-        reverse direction and lone-surrogate U+FFFD substitution are
-        covered structurally (LS-P-16) but not yet by a non-BMP runtime
-        round-trip.
+        cursor by one then two units. The UTF-16 → UTF-8 reverse
+        direction is covered by a non-BMP runtime round-trip
+        (test_sr17_utf16_to_utf8_supplementary_plane_transcoding —
+        U+1F600 surrogate pair D83D DE00 → UTF-8 F0 9F 98 80) and the
+        Canonical-ABI lossy lone-surrogate U+FFFD substitution by
+        test_sr17_utf16_to_utf8_lone_high_surrogate_replacement and
+        test_sr17_utf16_to_utf8_midstring_lone_surrogate_replacement
+        (lone high surrogate, terminal and mid-string, → U+FFFD
+        EF BF BD), with malformed-input coverage in
+        test_sr17_utf16_to_utf8_malformed_surrogate_matrix. The async
+        cross-encoding path reuses the same shared decode/encode helpers
+        and is independently exercised over the supplementary plane and
+        a lone surrogate by inc2_async_utf16_to_utf8_param_* in
+        tests/async_cross_encoding.rs (#272, post-v0.31.0-audit).
 
   - id: SR-18
     type: requirement


### PR DESCRIPTION
## What

SR-17's `verification-description` (authored at the v0.31.0 traceability audit) lists the **UTF-16 → UTF-8 reverse direction** and **lone-surrogate U+FFFD substitution** as a carried gap — "covered structurally (LS-P-16) but not yet by a non-BMP runtime round-trip". The subsequent **#272 async cross-encoding campaign** closed that gap with runtime oracles, but the SR text was never updated. The result was an *understated* (phantom) gap in the safety record — the safe failure direction, but still a traceability defect that under-credits real verification.

This is a **text-only** correction to one existing `verified` SR. No links, artifacts, or statuses change.

## Oracles that close the gap (all passing under wasmtime)

| Oracle | Covers |
|---|---|
| `test_sr17_utf16_to_utf8_supplementary_plane_transcoding` | reverse-direction non-BMP round-trip — U+1F600 pair `D83D DE00` → UTF-8 `F0 9F 98 80` |
| `test_sr17_utf16_to_utf8_lone_high_surrogate_replacement` | terminal lone high surrogate → U+FFFD `EF BF BD` |
| `test_sr17_utf16_to_utf8_midstring_lone_surrogate_replacement` | mid-string lone surrogate → U+FFFD |
| `test_sr17_utf16_to_utf8_malformed_surrogate_matrix` | malformed-input matrix |
| `inc2_async_utf16_to_utf8_param_*` (`tests/async_cross_encoding.rs`) | async path over the same shared decode/encode helpers |

## Verification

- `adapter_safety` SR-17 oracles: **8 passed / 0 failed**; async non-BMP oracles: **44 passed / 0 failed**.
- `rivet validate`: identical with and without this edit — **180 errors / 101 warnings / 0 broken cross-refs** (the pre-existing left-side `missing: feature/design-decision` baseline; this edit changes no validation state).
- LS-N gate (`run_ls_verification.py`): **57 passed / 0 failed / 0 missing**.

## Scope

Touches only `safety/requirements/safety-requirements.yaml` — **no Tier-5 source path**, so no Mythos gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)