### PR TITLE
feat(adapter): #286 5d PARAM — depth-2 list<list<string>> PARAM cross-encoding transcoding (closes #286)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -5116,17 +5116,20 @@ impl Indirection {
     }
 }
 
-/// #286 5d: the per-indirection RESULT recurse/transcode decision, shared by the
-/// emitter and the result guard so the guard's allow-set is EXACTLY what
-/// `emit_patch_nested_indirections` transcodes or recurses into (allow-set ≡
-/// transcode-set). A leaf is depth-bounded transcodable iff it is a `string`
-/// (transcoded directly) OR a nested `list<elem>` whose immediate inner
-/// indirections are all strings (the depth-2 `list<list<string>>` case the
-/// emitter recurses one level for). Returns `false` for a nested `list<u8>`
-/// (raw-copied binary) and for deeper-than-2 nesting (whose inner subtree is a
-/// `list`, not all strings) — both remain fail-loud, matching the emitter's
-/// recursion guard and the async-adapter local budget (sized for depth-2).
-pub(crate) fn indirection_result_transcodable_depth2(ind: &Indirection) -> bool {
+/// #286 5d: the per-indirection recurse/transcode decision, shared by BOTH the
+/// result and param emitters/guards so each guard's allow-set is EXACTLY what
+/// the emitter transcodes or recurses into (allow-set ≡ transcode-set). The
+/// decision is DIRECTION-AGNOSTIC — it inspects only the type structure, which
+/// is identical for `emit_patch_nested_indirections` (result) and
+/// `emit_param_nested_indirections` (param). A leaf is depth-bounded transcodable
+/// iff it is a `string` (transcoded directly) OR a nested `list<elem>` whose
+/// immediate inner indirections are all strings (the depth-2 `list<list<string>>`
+/// case the emitter recurses one level for). Returns `false` for a nested
+/// `list<u8>` (raw-copied binary) and for deeper-than-2 nesting (whose inner
+/// subtree is a `list`, not all strings) — both remain fail-loud, matching the
+/// emitter's recursion guard and the async-adapter local budget (sized for
+/// depth-2 on both sides).
+pub(crate) fn indirection_transcodable_depth2(ind: &Indirection) -> bool {
     match &ind.kind {
         IndirectionKind::String => true,
         IndirectionKind::List { elem } => {
@@ -11955,7 +11958,7 @@ impl FactStyleGenerator {
                 // makes the whole result NOT nested-string-allowed (fail-loud).
                 inner_indirections
                     .iter()
-                    .all(indirection_result_transcodable_depth2)
+                    .all(indirection_transcodable_depth2)
             })
             // At least one result must actually carry a nested string for this
             // predicate to widen the allow-set (a pure `list<u32>` has no inner
@@ -11966,7 +11969,7 @@ impl FactStyleGenerator {
                 | crate::parser::ComponentValType::FixedSizeList(elem, _) => {
                     let inner = collect_indirections(elem, 0);
                     !inner.is_empty()
-                        && inner.iter().all(indirection_result_transcodable_depth2)
+                        && inner.iter().all(indirection_transcodable_depth2)
                 }
                 _ => false,
             });
@@ -12043,7 +12046,13 @@ impl FactStyleGenerator {
                     // top-level path handles it.
                     _ => Vec::new(),
                 };
-                inner_indirections.iter().all(|ind| ind.is_string())
+                // #286 5d: a leaf is transcodable iff `string` OR `list<string>`
+                // (depth-2 — `emit_param_nested_indirections` recurses one level);
+                // a nested `list<u8>` or deeper-than-2 nesting stays fail-loud.
+                // Same direction-agnostic decision as the result guard.
+                inner_indirections
+                    .iter()
+                    .all(indirection_transcodable_depth2)
             })
             // At least one param must actually carry a nested string for this
             // predicate to widen the allow-set (a pure `list<u32>` has no inner
@@ -12053,7 +12062,7 @@ impl FactStyleGenerator {
                 crate::parser::ComponentValType::List(elem)
                 | crate::parser::ComponentValType::FixedSizeList(elem, _) => {
                     let inner = collect_indirections(elem, 0);
-                    !inner.is_empty() && inner.iter().all(|ind| ind.is_string())
+                    !inner.is_empty() && inner.iter().all(indirection_transcodable_depth2)
                 }
                 _ => false,
             });
