### PR TITLE
ci(fuzz): #168 — pin `cargo fuzz run --target gnu` to defeat runner cargo-config drift

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -113,8 +113,21 @@ jobs:
           key: ${{ runner.os }}-fuzz-v2-${{ matrix.target }}-${{ hashFiles('fuzz/Cargo.toml', 'meld-core/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-fuzz-v2-${{ matrix.target }}-
 
+      # Layer 3 defense against #168 (the layer that actually holds): an
+      # EXPLICIT `--target` on `cargo fuzz run`. Layer 2 (`CARGO_BUILD_TARGET`
+      # env) is insufficient because cargo-fuzz DERIVES its own target from the
+      # runner's cargo config (`[build] target = "x86_64-unknown-linux-musl"` on
+      # drifted runners) and passes it as an explicit `--target`, which takes
+      # strict precedence over the env var. The result: `libfuzzer-sys`'s
+      # build.rs sees `TARGET=...musl`, the `cc` crate looks for
+      # `x86_64-linux-musl-g++` (not installed) and fails with "ToolNotFound" —
+      # observed intermittently on PRs #290/#292 despite Layers 1+2. Passing
+      # `--target` here occupies the SAME (highest) precedence slot cargo-fuzz
+      # uses, forcing the host gnu target on every runner: no musl std, no
+      # cross-compiler, sanitizer stays compatible. Harmless on clean runners
+      # (gnu IS the native host triple). See pulseengine/meld#168.
       - name: Run target for 60 s
-        run: cargo +nightly fuzz run --release "$FUZZ_TARGET" -- -max_total_time=60
+        run: cargo +nightly fuzz run --release --target x86_64-unknown-linux-gnu "$FUZZ_TARGET" -- -max_total_time=60
 
       - name: Upload crash artifacts on failure
         if: failure()


### PR DESCRIPTION
## Diagnosis

The Fuzz-smoke matrix jobs still fail intermittently per-runner (1/4–4/4 across recent runs, masked at workflow level by `continue-on-error: true`) with `libfuzzer-sys` build.rs → `cc` → `ToolNotFound: x86_64-linux-musl-g++`.

**Root cause of why the existing mitigation is insufficient:** Layer 2 (`CARGO_BUILD_TARGET=...gnu` env) loses a precedence fight. cargo-fuzz **derives its own target** from the drifted runner's cargo config (`[build] target = "x86_64-unknown-linux-musl"`) and passes it as an explicit `--target`, which beats the env var (cargo precedence: explicit `--target` > `CARGO_BUILD_TARGET` > `[build] target`). The build runs for musl → `TARGET=...musl` reaches libfuzzer-sys's `cc` → it looks for the absent musl cross-compiler.

## Fix

Pass `--target x86_64-unknown-linux-gnu` **explicitly** on `cargo fuzz run` (Layer 3). This occupies the same highest-precedence slot cargo-fuzz uses, forcing the host gnu target on every runner regardless of its cargo config — no musl std, no cross-compiler, sanitizer-compatible (gnu is dynamically linked). No-op on clean runners (gnu is the native host). Layers 1+2 retained.

## Verification

- `cargo fuzz run --target <TRIPLE>` confirmed a documented option locally; the fix is sound by cargo-fuzz's target-selection contract + cargo precedence.
- The drifted-runner failure is **not locally reproducible** (runner-config dependent), so the conclusive oracle is **CI-observable**: the musl-g++ failure mode should disappear across subsequent fuzz runs. I'll watch this PR's fuzz jobs + follow-up runs.

## Scope

Workflow-only (`.github/workflows/fuzz.yml`), non-Tier-5. The #168 infra asks (re-image the rust-cpu runners; add a boot health-check) remain the proper **root-cause** fix — this is a robust meld-side mitigation so CI stops needing per-PR `gh run rerun --failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)