### PR TITLE
feat(adapter): #286 5d — depth-2 list<list<string>> RESULT cross-encoding transcoding

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -4896,6 +4896,26 @@ impl Indirection {
     }
 }
 
+/// #286 5d: the per-indirection RESULT recurse/transcode decision, shared by the
+/// emitter and the result guard so the guard's allow-set is EXACTLY what
+/// `emit_patch_nested_indirections` transcodes or recurses into (allow-set ≡
+/// transcode-set). A leaf is depth-bounded transcodable iff it is a `string`
+/// (transcoded directly) OR a nested `list<elem>` whose immediate inner
+/// indirections are all strings (the depth-2 `list<list<string>>` case the
+/// emitter recurses one level for). Returns `false` for a nested `list<u8>`
+/// (raw-copied binary) and for deeper-than-2 nesting (whose inner subtree is a
+/// `list`, not all strings) — both remain fail-loud, matching the emitter's
+/// recursion guard and the async-adapter local budget (sized for depth-2).
+pub(crate) fn indirection_result_transcodable_depth2(ind: &Indirection) -> bool {
+    match &ind.kind {
+        IndirectionKind::String => true,
+        IndirectionKind::List { elem } => {
+            let sub = collect_indirections(elem, 0);
+            !sub.is_empty() && sub.iter().all(|s| s.is_string())
+        }
+    }
+}
+
 /// For a given element type, find every field offset that holds a (ptr, len)
 /// pair that needs cross-memory copying. See [`Indirection`].
 pub(crate) fn collect_indirections(
@@ -9730,7 +9750,17 @@ impl FactStyleGenerator {
         // under the REAL adapter (6-scratch, dest-latin1 nested param) by
         // `inc5c_b_callback_adapter_nested_param_dest_latin1_locals_within_budget`
         // (and the utf8→utf16 5-scratch case by the inc-5c-a test).
-        let mut body = Function::new([(27, wasm_encoder::ValType::I32)]);
+        //
+        // #286 5d (DEPTH-2 nested `list<list<string>>` RESULT): the result
+        // writeback now recurses one level, adding a SECOND nested-loop block at
+        // `l_first_scratch + 6 = l_p2 + 11 ..= l_p2 + 16` (offsets 16..=21) LIVE
+        // simultaneously with the depth-0 block (offsets 10..=15) and the leaf
+        // transcode. The result `transcode_base` therefore shifts past the
+        // depth-1 block to `l_p2 + 17` (6-scratch → offsets 22..=27); top index
+        // offset 27 ⇒ budget grows 27 → 28. Only the deepest leaf transcodes at
+        // once, so a single shared transcode block suffices. Proven under the
+        // REAL adapter by `d5d_callback_adapter_depth2_nested_result_within_budget`.
+        let mut body = Function::new([(28, wasm_encoder::ValType::I32)]);
 
         // Step 0.5: copy string/list params from caller to callee memory.
         // Shared with the stackful emitter (SR-32, #140); see
@@ -9979,11 +10009,12 @@ impl FactStyleGenerator {
                         // SAME index passed to `emit_param_copy_step` above
                         // (`l_p2 + 16`) — the param transcode (step 0.5) and the
                         // result transcode (step 3) are never simultaneously
-                        // live, and `l_p2 + 16 ..= l_p2 + 20` (block offsets
-                        // 21..=25, declared by the budget of 26) does not
-                        // overlap the writeback/nested region `l_p2 + 1 ..=
-                        // l_p2 + 10` that IS live here.
-                        l_p2 + 16,
+                        // live. #286 5d: shifted to `l_p2 + 17` so the shared
+                        // leaf-transcode block (offsets 22..=27) sits past the
+                        // depth-1 recursion block `l_p2 + 11 ..= l_p2 + 16`
+                        // (offsets 16..=21); both are disjoint from the depth-0
+                        // nested region `l_p2 + 1 ..= l_p2 + 10` live here.
+                        l_p2 + 17,
                         site.requirements.caller_encoding,
                         site.requirements.callee_encoding,
                         // Result-side: governed by the callee's string encoding.
@@ -11219,7 +11250,16 @@ impl FactStyleGenerator {
         // nested param) by
         // `inc5c_b_stackful_adapter_nested_param_dest_latin1_locals_within_budget`
         // (and the utf8→utf16 5-scratch case by the inc-5c-a test).
-        let mut body = Function::new([(18, wasm_encoder::ValType::I32)]);
+        //
+        // #286 5d (DEPTH-2 nested `list<list<string>>` RESULT): the result
+        // writeback recurses one level, adding a SECOND nested-loop block at
+        // `l_first_scratch + 6 = l_scratch + 11 ..= l_scratch + 16` (offsets
+        // 11..=16) LIVE with the depth-0 block (offsets 5..=10) and the leaf
+        // transcode. The result `transcode_base` shifts past it to `l_scratch +
+        // 17` (6-scratch → offsets 17..=22); top index offset 22 ⇒ budget grows
+        // 18 → 23. Proven under the REAL adapter by
+        // `d5d_stackful_adapter_depth2_nested_result_within_budget`.
+        let mut body = Function::new([(23, wasm_encoder::ValType::I32)]);
 
         // Step 0.5: cross-memory param copy (shared with callback path)
         self.emit_param_copy_step(
@@ -11326,11 +11366,13 @@ impl FactStyleGenerator {
                         // #272 inc 3: the result transcode's 5 scratch locals.
                         // SAME index passed to `emit_param_copy_step` above
                         // (`l_scratch + 12`) — param (step 0.5) and result
-                        // (step 3) transcodes are never simultaneously live, and
-                        // `l_scratch + 12 ..= l_scratch + 16` (declared by the
-                        // budget of 18) does not overlap the writeback/nested
-                        // region `l_scratch + 1 ..= l_scratch + 10` live here.
-                        l_scratch + 12,
+                        // (step 3) transcodes are never simultaneously live.
+                        // #286 5d: shifted to `l_scratch + 17` so the shared
+                        // leaf-transcode block (offsets 17..=22) sits past the
+                        // depth-1 recursion block `l_scratch + 11 ..= l_scratch +
+                        // 16` (offsets 11..=16); both disjoint from the depth-0
+                        // nested region `l_scratch + 1 ..= l_scratch + 10`.
+                        l_scratch + 17,
                         site.requirements.caller_encoding,
                         site.requirements.callee_encoding,
                         // Result-side: governed by the callee's string encoding.
@@ -11686,10 +11728,14 @@ impl FactStyleGenerator {
                     // for the nested case; the top-level path handles it.
                     _ => Vec::new(),
                 };
-                // Every inner indirection of THIS result must be a string for the
-                // nested transcode to be safe; a `list<u8>` inner (is_string ==
-                // false) makes the whole result NOT nested-string-allowed.
-                inner_indirections.iter().all(|ind| ind.is_string())
+                // Every inner indirection of THIS result must be transcodable for
+                // the nested transcode to be safe. #286 5d: a leaf is transcodable
+                // iff it is a `string` OR a `list<string>` (depth-2 — the emitter
+                // recurses one level); a nested `list<u8>` or deeper-than-2 nesting
+                // makes the whole result NOT nested-string-allowed (fail-loud).
+                inner_indirections
+                    .iter()
+                    .all(indirection_result_transcodable_depth2)
             })
             // At least one result must actually carry a nested string for this
             // predicate to widen the allow-set (a pure `list<u32>` has no inner
@@ -11699,7 +11745,8 @@ impl FactStyleGenerator {
                 crate::parser::ComponentValType::List(elem)
                 | crate::parser::ComponentValType::FixedSizeList(elem, _) => {
                     let inner = collect_indirections(elem, 0);
-                    !inner.is_empty() && inner.iter().all(|ind| ind.is_string())
+                    !inner.is_empty()
+                        && inner.iter().all(indirection_result_transcodable_depth2)
                 }
                 _ => false,
             });
@@ -13736,6 +13783,37 @@ mod tests {
         caller_enc: crate::parser::CanonStringEncoding,
         callee_enc: crate::parser::CanonStringEncoding,
     ) -> (crate::merger::MergedModule, crate::resolver::AdapterSite) {
+        // Depth-1: outer result = `list<string>` (outer element = `string`).
+        xenc_nested_result_merged_and_site(
+            caller_enc,
+            callee_enc,
+            crate::parser::ComponentValType::String,
+        )
+    }
+
+    /// #286 5d: depth-2 fixture — outer result = `list<list<string>>` (outer
+    /// element = `list<string>`), so the writeback recurses one level.
+    fn xenc_list_list_string_result_merged_and_site(
+        caller_enc: crate::parser::CanonStringEncoding,
+        callee_enc: crate::parser::CanonStringEncoding,
+    ) -> (crate::merger::MergedModule, crate::resolver::AdapterSite) {
+        xenc_nested_result_merged_and_site(
+            caller_enc,
+            callee_enc,
+            crate::parser::ComponentValType::List(Box::new(
+                crate::parser::ComponentValType::String,
+            )),
+        )
+    }
+
+    /// Shared fixture: build a merged module + async-lift site whose result is
+    /// `list<OUTER_ELEM>`. `outer_elem = string` → `list<string>` (depth-1);
+    /// `outer_elem = list<string>` → `list<list<string>>` (depth-2).
+    fn xenc_nested_result_merged_and_site(
+        caller_enc: crate::parser::CanonStringEncoding,
+        callee_enc: crate::parser::CanonStringEncoding,
+        outer_elem: crate::parser::ComponentValType,
+    ) -> (crate::merger::MergedModule, crate::resolver::AdapterSite) {
         use wasm_encoder::{EntityType, ExportKind, Function, ValType};
         let mut merged = empty_merged();
         // type 0: (retptr: i32) -> () — caller type; one retptr param, void.
@@ -13773,11 +13851,11 @@ mod tests {
         merged.memory_index_map.insert((0, 0, 0), 0);
         merged.memory_index_map.insert((1, 0, 0), 1);
 
-        // The nested-result element type: `string` (so the outer result is
-        // `list<string>`).
-        let list_string = crate::parser::ComponentValType::List(Box::new(
-            crate::parser::ComponentValType::String,
-        ));
+        // The outer result type is `list<outer_elem>`: `list<string>` (depth-1,
+        // outer_elem = string) or `list<list<string>>` (depth-2, outer_elem =
+        // list<string>). The writeback recurses when the element bears nested
+        // pointer indirections.
+        let list_string = crate::parser::ComponentValType::List(Box::new(outer_elem));
 
         // Result globals: a (ptr, len) i32 pair with a `list<string>`
         // result_type so the writeback walks nested indirections.
@@ -13882,6 +13960,106 @@ mod tests {
             .expect("stackful emitter must succeed for the inc-5a list<string> result site");
         let cpc = site_caller_param_count(&site, &merged);
         assert_locals_within_budget(adapter.body, cpc, "#272 inc-5a stackful nested result");
+    }
+
+    /// #286 5d (integration, callback): the CALLBACK async adapter's DEPTH-2
+    /// `list<list<string>>` RESULT recursion must stay within the grown budget
+    /// (28) under simultaneous liveness — depth-0 loop (offsets 10..=15), depth-1
+    /// recursion loop (offsets 16..=21), and the shared leaf transcode
+    /// (`l_p2 + 17 ..= l_p2 + 22`, offsets 22..=27) all live at once, DISJOINT,
+    /// top index offset 27 < 28. Generates the REAL adapter — the budget-bug
+    /// class (unknown-local overflow AND valid-but-wrong local-reuse collision)
+    /// the synthetic loop oracle cannot reach.
+    #[test]
+    fn d5d_callback_adapter_depth2_nested_result_within_budget() {
+        use crate::parser::CanonStringEncoding;
+        let gen_ = FactStyleGenerator::new(AdapterConfig::default());
+        let (merged, site) = xenc_list_list_string_result_merged_and_site(
+            CanonStringEncoding::Utf16,
+            CanonStringEncoding::Utf8,
+        );
+        let adapter = gen_
+            .generate_async_callback_adapter(&site, &merged)
+            .expect("callback emitter must succeed for the #286 5d list<list<string>> result");
+        let cpc = site_caller_param_count(&site, &merged);
+        assert_locals_within_budget(adapter.body, cpc, "#286 5d callback depth-2 nested result");
+    }
+
+    /// #286 5d (integration, stackful): the STACKFUL adapter's DEPTH-2
+    /// `list<list<string>>` RESULT recursion must stay within the grown budget
+    /// (23) — depth-0 loop (offsets 5..=10), depth-1 recursion loop (offsets
+    /// 11..=16), shared leaf transcode (`l_scratch + 17 ..= l_scratch + 22`,
+    /// offsets 17..=22), DISJOINT, top index offset 22 < 23. Generates the REAL
+    /// adapter.
+    #[test]
+    fn d5d_stackful_adapter_depth2_nested_result_within_budget() {
+        use crate::parser::CanonStringEncoding;
+        let gen_ = FactStyleGenerator::new(AdapterConfig::default());
+        let (mut merged, site) = xenc_list_list_string_result_merged_and_site(
+            CanonStringEncoding::Utf16,
+            CanonStringEncoding::Utf8,
+        );
+        merged.exports[0].name = site.export_name.clone();
+        let adapter = gen_
+            .generate_async_stackful_adapter(&site, &merged)
+            .expect("stackful emitter must succeed for the #286 5d list<list<string>> result");
+        let cpc = site_caller_param_count(&site, &merged);
+        assert_locals_within_budget(adapter.body, cpc, "#286 5d stackful depth-2 nested result");
+    }
+
+    /// #286 5d guard (POSITIVE): a DEPTH-2 `list<list<string>>` RESULT in the
+    /// callee=Utf8 → caller=Utf16 direction is now ALLOWED — the emitter recurses
+    /// one level and transcodes the deepest strings.
+    #[test]
+    fn d5d_async_nested_list_list_string_result_allowed() {
+        use crate::parser::CanonStringEncoding;
+        let (_merged, site) = xenc_list_list_string_result_merged_and_site(
+            CanonStringEncoding::Utf16,
+            CanonStringEncoding::Utf8,
+        );
+        FactStyleGenerator::guard_async_cross_encoding_strings(&site)
+            .expect("#286 5d: a depth-2 list<list<string>> result (Utf8 → Utf16) must be ALLOWED");
+    }
+
+    /// #286 5d guard (NEGATIVE — allow-set ≡ transcode-set): a DEPTH-2
+    /// `list<list<u8>>` RESULT must STAY FAIL-LOUD — the deepest leaf is a
+    /// `list<u8>` (binary, raw-copied, never transcoded), so the recursion guard
+    /// rejects it and the adapter must not be generated for cross-encoding.
+    #[test]
+    fn d5d_async_nested_list_list_u8_result_fail_loud() {
+        use crate::parser::{CanonStringEncoding, ComponentValType, PrimitiveValType};
+        let (_merged, site) = xenc_nested_result_merged_and_site(
+            CanonStringEncoding::Utf16,
+            CanonStringEncoding::Utf8,
+            ComponentValType::List(Box::new(ComponentValType::Primitive(PrimitiveValType::U8))),
+        );
+        assert!(
+            FactStyleGenerator::guard_async_cross_encoding_strings(&site).is_err(),
+            "#286 5d: a depth-2 list<list<u8>> result must stay FAIL-LOUD (deepest leaf \
+             is binary list<u8>, never transcoded)"
+        );
+    }
+
+    /// #286 5d guard (NEGATIVE — depth bound): a DEPTH-3
+    /// `list<list<list<string>>>` RESULT must STAY FAIL-LOUD — the emitter
+    /// recurses exactly one level and the async-adapter budget is sized for
+    /// depth-2; the guard must not widen past what the emitter+budget support.
+    #[test]
+    fn d5d_async_nested_depth3_result_fail_loud() {
+        use crate::parser::{CanonStringEncoding, ComponentValType};
+        let depth2 = ComponentValType::List(Box::new(ComponentValType::List(Box::new(
+            ComponentValType::String,
+        ))));
+        let (_merged, site) = xenc_nested_result_merged_and_site(
+            CanonStringEncoding::Utf16,
+            CanonStringEncoding::Utf8,
+            depth2, // outer_elem = list<list<string>> ⇒ result = list<list<list<string>>>
+        );
+        assert!(
+            FactStyleGenerator::guard_async_cross_encoding_strings(&site).is_err(),
+            "#286 5d: a depth-3 list<list<list<string>>> result must stay FAIL-LOUD \
+             (emitter recurses one level; budget sized for depth-2)"
+        );
     }
 
     /// #272 inc-5a guard: a NESTED `list<string>` RESULT in the callee=Utf8 →

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -4087,6 +4087,112 @@ fn emit_patch_nested_indirections(
             continue;
         }
 
+        // #286 5d: a nested pointer-bearing LIST (e.g. `list<list<string>>`) —
+        // the inner element ITSELF carries indirections (its own strings), so
+        // raw-copying the inner array verbatim would leave those inner `(ptr,
+        // len)` pairs dangling into callee memory and un-transcoded. Instead we
+        // copy the inner array into caller memory, store the relocated header,
+        // and RECURSE one nesting level down to patch each inner element.
+        //
+        // Recursion is at CODEGEN time (statically-nested wasm loops, depth
+        // known from the WIT type): each depth `d` gets a disjoint 6-local loop
+        // block at `l_first_scratch + 6*d`, while the transcode scratch
+        // (`l_transcode_base..`) is SHARED — only the single deepest string leaf
+        // transcodes at any instant (a level either recurses OR transcodes,
+        // never both), so `l_new_ptr` at each depth is its own local and never
+        // collides with the leaf sink. The caller sizes `l_transcode_base` past
+        // the deepest loop block (≥ `l_first_scratch + 6*max_depth`).
+        //
+        // Allow-set ≡ transcode-set: recurse ONLY when the inner subtree is
+        // ALL strings (`list<list<string>>`, not `list<list<u8>>`) AND the
+        // direction is one the leaf transcodes; otherwise fall through to the
+        // verbatim raw-copy (a nested `list<u8>` stays binary, fail-safe).
+        if let IndirectionKind::List { elem } = &ind.kind {
+            let sub = collect_indirections(elem, 0);
+            if inner_transcode_dir && !sub.is_empty() && sub.iter().all(|s| s.is_string()) {
+                let (_, inner_align) = cabi_size_align(elem);
+                // `l_old_ptr` = inner array base (callee), `l_buf_len` = inner
+                // ELEMENT count (a nested list len is the element count, never
+                // tag-encoded). Guard `count * sub_elem_size` against 2^32 wrap.
+                emit_overflow_guard(body, l_buf_len, *sub_elem_size);
+
+                // Skip the whole inner patch if (old_ptr, count*sub_elem_size)
+                // doesn't fit callee memory — fail-safe (matches the raw-copy).
+                body.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+                body.instruction(&Instruction::LocalGet(l_old_ptr));
+                body.instruction(&Instruction::LocalGet(l_buf_len));
+                if *sub_elem_size != 1 {
+                    body.instruction(&Instruction::I32Const(*sub_elem_size as i32));
+                    body.instruction(&Instruction::I32Mul);
+                }
+                body.instruction(&Instruction::I32Add);
+                body.instruction(&Instruction::MemorySize(callee_memory));
+                body.instruction(&Instruction::I32Const(16));
+                body.instruction(&Instruction::I32Shl);
+                body.instruction(&Instruction::I32GtU);
+                body.instruction(&Instruction::BrIf(0));
+
+                // new_ptr = realloc(0, 0, inner_align, count*sub_elem_size) in
+                // caller memory; bulk-copy the inner array callee→caller.
+                body.instruction(&Instruction::I32Const(0));
+                body.instruction(&Instruction::I32Const(0));
+                body.instruction(&Instruction::I32Const(inner_align as i32));
+                body.instruction(&Instruction::LocalGet(l_buf_len));
+                if *sub_elem_size != 1 {
+                    body.instruction(&Instruction::I32Const(*sub_elem_size as i32));
+                    body.instruction(&Instruction::I32Mul);
+                }
+                emit_checked_realloc(body, realloc_func, l_new_ptr);
+
+                body.instruction(&Instruction::LocalGet(l_new_ptr));
+                body.instruction(&Instruction::LocalGet(l_old_ptr));
+                body.instruction(&Instruction::LocalGet(l_buf_len));
+                if *sub_elem_size != 1 {
+                    body.instruction(&Instruction::I32Const(*sub_elem_size as i32));
+                    body.instruction(&Instruction::I32Mul);
+                }
+                body.instruction(&Instruction::MemoryCopy {
+                    dst_mem: caller_memory,
+                    src_mem: callee_memory,
+                });
+
+                // Store the relocated inner-array pointer + (unchanged) element
+                // count into the caller-memory header.
+                body.instruction(&Instruction::LocalGet(l_rec_dst));
+                body.instruction(&Instruction::LocalGet(l_new_ptr));
+                body.instruction(&Instruction::I32Store(dst_mem_arg_ptr));
+                body.instruction(&Instruction::LocalGet(l_rec_dst));
+                body.instruction(&Instruction::LocalGet(l_buf_len));
+                body.instruction(&Instruction::I32Store(dst_mem_arg_len));
+
+                // RECURSE one level down: patch the inner array's elements,
+                // reading source headers from the callee original (`l_old_ptr`)
+                // and writing patched headers into the caller copy
+                // (`l_new_ptr`). Disjoint loop block at `l_first_scratch + 6`;
+                // `l_transcode_base` shared. `l_old_ptr`/`l_new_ptr`/`l_buf_len`
+                // (this depth) are read-only during the call (its block is +6).
+                emit_patch_nested_indirections(
+                    body,
+                    elem,
+                    l_new_ptr,
+                    l_old_ptr,
+                    l_buf_len,
+                    *sub_elem_size,
+                    l_first_scratch + 6,
+                    realloc_func,
+                    caller_memory,
+                    callee_memory,
+                    callee_compact_utf16,
+                    caller_encoding,
+                    callee_encoding,
+                    l_transcode_base,
+                );
+
+                body.instruction(&Instruction::End); // end bounds block
+                continue;
+            }
+        }
+
         // LS-P-14: trap if `len * sub_elem_size` would wrap mod 2^32. Without
         // this guard a callee-supplied `len` near `u32::MAX / sub_elem_size`
         // wraps `buf_len` to a small value; the bounds check below uses

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -2844,6 +2844,131 @@ pub fn build_nested_list_string_result_test_module(
     module.finish()
 }
 
+/// #286 5d — DEPTH-2 nested-result oracle module: drives the production
+/// `emit_patch_nested_indirections` over `elem_ty = list<string>` (so the outer
+/// result is `list<list<string>>`), exercising the codegen-time recursion.
+///
+/// Identical to [`build_nested_list_string_result_test_module`] except:
+/// `elem_ty = List(String)` (one nesting level deeper), and the local layout is
+/// sized for depth-2 — `l_first_scratch = 3` (depth-0 block 3..=8), the depth-1
+/// recursion block is 9..=14, and `l_transcode_base = 15` (shared transcode
+/// scratch 15..=20, past BOTH loop blocks). 18 i32 locals (indices 3..=20).
+/// Exported `patch(outer_caller, outer_callee, count)`; the host lays out the
+/// two-level `list<list<string>>` in callee memory and reads back the doubly
+/// relocated + transcoded result from caller memory.
+pub fn build_nested_list_list_string_result_test_module(
+    caller_enc: crate::parser::CanonStringEncoding,
+    callee_enc: crate::parser::CanonStringEncoding,
+) -> Vec<u8> {
+    use crate::parser::ComponentValType;
+    use wasm_encoder::{
+        CodeSection, ConstExpr, ExportKind, ExportSection, FunctionSection, GlobalSection,
+        GlobalType, MemorySection, MemoryType, Module, TypeSection, ValType,
+    };
+
+    let callee_compact_utf16 =
+        matches!(callee_enc, crate::parser::CanonStringEncoding::CompactUtf16);
+
+    let mut types = TypeSection::new();
+    types.ty().function(
+        [ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+        [ValType::I32],
+    );
+    types
+        .ty()
+        .function([ValType::I32, ValType::I32, ValType::I32], []);
+
+    let mut functions = FunctionSection::new();
+    functions.function(0);
+    functions.function(1);
+
+    let mut memory = MemorySection::new();
+    for _ in 0..2 {
+        memory.memory(MemoryType {
+            minimum: 1,
+            maximum: None,
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        });
+    }
+
+    let mut globals = GlobalSection::new();
+    globals.global(
+        GlobalType {
+            val_type: ValType::I32,
+            mutable: true,
+            shared: false,
+        },
+        &ConstExpr::i32_const(2048),
+    );
+
+    let mut exports = ExportSection::new();
+    exports.export("patch", ExportKind::Func, 1);
+    exports.export("caller_memory", ExportKind::Memory, 0);
+    exports.export("callee_memory", ExportKind::Memory, 1);
+
+    let mut code = CodeSection::new();
+
+    // func 0: cabi_realloc — bump allocator over global 0 in CALLER memory 0.
+    {
+        let mut f = Function::new([(1, ValType::I32)]);
+        f.instruction(&Instruction::GlobalGet(0));
+        f.instruction(&Instruction::LocalGet(2));
+        f.instruction(&Instruction::I32Add);
+        f.instruction(&Instruction::I32Const(1));
+        f.instruction(&Instruction::I32Sub);
+        f.instruction(&Instruction::LocalGet(2));
+        f.instruction(&Instruction::I32Const(1));
+        f.instruction(&Instruction::I32Sub);
+        f.instruction(&Instruction::I32Const(-1));
+        f.instruction(&Instruction::I32Xor);
+        f.instruction(&Instruction::I32And);
+        f.instruction(&Instruction::LocalSet(4));
+        f.instruction(&Instruction::LocalGet(4));
+        f.instruction(&Instruction::LocalGet(3));
+        f.instruction(&Instruction::I32Add);
+        f.instruction(&Instruction::GlobalSet(0));
+        f.instruction(&Instruction::LocalGet(4));
+        f.instruction(&Instruction::End);
+        code.function(&f);
+    }
+
+    // func 1: patch(outer_caller, outer_callee, count) -> () for list<list<string>>.
+    {
+        let elem_ty = ComponentValType::List(Box::new(ComponentValType::String));
+        let mut f = Function::new([(18, ValType::I32)]);
+        emit_patch_nested_indirections(
+            &mut f,
+            &elem_ty,
+            0, // l_dst_ptr  (caller outer list)
+            1, // l_callee_src (callee outer list)
+            2, // l_src_len (outer count)
+            8, // elem_size (outer element = inner list (ptr, len))
+            3, // l_first_scratch (depth-0 block 3..=8; depth-1 recursion 9..=14)
+            0, // realloc_func (allocates in caller memory 0)
+            0, // caller_memory
+            1, // callee_memory
+            callee_compact_utf16,
+            Some(caller_enc),
+            Some(callee_enc),
+            15, // l_transcode_base (shared scratch 15..=20, past both loop blocks)
+        );
+        f.instruction(&Instruction::End);
+        code.function(&f);
+    }
+
+    let mut module = Module::new();
+    module
+        .section(&types)
+        .section(&functions)
+        .section(&memory)
+        .section(&globals)
+        .section(&exports)
+        .section(&code);
+    module.finish()
+}
+
 /// Shared builder for the two inc-5a nested-result oracle modules.
 ///
 /// `elem_ty` is the OUTER list's element type (`string` or `list<u8>`).

--- a/meld-core/src/adapter/mod.rs
+++ b/meld-core/src/adapter/mod.rs
@@ -73,6 +73,12 @@ pub use fact::build_nested_list_u8_result_not_transcoded_test_module;
 #[doc(hidden)]
 pub use fact::build_nested_list_string_result_test_module;
 
+/// Test-support: build the #286 5d DEPTH-2 NESTED `list<list<string>>` RESULT
+/// transcode oracle module (exercises the codegen-time recursion).
+/// `#[doc(hidden)]` — not a supported API; see the function's own docs.
+#[doc(hidden)]
+pub use fact::build_nested_list_list_string_result_test_module;
+
 /// Test-support: build the #272 inc-5c-a NESTED `list<string>` PARAM transcode
 /// (UTF-8 → UTF-16) oracle module. `#[doc(hidden)]` — not a supported API; see
 /// the function's own docs.

--- a/meld-core/tests/async_cross_encoding.rs
+++ b/meld-core/tests/async_cross_encoding.rs
@@ -36,9 +36,9 @@
 
 use meld_core::adapter::{
     build_latin1_to_utf8_transcode_test_module, build_latin1_to_utf16_transcode_test_module,
-    build_nested_list_string_result_test_module, build_utf8_to_latin1_transcode_test_module,
-    build_utf8_to_utf16_transcode_test_module, build_utf16_to_latin1_transcode_test_module,
-    build_utf16_to_utf8_transcode_test_module,
+    build_nested_list_list_string_result_test_module, build_nested_list_string_result_test_module,
+    build_utf8_to_latin1_transcode_test_module, build_utf8_to_utf16_transcode_test_module,
+    build_utf16_to_latin1_transcode_test_module, build_utf16_to_utf8_transcode_test_module,
 };
 use meld_core::parser::CanonStringEncoding;
 use wasmtime::{Config, Engine, Instance, Module as RuntimeModule, Store};
@@ -974,6 +974,153 @@ fn inc5b_nested_list_string_utf16_to_latin1() {
         "non-latin1 \"中\" → TAGGED len (1 | UTF16_TAG)"
     );
     assert_eq!(recs[1].bytes, vec![0x2D, 0x4E]);
+}
+
+// ----------------------------------------------------------------------------
+// #286 5d — DEPTH-2 nested `list<list<string>>` RESULT transcode (UTF-8 →
+// UTF-16). Exercises the codegen-time recursion in `emit_patch_nested_indirections`:
+// the OUTER leaf is a `list<string>` (pointer-bearing, NOT a string) so the
+// emitter must copy each inner list into caller memory and RECURSE to transcode
+// the deepest strings — not raw-copy the inner array (which would leave the
+// inner string pointers dangling into callee memory + un-transcoded).
+//
+// RESULT direction (callee PRODUCES, caller READS): callee memory 1 holds the
+// real two-level value; caller memory 0 gets the stale outer-array duplicate
+// (the post-outer-bulk-copy state). After `patch`, the host follows the doubly
+// relocated pointers ENTIRELY within caller memory and asserts each deepest
+// string was transcoded UTF-8 → UTF-16.
+// ----------------------------------------------------------------------------
+
+// callee-memory offsets: 3 UTF-8 inner strings, 2 inner lists, 1 outer list.
+const D2_HI_OFF: i32 = 100; // "Hi"  UTF-8 [0x48,0x69]
+const D2_E_OFF: i32 = 110; // "é"   UTF-8 [0xC3,0xA9] (U+00E9)
+const D2_OK_OFF: i32 = 120; // "ok"  UTF-8 [0x6F,0x6B]
+const D2_INNER_A_OFF: i32 = 200; // inner list A: [(Hi,2),(é,2)]
+const D2_INNER_B_OFF: i32 = 240; // inner list B: [(ok,2)]
+const D2_OUTER_OFF: i32 = 300; // outer list: [(A,2),(B,1)]
+
+/// Read an 8-byte `(ptr, len)` header from `mem` at `off`.
+fn read_hdr(mem: &wasmtime::Memory, store: &mut Store<()>, off: usize) -> (i32, i32) {
+    let mut hdr = [0u8; 8];
+    mem.read(store, off, &mut hdr).expect("read header");
+    (
+        i32::from_le_bytes(hdr[0..4].try_into().unwrap()),
+        i32::from_le_bytes(hdr[4..8].try_into().unwrap()),
+    )
+}
+
+#[test]
+fn d5d_depth2_nested_list_list_string_utf8_to_utf16_transcodes() {
+    let wasm = build_nested_list_list_string_result_test_module(
+        CanonStringEncoding::Utf16,
+        CanonStringEncoding::Utf8,
+    );
+    let mut validator = wasmparser::Validator::new();
+    validator
+        .validate_all(&wasm)
+        .expect("#286 5d depth-2 oracle module should validate");
+
+    let mut config = Config::new();
+    config.wasm_multi_memory(true);
+    let engine = Engine::new(&config).unwrap();
+    let module = RuntimeModule::new(&engine, &wasm).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    let caller_mem = instance.get_memory(&mut store, "caller_memory").unwrap();
+    let callee_mem = instance.get_memory(&mut store, "callee_memory").unwrap();
+
+    // Inner UTF-8 source strings (callee memory only).
+    callee_mem
+        .write(&mut store, D2_HI_OFF as usize, &[0x48, 0x69])
+        .unwrap();
+    callee_mem
+        .write(&mut store, D2_E_OFF as usize, &[0xC3, 0xA9])
+        .unwrap();
+    callee_mem
+        .write(&mut store, D2_OK_OFF as usize, &[0x6F, 0x6B])
+        .unwrap();
+
+    // Inner lists of (str_ptr, str_len) — callee memory only.
+    let mut inner_a = Vec::new();
+    inner_a.extend_from_slice(&D2_HI_OFF.to_le_bytes());
+    inner_a.extend_from_slice(&2i32.to_le_bytes());
+    inner_a.extend_from_slice(&D2_E_OFF.to_le_bytes());
+    inner_a.extend_from_slice(&2i32.to_le_bytes());
+    callee_mem
+        .write(&mut store, D2_INNER_A_OFF as usize, &inner_a)
+        .unwrap();
+
+    let mut inner_b = Vec::new();
+    inner_b.extend_from_slice(&D2_OK_OFF.to_le_bytes());
+    inner_b.extend_from_slice(&2i32.to_le_bytes());
+    callee_mem
+        .write(&mut store, D2_INNER_B_OFF as usize, &inner_b)
+        .unwrap();
+
+    // Outer list of (inner_list_ptr, inner_count) — written to BOTH memories
+    // (caller = the stale post-outer-bulk-copy duplicate the emitter overwrites).
+    let mut outer = Vec::new();
+    outer.extend_from_slice(&D2_INNER_A_OFF.to_le_bytes());
+    outer.extend_from_slice(&2i32.to_le_bytes());
+    outer.extend_from_slice(&D2_INNER_B_OFF.to_le_bytes());
+    outer.extend_from_slice(&1i32.to_le_bytes());
+    callee_mem
+        .write(&mut store, D2_OUTER_OFF as usize, &outer)
+        .unwrap();
+    caller_mem
+        .write(&mut store, D2_OUTER_OFF as usize, &outer)
+        .unwrap();
+
+    instance
+        .get_typed_func::<(i32, i32, i32), ()>(&mut store, "patch")
+        .unwrap()
+        .call(&mut store, (D2_OUTER_OFF, D2_OUTER_OFF, 2))
+        .expect("depth-2 patch runs");
+
+    // Follow the doubly relocated pointers ENTIRELY within caller memory.
+    // Expected inner strings transcoded to UTF-16LE:
+    //   "Hi" → [0x48,0x00,0x69,0x00] (2 units), "é" → [0xE9,0x00] (1 unit),
+    //   "ok" → [0x6F,0x00,0x6B,0x00] (2 units).
+    let expected: [&[(&[u8], i32)]; 2] = [
+        &[(&[0x48, 0x00, 0x69, 0x00], 2), (&[0xE9, 0x00], 1)],
+        &[(&[0x6F, 0x00, 0x6B, 0x00], 2)],
+    ];
+    for (oi, inner_expected) in expected.iter().enumerate() {
+        let (inner_ptr, inner_len) =
+            read_hdr(&caller_mem, &mut store, D2_OUTER_OFF as usize + oi * 8);
+        assert_eq!(
+            inner_len as usize,
+            inner_expected.len(),
+            "outer[{oi}] inner-list element count preserved"
+        );
+        // The relocated inner-list pointer must be in the caller arena (>=2048),
+        // NOT the original callee offset — proving the inner array was copied.
+        assert!(
+            inner_ptr >= 2048,
+            "outer[{oi}] inner-list ptr {inner_ptr} must be relocated into caller memory"
+        );
+        for (ii, (want_bytes, want_units)) in inner_expected.iter().enumerate() {
+            let (str_ptr, str_len) = read_hdr(&caller_mem, &mut store, inner_ptr as usize + ii * 8);
+            assert_eq!(
+                str_len, *want_units,
+                "outer[{oi}].inner[{ii}] transcoded UTF-16 code-unit count"
+            );
+            assert!(
+                str_ptr >= 2048,
+                "outer[{oi}].inner[{ii}] string ptr {str_ptr} must be relocated into caller memory"
+            );
+            let mut got = vec![0u8; want_bytes.len()];
+            caller_mem
+                .read(&mut store, str_ptr as usize, &mut got)
+                .unwrap();
+            assert_eq!(
+                &got, want_bytes,
+                "outer[{oi}].inner[{ii}] must be transcoded UTF-8 → UTF-16 (a raw copy \
+                 would leave the UTF-8 bytes / dangling callee ptr)"
+            );
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## What

Closes the last #272 cross-encoding gap on the RESULT side: depth-2 nested strings (`list<list<string>>`) now transcode across encodings, instead of failing loud. Builds on 5d-pre (#290, the type-carrying `Indirection` descriptor).

## How (three verified increments)

1. **Codegen-time recursion** (3ada8da) in `emit_patch_nested_indirections`: a `List { elem }` leaf with an all-string subtree, in a transcodable direction, copies the inner array into caller memory + recurses one level (reading source headers from the callee original, writing patched headers to the caller copy). Each depth `d` uses a disjoint 6-local block at `l_first_scratch + 6·depth`; the transcode scratch is **shared** because only the deepest leaf transcodes at any instant — so each depth's `l_new_ptr` is its own local and never collides with the leaf sink (the trap #286 warned about, avoided structurally). Depth-1 byte-identical.

2. **Depth-2 runtime oracle** (d06b22f): `d5d_depth2_...utf8_to_utf16_transcodes` drives the real emitter over `list<list<string>>`, follows the doubly relocated pointers in caller memory, asserts each deepest string transcoded UTF-8→UTF-16. Validator-valid + runtime-correct.

3. **Production-active** (7c2b510): guard widened via `indirection_result_transcodable_depth2` (allow-set ≡ emitter transcode-set); async-adapter budgets grown (callback 27→28, stackful 18→23) with the result `transcode_base` shifted past the depth-1 recursion block.

## Verification

- **Mandatory real-adapter integration tests** (the budget-bug class — unknown-local overflow AND valid-but-wrong local-reuse collision — that the synthetic oracle can't reach): `d5d_{callback,stackful}_adapter_depth2_nested_result_within_budget` generate the REAL async adapters and assert they validate within the grown budgets.
- **Allow-set ≡ transcode-set**: `d5d_async_nested_list_list_string_result_allowed` (depth-2 ALLOWED) + `d5d_async_nested_list_list_u8_result_fail_loud` + `d5d_async_nested_depth3_result_fail_loud` (binary `list<u8>` and depth-3 stay FAIL-LOUD — the emitter recurses exactly one level; budget sized for depth-2).
- Full `meld-core` suite 0 failed; clippy `-D warnings` + fmt clean.

## Scope

Tier-5 (`adapter/fact.rs`) → Mythos clean-room delta-pass + `mythos-pass-done` label before merge. PARAM-side depth-2 and result directions beyond utf8↔utf16/latin1 (already wired via the shared leaf dispatch) are covered; param-side depth-2 remains fail-loud (future increment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)