@@ -14748,6 +14757,37 @@ mod tests {
         caller_enc: crate::parser::CanonStringEncoding,
         callee_enc: crate::parser::CanonStringEncoding,
     ) -> (crate::merger::MergedModule, crate::resolver::AdapterSite) {
+        // Depth-1: outer param = `list<string>` (outer element = `string`).
+        xenc_nested_param_merged_and_site(
+            caller_enc,
+            callee_enc,
+            crate::parser::ComponentValType::String,
+        )
+    }
+
+    /// #286 5d: depth-2 fixture — outer param = `list<list<string>>` (outer
+    /// element = `list<string>`), so `emit_param_nested_indirections` recurses.
+    fn xenc_list_list_string_param_merged_and_site(
+        caller_enc: crate::parser::CanonStringEncoding,
+        callee_enc: crate::parser::CanonStringEncoding,
+    ) -> (crate::merger::MergedModule, crate::resolver::AdapterSite) {
+        xenc_nested_param_merged_and_site(
+            caller_enc,
+            callee_enc,
+            crate::parser::ComponentValType::List(Box::new(
+                crate::parser::ComponentValType::String,
+            )),
+        )
+    }
+
+    /// Shared fixture: build a merged module + async-lift site whose PARAM is
+    /// `list<OUTER_ELEM>`. `outer_elem = string` → `list<string>` (depth-1);
+    /// `outer_elem = list<string>` → `list<list<string>>` (depth-2).
+    fn xenc_nested_param_merged_and_site(
+        caller_enc: crate::parser::CanonStringEncoding,
+        callee_enc: crate::parser::CanonStringEncoding,
+        outer_elem: crate::parser::ComponentValType,
+    ) -> (crate::merger::MergedModule, crate::resolver::AdapterSite) {
         use wasm_encoder::{EntityType, ExportKind, Function, ValType};
         let mut merged = empty_merged();
         // type 0: () -> i32 (lift, callback-mode packed return).
@@ -14797,9 +14837,10 @@ mod tests {
             component_idx: None,
         });
 
-        let list_string = crate::parser::ComponentValType::List(Box::new(
-            crate::parser::ComponentValType::String,
-        ));
+        // Outer param type `list<outer_elem>`: `list<string>` (depth-1) or
+        // `list<list<string>>` (depth-2). `emit_param_nested_indirections`
+        // recurses when the element bears nested pointer indirections.
+        let list_string = crate::parser::ComponentValType::List(Box::new(outer_elem));
 
         let mut site = async_lift_site(export_name);
         site.from_component = 0;
@@ -15098,6 +15139,103 @@ mod tests {
         assert_locals_within_budget(adapter.body, cpc, "#272 inc-5c-a stackful nested param");
     }
 
+    /// #286 5d (integration, callback): the CALLBACK async adapter's DEPTH-2
+    /// `list<list<string>>` PARAM recursion must stay within budget (28) under
+    /// simultaneous liveness — depth-0 nested walk (offsets 10..=14), depth-1
+    /// recursion block (`l_first_scratch + 5 = l_p2 + 10 ..= l_p2 + 14`, offsets
+    /// 15..=19), shared leaf transcode (`transcode_base = l_p2 + 16 ..= l_p2 + 21`,
+    /// offsets 21..=26) — all DISJOINT, top index offset 26 < 28. The param
+    /// transcode_base already sat past the depth-1 block (no relayout needed; the
+    /// result-side growth to 28 provides the headroom). Generates the REAL
+    /// adapter — the budget-bug class the synthetic loop oracle cannot reach.
+    #[test]
+    fn d5d_callback_adapter_depth2_nested_param_within_budget() {
+        use crate::parser::CanonStringEncoding;
+        let gen_ = FactStyleGenerator::new(AdapterConfig::default());
+        let (merged, site) = xenc_list_list_string_param_merged_and_site(
+            CanonStringEncoding::Utf8,
+            CanonStringEncoding::Utf16,
+        );
+        let adapter = gen_
+            .generate_async_callback_adapter(&site, &merged)
+            .expect("callback emitter must succeed for the #286 5d list<list<string>> param");
+        let cpc = site_caller_param_count(&site, &merged);
+        assert_locals_within_budget(adapter.body, cpc, "#286 5d callback depth-2 nested param");
+    }
+
+    /// #286 5d (integration, stackful): the STACKFUL adapter's DEPTH-2
+    /// `list<list<string>>` PARAM recursion must stay within budget (23). Layout:
+    /// depth-0 walk at offsets 1..=5, depth-1 recursion block at offsets 6..=10
+    /// (`l_scratch + 6 ..= l_scratch + 10`), shared transcode at offsets 12..=17
+    /// (`l_scratch + 12 ..= l_scratch + 17`) — all DISJOINT, top index offset
+    /// less than 23. Generates the REAL adapter.
+    #[test]
+    fn d5d_stackful_adapter_depth2_nested_param_within_budget() {
+        use crate::parser::CanonStringEncoding;
+        let gen_ = FactStyleGenerator::new(AdapterConfig::default());
+        let (mut merged, site) = xenc_list_list_string_param_merged_and_site(
+            CanonStringEncoding::Utf8,
+            CanonStringEncoding::Utf16,
+        );
+        merged.exports[0].name = site.export_name.clone();
+        let adapter = gen_
+            .generate_async_stackful_adapter(&site, &merged)
+            .expect("stackful emitter must succeed for the #286 5d list<list<string>> param");
+        let cpc = site_caller_param_count(&site, &merged);
+        assert_locals_within_budget(adapter.body, cpc, "#286 5d stackful depth-2 nested param");
+    }
+
+    /// #286 5d guard (POSITIVE, param): a DEPTH-2 `list<list<string>>` PARAM in the
+    /// caller=Utf8 → callee=Utf16 direction is now ALLOWED — the param emitter
+    /// recurses one level and transcodes the deepest strings.
+    #[test]
+    fn d5d_async_nested_list_list_string_param_allowed() {
+        use crate::parser::CanonStringEncoding;
+        let (_merged, site) = xenc_list_list_string_param_merged_and_site(
+            CanonStringEncoding::Utf8,
+            CanonStringEncoding::Utf16,
+        );
+        FactStyleGenerator::guard_async_cross_encoding_strings(&site)
+            .expect("#286 5d: a depth-2 list<list<string>> param (Utf8 → Utf16) must be ALLOWED");
+    }
+
+    /// #286 5d guard (NEGATIVE, param — allow-set ≡ transcode-set): a DEPTH-2
+    /// `list<list<u8>>` PARAM must STAY FAIL-LOUD (deepest leaf is binary
+    /// `list<u8>`, deep-copied not transcoded).
+    #[test]
+    fn d5d_async_nested_list_list_u8_param_fail_loud() {
+        use crate::parser::{CanonStringEncoding, ComponentValType, PrimitiveValType};
+        let (_merged, site) = xenc_nested_param_merged_and_site(
+            CanonStringEncoding::Utf8,
+            CanonStringEncoding::Utf16,
+            ComponentValType::List(Box::new(ComponentValType::Primitive(PrimitiveValType::U8))),
+        );
+        assert!(
+            FactStyleGenerator::guard_async_cross_encoding_strings(&site).is_err(),
+            "#286 5d: a depth-2 list<list<u8>> param must stay FAIL-LOUD"
+        );
+    }
+
+    /// #286 5d guard (NEGATIVE, param — depth bound): a DEPTH-3
+    /// `list<list<list<string>>>` PARAM must STAY FAIL-LOUD (emitter recurses one
+    /// level; budget sized for depth-2).
+    #[test]
+    fn d5d_async_nested_depth3_param_fail_loud() {
+        use crate::parser::{CanonStringEncoding, ComponentValType};
+        let depth2 = ComponentValType::List(Box::new(ComponentValType::List(Box::new(
+            ComponentValType::String,
+        ))));
+        let (_merged, site) = xenc_nested_param_merged_and_site(
+            CanonStringEncoding::Utf8,
+            CanonStringEncoding::Utf16,
+            depth2,
+        );
+        assert!(
+            FactStyleGenerator::guard_async_cross_encoding_strings(&site).is_err(),
+            "#286 5d: a depth-3 list<list<list<string>>> param must stay FAIL-LOUD"
+        );
+    }
+
     /// #272 inc-5c-a guard: a NESTED `list<string>` PARAM in the caller=Utf8 →
     /// callee=Utf16 direction is now ALLOWED (the emitter transcodes its inner
     /// strings). The guard must NOT fail loud.
@@ -15289,14 +15427,16 @@ mod tests {
         }
     }
 
-    /// #272 inc-5c-b guard (negative): DEEPER list nesting
-    /// (`list<list<string>>`) must STILL fail loud in every direction — the inner
-    /// element is a `list<string>`, which `collect_indirections` reports as
-    /// is_string == false (it does not recurse list elements), so the nested walk
-    /// would only deep-copy the inner list verbatim, NOT transcode the
-    /// deeper strings. The allow-set (≡ transcode-set) refuses it.
+    /// #286 5d (was #272 inc-5c-b negative): DEPTH-2 list nesting
+    /// (`list<list<string>>`) PARAM is now ALLOWED in every implemented direction
+    /// — `emit_param_nested_indirections` recurses one level and transcodes the
+    /// deeper strings (the allow-set ≡ transcode-set widened to depth-2). Before
+    /// #286 5d this asserted fail-loud; that invariant is intentionally inverted.
+    /// (Depth-3 and nested `list<u8>` still fail loud — see
+    /// `d5d_async_nested_depth3_param_fail_loud` /
+    /// `d5d_async_nested_list_list_u8_param_fail_loud`.)
     #[test]
-    fn inc5c_b_async_deeper_list_nesting_param_fails_loud_all_directions() {
+    fn d5d_async_deeper_list_nesting_param_allowed_all_directions() {
         use crate::parser::CanonStringEncoding as Enc;
         use crate::parser::ComponentValType;
         let dirs = [
@@ -15313,7 +15453,9 @@ mod tests {
             site.requirements.param_wit_types = vec![ComponentValType::List(Box::new(
                 ComponentValType::List(Box::new(ComponentValType::String)),
             ))];
-            FactStyleGenerator::guard_async_cross_encoding_strings(&site).unwrap_err();
+            FactStyleGenerator::guard_async_cross_encoding_strings(&site).unwrap_or_else(|e| {
+                panic!("#286 5d: depth-2 list<list<string>> param must be ALLOWED for {caller:?}→{callee:?}: {e}")
+            });
         }
     }
 

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -4745,6 +4745,107 @@ fn emit_param_nested_indirections(
             continue;
         }
 
+        // #286 5d: a nested pointer-bearing LIST PARAM (e.g. `list<list<string>>`)
+        // — the inner element ITSELF carries indirections (its own strings), so a
+        // verbatim deep-copy would leave those inner `(ptr, len)` pairs dangling
+        // into CALLER memory and un-transcoded. Instead we deep-copy the inner
+        // array into CALLEE memory, store the relocated header, and RECURSE one
+        // nesting level down to patch each inner element IN-PLACE (transcode each
+        // string caller→callee). The param-side mirror of the result-side
+        // recursion in `emit_patch_nested_indirections`.
+        //
+        // Codegen-time recursion: each depth `d` gets a disjoint 5-local block at
+        // `l_first_scratch + 5*d`; the transcode scratch (`l_transcode_base..`) is
+        // SHARED — only the single deepest string leaf transcodes at any instant.
+        // The caller sizes `l_transcode_base >= l_first_scratch + 5*max_depth`.
+        //
+        // Allow-set ≡ transcode-set: recurse ONLY when the inner subtree is all
+        // strings AND the direction is transcodable; a nested `list<u8>` or
+        // non-transcode direction falls through to the verbatim deep-copy below.
+        if let IndirectionKind::List { elem } = &ind.kind {
+            let sub = collect_indirections(elem, 0);
+            if inner_transcode_dir && !sub.is_empty() && sub.iter().all(|s| s.is_string()) {
+                let (_, inner_align) = cabi_size_align(elem);
+                // `l_old_ptr` = inner array base (CALLER), `l_buf_len` = inner
+                // ELEMENT count (a nested list len is the element count, never
+                // tag-encoded). Guard `count * sub_elem_size` against 2^32 wrap.
+                emit_overflow_guard(body, l_buf_len, *sub_elem_size);
+
+                // Skip the inner patch if (old_ptr, count*sub_elem_size) doesn't
+                // fit CALLER memory (the source) — fail-safe (matches deep-copy).
+                body.instruction(&Instruction::Block(wasm_encoder::BlockType::Empty));
+                body.instruction(&Instruction::LocalGet(l_old_ptr));
+                body.instruction(&Instruction::LocalGet(l_buf_len));
+                if *sub_elem_size != 1 {
+                    body.instruction(&Instruction::I32Const(*sub_elem_size as i32));
+                    body.instruction(&Instruction::I32Mul);
+                }
+                body.instruction(&Instruction::I32Add);
+                body.instruction(&Instruction::MemorySize(caller_memory));
+                body.instruction(&Instruction::I32Const(16));
+                body.instruction(&Instruction::I32Shl);
+                body.instruction(&Instruction::I32GtU);
+                body.instruction(&Instruction::BrIf(0));
+
+                // new_ptr = realloc(0, 0, inner_align, count*sub_elem_size) in
+                // CALLEE memory; bulk-copy the inner array caller→callee.
+                body.instruction(&Instruction::I32Const(0));
+                body.instruction(&Instruction::I32Const(0));
+                body.instruction(&Instruction::I32Const(inner_align as i32));
+                body.instruction(&Instruction::LocalGet(l_buf_len));
+                if *sub_elem_size != 1 {
+                    body.instruction(&Instruction::I32Const(*sub_elem_size as i32));
+                    body.instruction(&Instruction::I32Mul);
+                }
+                emit_checked_realloc(body, realloc_func, l_new_ptr);
+
+                body.instruction(&Instruction::LocalGet(l_new_ptr));
+                body.instruction(&Instruction::LocalGet(l_old_ptr));
+                body.instruction(&Instruction::LocalGet(l_buf_len));
+                if *sub_elem_size != 1 {
+                    body.instruction(&Instruction::I32Const(*sub_elem_size as i32));
+                    body.instruction(&Instruction::I32Mul);
+                }
+                body.instruction(&Instruction::MemoryCopy {
+                    dst_mem: callee_memory,
+                    src_mem: caller_memory,
+                });
+
+                // Store the relocated (callee) inner-array pointer + (unchanged)
+                // element count into the callee-memory header.
+                body.instruction(&Instruction::LocalGet(l_rec));
+                body.instruction(&Instruction::LocalGet(l_new_ptr));
+                body.instruction(&Instruction::I32Store(rec_mem_arg_ptr));
+                body.instruction(&Instruction::LocalGet(l_rec));
+                body.instruction(&Instruction::LocalGet(l_buf_len));
+                body.instruction(&Instruction::I32Store(rec_mem_arg_len));
+
+                // RECURSE one level down: patch the inner array IN-PLACE (its
+                // headers still point into CALLER memory after the bulk copy;
+                // the recursion reads them, transcodes caller→callee, and writes
+                // back callee pointers). Disjoint loop block at `l_first_scratch +
+                // 5`; `l_transcode_base` shared. `l_old_ptr`/`l_new_ptr`/`l_buf_len`
+                // (this depth) are read-only during the call (its block is +5).
+                emit_param_nested_indirections(
+                    body,
+                    elem,
+                    l_new_ptr,
+                    l_buf_len,
+                    *sub_elem_size,
+                    l_first_scratch + 5,
+                    realloc_func,
+                    caller_memory,
+                    callee_memory,
+                    caller_encoding,
+                    callee_encoding,
+                    l_transcode_base,
+                );
+
+                body.instruction(&Instruction::End); // end bounds block
+                continue;
+            }
+        }
+
         // DEEP-COPY verbatim (a `list<u8>` is_string == false, OR a
         // same-encoding string): realloc a CALLEE buffer + memory.copy
         // caller → callee, re-point. This CLOSES #281 — the inner buffer now

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -3413,6 +3413,125 @@ pub fn build_nested_list_string_param_test_module(
     module.finish()
 }
 
+/// #286 5d — DEPTH-2 nested-PARAM oracle module: drives the production
+/// `emit_param_nested_indirections` over `elem_ty = list<string>` (so the outer
+/// param is `list<list<string>>`), exercising the codegen-time PARAM recursion.
+///
+/// Identical to [`build_nested_list_string_param_test_module`] except
+/// `elem_ty = List(String)` and the depth-2 local layout: `l_first_scratch = 2`
+/// (depth-0 block 2..=6), depth-1 recursion block 7..=11 (the param walk uses 5
+/// locals/depth), `l_transcode_base = 12` (shared scratch 12..=17, past both
+/// loop blocks) — 16 i32 locals (indices 2..=17). Exported `patch(outer_callee,
+/// count)`; the host lays out the two-level `list<list<string>>` (inner data in
+/// CALLER memory, shallow outer array in CALLEE memory) and reads back the doubly
+/// relocated + transcoded result from CALLEE memory.
+pub fn build_nested_list_list_string_param_test_module(
+    caller_enc: crate::parser::CanonStringEncoding,
+    callee_enc: crate::parser::CanonStringEncoding,
+) -> Vec<u8> {
+    use crate::parser::ComponentValType;
+    use wasm_encoder::{
+        CodeSection, ConstExpr, ExportKind, ExportSection, FunctionSection, GlobalSection,
+        GlobalType, MemorySection, MemoryType, Module, TypeSection, ValType,
+    };
+
+    let mut types = TypeSection::new();
+    types.ty().function(
+        [ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+        [ValType::I32],
+    );
+    types.ty().function([ValType::I32, ValType::I32], []);
+
+    let mut functions = FunctionSection::new();
+    functions.function(0);
+    functions.function(1);
+
+    let mut memory = MemorySection::new();
+    for _ in 0..2 {
+        memory.memory(MemoryType {
+            minimum: 1,
+            maximum: None,
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        });
+    }
+
+    let mut globals = GlobalSection::new();
+    globals.global(
+        GlobalType {
+            val_type: ValType::I32,
+            mutable: true,
+            shared: false,
+        },
+        &ConstExpr::i32_const(2048),
+    );
+
+    let mut exports = ExportSection::new();
+    exports.export("patch", ExportKind::Func, 1);
+    exports.export("caller_memory", ExportKind::Memory, 0);
+    exports.export("callee_memory", ExportKind::Memory, 1);
+
+    let mut code = CodeSection::new();
+
+    // func 0: cabi_realloc — bump allocator over global 0 (writes land in CALLEE
+    // memory 1 via the production emitter's MemArgs).
+    {
+        let mut f = Function::new([(1, ValType::I32)]);
+        f.instruction(&Instruction::GlobalGet(0));
+        f.instruction(&Instruction::LocalGet(2));
+        f.instruction(&Instruction::I32Add);
+        f.instruction(&Instruction::I32Const(1));
+        f.instruction(&Instruction::I32Sub);
+        f.instruction(&Instruction::LocalGet(2));
+        f.instruction(&Instruction::I32Const(1));
+        f.instruction(&Instruction::I32Sub);
+        f.instruction(&Instruction::I32Const(-1));
+        f.instruction(&Instruction::I32Xor);
+        f.instruction(&Instruction::I32And);
+        f.instruction(&Instruction::LocalSet(4));
+        f.instruction(&Instruction::LocalGet(4));
+        f.instruction(&Instruction::LocalGet(3));
+        f.instruction(&Instruction::I32Add);
+        f.instruction(&Instruction::GlobalSet(0));
+        f.instruction(&Instruction::LocalGet(4));
+        f.instruction(&Instruction::End);
+        code.function(&f);
+    }
+
+    // func 1: patch(outer_callee, count) -> () for list<list<string>>.
+    {
+        let elem_ty = ComponentValType::List(Box::new(ComponentValType::String));
+        let mut f = Function::new([(16, ValType::I32)]);
+        emit_param_nested_indirections(
+            &mut f,
+            &elem_ty,
+            0, // l_array_ptr (callee outer list)
+            1, // l_len (outer count)
+            8, // elem_size (outer element = inner list (ptr, len))
+            2, // l_first_scratch (depth-0 block 2..=6; depth-1 recursion 7..=11)
+            0, // realloc_func (allocates in callee memory 1)
+            0, // caller_memory
+            1, // callee_memory
+            Some(caller_enc),
+            Some(callee_enc),
+            12, // l_transcode_base (shared scratch 12..=17, past both loop blocks)
+        );
+        f.instruction(&Instruction::End);
+        code.function(&f);
+    }
+
+    let mut module = Module::new();
+    module
+        .section(&types)
+        .section(&functions)
+        .section(&memory)
+        .section(&globals)
+        .section(&exports)
+        .section(&code);
+    module.finish()
+}
+
 /// Shared builder for the two inc-5c-a nested-PARAM oracle modules — the
 /// param-direction mirror of [`build_nested_list_result_test_module`].
 ///

--- a/meld-core/src/adapter/mod.rs
+++ b/meld-core/src/adapter/mod.rs
@@ -97,6 +97,12 @@ pub use fact::build_nested_list_u8_param_deep_copied_test_module;
 #[doc(hidden)]
 pub use fact::build_nested_list_string_param_test_module;
 
+/// Test-support: build the #286 5d DEPTH-2 NESTED `list<list<string>>` PARAM
+/// transcode oracle module (exercises the codegen-time param recursion).
+/// `#[doc(hidden)]` — not a supported API; see the function's own docs.
+#[doc(hidden)]
+pub use fact::build_nested_list_list_string_param_test_module;
+
 use crate::Result;
 use crate::merger::MergedModule;
 use crate::resolver::DependencyGraph;

--- a/meld-core/tests/async_cross_encoding.rs
+++ b/meld-core/tests/async_cross_encoding.rs
@@ -36,6 +36,7 @@
 
 use meld_core::adapter::{
     build_latin1_to_utf8_transcode_test_module, build_latin1_to_utf16_transcode_test_module,
+    build_nested_list_list_string_param_test_module,
     build_nested_list_list_string_result_test_module, build_nested_list_string_result_test_module,
     build_utf8_to_latin1_transcode_test_module, build_utf8_to_utf16_transcode_test_module,
     build_utf16_to_latin1_transcode_test_module, build_utf16_to_utf8_transcode_test_module,
@@ -1118,6 +1119,129 @@ fn d5d_depth2_nested_list_list_string_utf8_to_utf16_transcodes() {
                 &got, want_bytes,
                 "outer[{oi}].inner[{ii}] must be transcoded UTF-8 → UTF-16 (a raw copy \
                  would leave the UTF-8 bytes / dangling callee ptr)"
+            );
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// #286 5d — DEPTH-2 nested `list<list<string>>` PARAM transcode (UTF-8 → UTF-16).
+// The param-direction mirror of d5d_depth2 (RESULT): exercises the codegen-time
+// recursion in `emit_param_nested_indirections`. PARAM direction (caller
+// PROVIDES, callee READS): the full two-level value lives in CALLER memory; the
+// SHALLOW outer array (inner ptrs → caller) is in CALLEE memory. After `patch`,
+// the host follows the doubly relocated pointers ENTIRELY within CALLEE memory
+// and asserts each deepest string was deep-copied + transcoded UTF-8 → UTF-16.
+// ----------------------------------------------------------------------------
+
+// CALLER-memory offsets: 3 UTF-8 inner strings + 2 inner lists. CALLEE: outer.
+const PD2_HI_OFF: i32 = 100; // "Hi" UTF-8
+const PD2_E_OFF: i32 = 110; // "é"  UTF-8 [0xC3,0xA9]
+const PD2_OK_OFF: i32 = 120; // "ok" UTF-8
+const PD2_INNER_A_OFF: i32 = 200; // inner list A: [(Hi,2),(é,2)] (in CALLER)
+const PD2_INNER_B_OFF: i32 = 240; // inner list B: [(ok,2)]       (in CALLER)
+const PD2_OUTER_OFF: i32 = 300; // shallow outer list (in CALLEE)
+
+#[test]
+fn d5d_depth2_nested_list_list_string_param_utf8_to_utf16_transcodes() {
+    let wasm = build_nested_list_list_string_param_test_module(
+        CanonStringEncoding::Utf8,  // caller PROVIDES Utf8
+        CanonStringEncoding::Utf16, // callee READS Utf16
+    );
+    let mut validator = wasmparser::Validator::new();
+    validator
+        .validate_all(&wasm)
+        .expect("#286 5d depth-2 PARAM oracle module should validate");
+
+    let mut config = Config::new();
+    config.wasm_multi_memory(true);
+    let engine = Engine::new(&config).unwrap();
+    let module = RuntimeModule::new(&engine, &wasm).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    let caller_mem = instance.get_memory(&mut store, "caller_memory").unwrap();
+    let callee_mem = instance.get_memory(&mut store, "callee_memory").unwrap();
+
+    // Full nested value in CALLER memory: inner UTF-8 strings + inner lists.
+    caller_mem
+        .write(&mut store, PD2_HI_OFF as usize, &[0x48, 0x69])
+        .unwrap();
+    caller_mem
+        .write(&mut store, PD2_E_OFF as usize, &[0xC3, 0xA9])
+        .unwrap();
+    caller_mem
+        .write(&mut store, PD2_OK_OFF as usize, &[0x6F, 0x6B])
+        .unwrap();
+
+    let mut inner_a = Vec::new();
+    inner_a.extend_from_slice(&PD2_HI_OFF.to_le_bytes());
+    inner_a.extend_from_slice(&2i32.to_le_bytes());
+    inner_a.extend_from_slice(&PD2_E_OFF.to_le_bytes());
+    inner_a.extend_from_slice(&2i32.to_le_bytes());
+    caller_mem
+        .write(&mut store, PD2_INNER_A_OFF as usize, &inner_a)
+        .unwrap();
+
+    let mut inner_b = Vec::new();
+    inner_b.extend_from_slice(&PD2_OK_OFF.to_le_bytes());
+    inner_b.extend_from_slice(&2i32.to_le_bytes());
+    caller_mem
+        .write(&mut store, PD2_INNER_B_OFF as usize, &inner_b)
+        .unwrap();
+
+    // SHALLOW outer list in CALLEE memory (inner_list_ptr → CALLER, count) — the
+    // post-outer-bulk-copy state.
+    let mut outer = Vec::new();
+    outer.extend_from_slice(&PD2_INNER_A_OFF.to_le_bytes());
+    outer.extend_from_slice(&2i32.to_le_bytes());
+    outer.extend_from_slice(&PD2_INNER_B_OFF.to_le_bytes());
+    outer.extend_from_slice(&1i32.to_le_bytes());
+    callee_mem
+        .write(&mut store, PD2_OUTER_OFF as usize, &outer)
+        .unwrap();
+
+    instance
+        .get_typed_func::<(i32, i32), ()>(&mut store, "patch")
+        .unwrap()
+        .call(&mut store, (PD2_OUTER_OFF, 2))
+        .expect("depth-2 param patch runs");
+
+    // Follow the doubly relocated pointers ENTIRELY within CALLEE memory.
+    let expected: [&[(&[u8], i32)]; 2] = [
+        &[(&[0x48, 0x00, 0x69, 0x00], 2), (&[0xE9, 0x00], 1)],
+        &[(&[0x6F, 0x00, 0x6B, 0x00], 2)],
+    ];
+    for (oi, inner_expected) in expected.iter().enumerate() {
+        let (inner_ptr, inner_len) =
+            read_hdr(&callee_mem, &mut store, PD2_OUTER_OFF as usize + oi * 8);
+        assert_eq!(
+            inner_len as usize,
+            inner_expected.len(),
+            "outer[{oi}] inner-list element count preserved"
+        );
+        assert!(
+            inner_ptr >= 2048,
+            "outer[{oi}] inner-list ptr {inner_ptr} must be relocated into CALLEE memory"
+        );
+        for (ii, (want_bytes, want_units)) in inner_expected.iter().enumerate() {
+            let (str_ptr, str_len) = read_hdr(&callee_mem, &mut store, inner_ptr as usize + ii * 8);
+            assert_eq!(
+                str_len, *want_units,
+                "outer[{oi}].inner[{ii}] transcoded UTF-16 code-unit count"
+            );
+            assert!(
+                str_ptr >= 2048,
+                "outer[{oi}].inner[{ii}] string ptr {str_ptr} must be relocated into CALLEE memory"
+            );
+            let mut got = vec![0u8; want_bytes.len()];
+            callee_mem
+                .read(&mut store, str_ptr as usize, &mut got)
+                .unwrap();
+            assert_eq!(
+                &got, want_bytes,
+                "outer[{oi}].inner[{ii}] must be deep-copied + transcoded UTF-8 → UTF-16 \
+                 (a verbatim deep-copy would leave UTF-8 bytes / dangling caller ptr)"
             );
         }
     }


### PR DESCRIPTION
## What

The PARAM-side mirror of the merged result-side depth-2 work (#291), **closing #286**: depth-2 nested strings (`list<list<string>>`) now transcode across encodings as PARAMS too, instead of failing loud.

## How (three verified increments)

1. **Codegen-time recursion** (9cad68f) in `emit_param_nested_indirections`: a `List { elem }` leaf with an all-string subtree deep-copies the inner array caller→callee, stores the relocated header, and recurses one level to patch the inner array **in-place** (transcoding each string caller→callee). Param-specific: 5-local-per-depth blocks (`l_first_scratch + 5·d`), inverted memory direction. Depth-1 byte-identical.

2. **Depth-2 runtime oracle** (c848cad): `d5d_depth2_..._param_utf8_to_utf16_transcodes` — full two-level value in caller memory, shallow outer in callee; after `patch`, follows the doubly relocated pointers within callee memory, asserting each deepest string transcoded. Validator-valid + runtime-correct.

3. **Production-active** (2662daa): param guard widened via the now-shared, direction-agnostic `indirection_transcodable_depth2` (allow-set ≡ transcode-set). **No budget growth needed** — proven by the real-adapter validator tests: the result-side budget growth (callback 28, stackful 23) + the existing param `transcode_base` headroom already accommodate the depth-1 param recursion block.

## Verification

- **Real-adapter integration tests**: `d5d_{callback,stackful}_adapter_depth2_nested_param_within_budget` generate the REAL async adapters and validate (the budget-bug class the synthetic oracle can't reach — confirming the no-growth claim).
- **Allow-set ≡ transcode-set**: `d5d_async_nested_list_list_string_param_allowed` + `d5d_async_deeper_list_nesting_param_allowed_all_directions` (all 6 directions) + `d5d_async_nested_list_list_u8_param_fail_loud` + `d5d_async_nested_depth3_param_fail_loud`. The stale `inc5c_b_..._param_fails_loud_all_directions` (old fail-loud invariant) was repurposed to assert the new ALLOWED behavior.
- Full `meld-core` suite 0 failed; clippy `-D warnings` + fmt clean.

## Scope

Tier-5 (`adapter/fact.rs`) → Mythos clean-room delta-pass + `mythos-pass-done` label before merge. With this, both RESULT and PARAM depth-2 `list<list<string>>` cross-encoding transcode across all directions — **#286 fully closed**. Depth-3+ stays fail-loud (emitter recurses one level; budget sized for depth-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)