### PR TITLE
release: v0.34.0 — identity-trampoline adapter inlining (#304) + multi-memory isolation commitment (#300/ADR-4)

### DIFF
--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -5306,6 +5306,28 @@ impl FactStyleGenerator {
             (t, b, AdapterClass::Direct)
         };
 
+        let target_function = self.resolve_target_function(site, merged)?;
+
+        // #304: a Direct adapter is a *pure identity trampoline* — body is
+        // exactly `local.get*; call target; end` — only when it carries no
+        // resource conversions AND no post-return. (The Direct `else` branch in
+        // `generate_direct_adapter` still emits `call post_return` when
+        // `has_post_return && result_count == 0`, so post-return must be
+        // excluded entirely, not just the result>0 case — wiring the caller
+        // straight to the target would otherwise skip the post-return cleanup.)
+        // When inlining is enabled and that holds, record the target so
+        // `wire_adapter_indices` bypasses this thunk. Fail-safe: any doubt → None.
+        let inline_target = if self.config.inline_adapters
+            && matches!(class, AdapterClass::Direct)
+            && options.resource_rep_calls.is_empty()
+            && options.resource_new_calls.is_empty()
+            && options.callee_post_return.is_none()
+        {
+            Some(target_function)
+        } else {
+            None
+        };
+
         Ok(AdapterFunction {
             name,
             type_idx,
@@ -5314,8 +5336,9 @@ impl FactStyleGenerator {
             source_module: site.from_module,
             target_component: site.to_component,
             target_module: site.to_module,
-            target_function: self.resolve_target_function(site, merged)?,
+            target_function,
             class,
+            inline_target,
         })
     }
 
@@ -10299,6 +10322,9 @@ impl FactStyleGenerator {
             target_module: site.to_module,
             target_function: target_func,
             class: AdapterClass::Async,
+            // Async-lift adapters transform (await/result delivery) — never a
+            // pure identity trampoline, so never inlined (#304).
+            inline_target: None,
         })
     }
 
@@ -11667,6 +11693,8 @@ impl FactStyleGenerator {
             target_module: site.to_module,
             target_function: target_func,
             class: AdapterClass::Async,
+            // Async-lift adapter — transforms, never a pure trampoline (#304).
+            inline_target: None,
         })
     }
 }

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -5317,6 +5317,9 @@ impl FactStyleGenerator {
         // straight to the target would otherwise skip the post-return cleanup.)
         // When inlining is enabled and that holds, record the target so
         // `wire_adapter_indices` bypasses this thunk. Fail-safe: any doubt → None.
+        // This guard MUST stay a superset of `generate_direct_adapter`'s
+        // complex-branch trigger — see the "#304 INVARIANT" note on its simple-
+        // trampoline `else` branch; the two are coupled and must move together.
         let inline_target = if self.config.inline_adapters
             && matches!(class, AdapterClass::Direct)
             && options.resource_rep_calls.is_empty()
@@ -5954,7 +5957,17 @@ impl FactStyleGenerator {
             func.instruction(&Instruction::End);
             Ok((type_idx, func))
         } else {
-            // Simple trampoline (no post-return or no results)
+            // Simple trampoline (no post-return or no results).
+            //
+            // #304 INVARIANT: when `callee_post_return.is_none()` (and no
+            // resource ops — guaranteed here by the enclosing `if`), this body
+            // is a *pure identity forward* — exactly `local.get 0..N; call
+            // target; end`. `generate_adapter`'s inline guard relies on that to
+            // wire the caller straight to the target and drop this thunk. If you
+            // add ANY instruction below for the post-return-free case (a trap, a
+            // result fixup, anything), you MUST extend that guard
+            // (`callee_post_return.is_none()` etc.) or the inlined path will
+            // silently diverge from the thunk. Keep the two in lockstep.
             let mut func = Function::new([]);
 
             for i in 0..param_count {

--- a/meld-core/src/adapter/mod.rs
+++ b/meld-core/src/adapter/mod.rs
@@ -175,6 +175,17 @@ pub struct AdapterFunction {
 
     /// Emitter class, for synthetic DWARF attribution (#144 inc 4).
     pub class: AdapterClass,
+
+    /// #304: when this adapter is a *pure identity trampoline* (a `Direct`
+    /// adapter whose body only re-pushes params and `call`s the target — no
+    /// transcoding, no resource conversion, no post-return), and adapter
+    /// inlining is enabled, this holds the target function's merged index.
+    /// `wire_adapter_indices` then wires the caller's import **directly** to the
+    /// target instead of to this thunk, so no forwarding indirection is
+    /// interposed at runtime; the now-unreferenced adapter is left for loom to
+    /// DCE. `None` means "keep the thunk" (the conservative default — set only
+    /// when the no-op forwarding is provable). See `inline_adapters`.
+    pub inline_target: Option<u32>,
 }
 
 /// Trait for adapter generators

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -403,8 +403,8 @@ impl Fuser {
         self.config.address_rebasing = requested_rebasing;
         if self.config.memory_strategy == MemoryStrategy::Auto {
             self.resolve_auto_memory_strategy();
-            if self.config.memory_strategy == MemoryStrategy::SharedMemory {
-                return match self.fuse_with_stats_resolved() {
+            let result = if self.config.memory_strategy == MemoryStrategy::SharedMemory {
+                match self.fuse_with_stats_resolved() {
                     Err(Error::MemoryStrategyUnsupported(msg)) => {
                         // Auto must never fail on input multi-memory accepts:
                         // a shared-plan refusal downgrades to multi-memory
@@ -418,8 +418,26 @@ impl Fuser {
                         self.fuse_with_stats_resolved()
                     }
                     other => other,
-                };
+                }
+            } else {
+                self.fuse_with_stats_resolved()
+            };
+            // #300 / ADR-4: `Auto` resolved a safety-relevant property (which
+            // inter-component isolation model protects components) automatically.
+            // Functional-safety builds must choose the strategy EXPLICITLY — so
+            // on an attested build (the release/safety build) surface the
+            // automatic choice loudly rather than letting it pass silently.
+            // `memory_strategy_label()` here is the FINAL strategy, after any
+            // shared->multi downgrade above.
+            if self.config.attestation {
+                log::warn!(
+                    "memory strategy: `Auto` resolved to '{}' for an attested build; \
+                     functional-safety builds should select `--memory` explicitly \
+                     (ADR-4: explicit, not auto)",
+                    self.memory_strategy_label()
+                );
             }
+            return result;
         }
         self.fuse_with_stats_resolved()
     }

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -261,6 +261,12 @@ pub struct FusionStats {
     /// Number of adapter functions generated
     pub adapter_functions: usize,
 
+    /// Number of identity-trampoline adapters inlined away (#304): the caller's
+    /// import was wired directly to the target instead of through the thunk, so
+    /// no forwarding indirection survives. The thunk itself is left unreferenced
+    /// for loom to DCE. Subset of `adapter_functions`.
+    pub adapters_inlined: usize,
+
     /// Number of imports resolved internally
     pub imports_resolved: usize,
 
@@ -667,7 +673,7 @@ impl Fuser {
         // re-rewrite the affected function bodies so that call sites go through
         // the adapter trampolines instead of calling the target directly.
         if !adapters.is_empty() {
-            self.wire_adapter_indices(&mut merged, &adapters, &graph)?;
+            stats.adapters_inlined = self.wire_adapter_indices(&mut merged, &adapters, &graph)?;
         }
 
         // Step 4: Encode output module.
@@ -787,7 +793,10 @@ impl Fuser {
         merged: &mut merger::MergedModule,
         adapters: &[adapter::AdapterFunction],
         graph: &resolver::DependencyGraph,
-    ) -> Result<()> {
+    ) -> Result<usize> {
+        // #304: count of identity trampolines inlined away (caller wired
+        // straight to the target instead of through the thunk).
+        let mut inlined_count = 0usize;
         use std::collections::{HashMap, HashSet};
         use wasm_encoder::{Function, Instruction, ValType};
 
@@ -860,8 +869,16 @@ impl Fuser {
         for (adapter_offset, (adapter, site)) in
             adapters.iter().zip(graph.adapter_sites.iter()).enumerate()
         {
+            // #304: a pure identity trampoline is bypassed — wire the caller's
+            // import straight to the target. (A widening wrapper, if any, takes
+            // precedence; the two are mutually exclusive since an identity
+            // forward has no result widening, but order defensively.) The
+            // bypassed thunk is left unreferenced for loom to DCE.
             let target_idx = if let Some(&wrapper_idx) = adapter_to_wrapper.get(&adapter_offset) {
                 wrapper_idx
+            } else if let Some(inline_target) = adapter.inline_target {
+                inlined_count += 1;
+                inline_target
             } else {
                 adapter_base + adapter_offset as u32
             };
@@ -1000,12 +1017,13 @@ impl Fuser {
         }
 
         log::info!(
-            "Wired {} adapter(s) into {} source module(s)",
+            "Wired {} adapter(s) into {} source module(s); {} identity trampoline(s) inlined",
             adapters.len(),
-            affected_modules.len()
+            affected_modules.len(),
+            inlined_count
         );
 
-        Ok(())
+        Ok(inlined_count)
     }
 
     /// Generate task.return shim functions for internal fused async calls.

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -473,6 +473,58 @@ impl Fuser {
         }
     }
 
+    /// #298 — whether the fused core's `cabi_realloc` is provably vestigial and
+    /// therefore safe to drop (so loom can DCE the allocator + `memory.grow`,
+    /// unblocking the single-address-space `--memory shared` MCU path).
+    ///
+    /// **Fail-safe and currently INERT.** This computes the verdict only; it is
+    /// not yet wired to change merge/encode behavior — that's the
+    /// corruption-critical step gated *behind* this verdict (the tolerant
+    /// rewriter + dead-function stubbing, see #298 / #299). The default on any
+    /// uncertainty is `false` (keep `cabi_realloc`): under-drop is a missed
+    /// optimization, over-drop is silent marshalling corruption.
+    ///
+    /// `cabi_realloc` is the component's *own* allocator, used by `canon lift`
+    /// when the host calls in with pointer-carrying args/results. So the
+    /// relevant surface is each component's **lifts** (exports): if every lift
+    /// is scalar (no string/list params or results) nothing needs the
+    /// allocator. (`canon lower`/imports use the *callee's* realloc, not this
+    /// one.) Two sound conservatisms: it also counts lifts that fusion will
+    /// internalize (over-keep), and it bails to `false` on any unresolvable
+    /// type, non-core output, or adapter presence.
+    fn cabi_realloc_drop_provably_safe(&self, graph: &resolver::DependencyGraph) -> bool {
+        // (1) Core-module output only: a P2 wrap aliases cabi_realloc for
+        //     `canon lower`, so dropping it there corrupts marshalling.
+        if self.config.output_format != OutputFormat::CoreModule {
+            return false;
+        }
+        // (2) No cross-component adapters: an adapter may marshal pointers and
+        //     consume the allocator. Over-keep; refine to per-site later.
+        if !graph.adapter_sites.is_empty() {
+            return false;
+        }
+        // (3) Every lift's component-level type must be provably scalar.
+        for comp in &self.components {
+            for entry in &comp.canonical_functions {
+                let parser::CanonicalEntry::Lift { type_index, .. } = entry else {
+                    continue;
+                };
+                let Some(td) = comp.get_type_definition(*type_index) else {
+                    return false; // unresolvable type => fail-safe keep
+                };
+                let parser::ComponentTypeKind::Function { params, results } = &td.kind else {
+                    return false; // non-function lift type => keep
+                };
+                if params.iter().any(|(_, t)| comp.type_contains_pointers(t))
+                    || results.iter().any(|(_, t)| comp.type_contains_pointers(t))
+                {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
     /// The fusion pipeline proper. `self.config.memory_strategy` is a
     /// concrete strategy here — `Auto` has been resolved by the caller.
     fn fuse_with_stats_resolved(&self) -> Result<(Vec<u8>, FusionStats)> {
@@ -516,6 +568,17 @@ impl Fuser {
         let resolver = Resolver::with_strategy(self.config.memory_strategy);
         let graph = resolver.resolve_with_hints(&self.components, &self.wiring_hints)?;
         stats.imports_resolved = graph.resolved_imports.len();
+
+        // #298 (INERT): compute the vestigial-cabi_realloc verdict for
+        // visibility. Not yet wired to drop anything — the actual drop is the
+        // corruption-critical step gated behind this and is implemented
+        // separately (tolerant rewriter + dead-function stubbing).
+        if self.cabi_realloc_drop_provably_safe(&graph) {
+            log::debug!(
+                "#298: cabi_realloc is provably vestigial for this fuse \
+                 (scalar lift surface, core output, no adapters) — drop not yet wired"
+            );
+        }
 
         // Step 2: Merge modules
         log::info!("Merging {} core modules", stats.modules_merged);
@@ -2487,6 +2550,135 @@ fn generate_stabilizing_shim(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- #298 inert vestigial-cabi_realloc verdict oracles ----------------
+    //
+    // These pin `cabi_realloc_drop_provably_safe` (the fail-safe verdict the
+    // future drop is gated behind). The verdict is INERT today — it only
+    // decides keep-vs-drop; nothing acts on it yet. Each oracle exercises one
+    // gate so the corruption-critical default (keep) cannot silently regress.
+
+    fn empty_graph_298() -> crate::resolver::DependencyGraph {
+        crate::resolver::DependencyGraph {
+            instantiation_order: Vec::new(),
+            resolved_imports: std::collections::HashMap::new(),
+            adapter_sites: Vec::new(),
+            module_resolutions: Vec::new(),
+            resource_graph: None,
+            stream_pair_graph: None,
+            reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
+            unresolved_imports: Vec::new(),
+        }
+    }
+
+    /// A component exporting exactly one lifted function with the given params
+    /// (no results). Empty params ⟹ scalar surface; a `String` param ⟹ pointer.
+    fn component_with_one_lift_298(
+        params: Vec<(String, crate::parser::ComponentValType)>,
+    ) -> crate::parser::ParsedComponent {
+        crate::parser::ParsedComponent {
+            name: None,
+            core_modules: Vec::new(),
+            imports: Vec::new(),
+            exports: Vec::new(),
+            types: vec![crate::parser::ComponentType {
+                kind: crate::parser::ComponentTypeKind::Function {
+                    params,
+                    results: Vec::new(),
+                },
+            }],
+            instances: Vec::new(),
+            canonical_functions: vec![crate::parser::CanonicalEntry::Lift {
+                core_func_index: 0,
+                type_index: 0,
+                options: crate::parser::CanonicalOptions::default(),
+            }],
+            sub_components: Vec::new(),
+            component_aliases: Vec::new(),
+            component_instances: Vec::new(),
+            core_entity_order: Vec::new(),
+            component_func_defs: Vec::new(),
+            component_instance_defs: Vec::new(),
+            component_type_defs: vec![crate::parser::ComponentTypeDef::Defined],
+            original_size: 0,
+            original_hash: String::new(),
+            depth_0_sections: Vec::new(),
+            p3_async_features: Vec::new(),
+        }
+    }
+
+    fn fuser_with_components_298(
+        components: Vec<crate::parser::ParsedComponent>,
+        output_format: OutputFormat,
+    ) -> Fuser {
+        let mut fuser = Fuser::new(FuserConfig {
+            output_format,
+            ..Default::default()
+        });
+        fuser.components = components;
+        fuser
+    }
+
+    /// Scalar lift surface + core output + no adapters ⟹ droppable (true).
+    #[test]
+    fn test_298_verdict_scalar_lift_surface_is_droppable() {
+        let fuser = fuser_with_components_298(
+            vec![component_with_one_lift_298(Vec::new())],
+            OutputFormat::CoreModule,
+        );
+        assert!(fuser.cabi_realloc_drop_provably_safe(&empty_graph_298()));
+    }
+
+    /// A pointer-carrying (string) lift param ⟹ cabi_realloc needed ⟹ keep.
+    #[test]
+    fn test_298_verdict_pointer_lift_surface_keeps_realloc() {
+        let fuser = fuser_with_components_298(
+            vec![component_with_one_lift_298(vec![(
+                "s".to_string(),
+                crate::parser::ComponentValType::String,
+            )])],
+            OutputFormat::CoreModule,
+        );
+        assert!(!fuser.cabi_realloc_drop_provably_safe(&empty_graph_298()));
+    }
+
+    /// Even a scalar surface must keep realloc when the output is a P2 wrap:
+    /// the wrap aliases cabi_realloc for `canon lower` (over-drop = corruption).
+    #[test]
+    fn test_298_verdict_component_output_keeps_realloc() {
+        let fuser = fuser_with_components_298(
+            vec![component_with_one_lift_298(Vec::new())],
+            OutputFormat::Component,
+        );
+        assert!(!fuser.cabi_realloc_drop_provably_safe(&empty_graph_298()));
+    }
+
+    /// Any cross-component adapter site ⟹ keep (an adapter may marshal pointers
+    /// and consume the allocator).
+    #[test]
+    fn test_298_verdict_adapter_sites_keep_realloc() {
+        let fuser = fuser_with_components_298(
+            vec![component_with_one_lift_298(Vec::new())],
+            OutputFormat::CoreModule,
+        );
+        let mut graph = empty_graph_298();
+        graph.adapter_sites.push(crate::resolver::AdapterSite {
+            from_component: 0,
+            from_module: 0,
+            import_name: "f".to_string(),
+            import_module: "m".to_string(),
+            import_func_type_idx: None,
+            to_component: 0,
+            to_module: 0,
+            export_name: "f".to_string(),
+            export_func_idx: 0,
+            crosses_memory: false,
+            is_async_lift: false,
+            requirements: crate::resolver::AdapterRequirements::default(),
+        });
+        assert!(!fuser.cabi_realloc_drop_provably_safe(&graph));
+    }
 
     /// #172: the library default is `Auto` — shared+rebase when provably
     /// safe, multi-memory otherwise. Pin it so a change is deliberate.

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -5368,6 +5368,162 @@ mod tests {
         );
     }
 
+    /// #298 positive control — validates the fork-side no-grow approach
+    /// (pulseengine/wit-bindgen `integration/embedded-rt-no-grow`, which backs
+    /// `cabi_realloc` with an embedder arena instead of `dlmalloc → $sbrk →
+    /// memory.grow`).
+    ///
+    /// The hypothesis the fork branch rests on: a component whose `cabi_realloc`
+    /// carries **no** `memory.grow` already fuses under `--memory shared`
+    /// (⟹ `address_rebasing`) **today**, with no #298 fix — because the
+    /// rewriter only rejects `memory.grow`, nothing else about the allocator.
+    /// This is the same harness as the kill-criterion oracle, with the
+    /// `memory.grow` removed from the body; it must SUCCEED.
+    ///
+    /// So the two fixes are complementary: the fork's no-grow `cabi_realloc`
+    /// unblocks the MCU path directly (belt), and #298's meld-side drop handles
+    /// the mixed/un-elided case (suspenders).
+    #[test]
+    fn test_298_no_grow_realloc_fuses_under_shared_rebase_today() {
+        use crate::parser::{FuncType, ModuleExport, ModuleImport, ParsedComponent};
+        use crate::resolver::{DependencyGraph, UnresolvedImport};
+
+        // Identical to the kill-criterion oracle, but the cabi_realloc body has
+        // NO memory.grow (an arena-backed realloc just returns a pointer).
+        let src = r#"(module
+            (type (func))
+            (type (func (param i32 i32 i32 i32) (result i32)))
+            (import "" "0" (func (type 0)))
+            (memory 1)
+            (func (type 1)
+                i32.const 0)
+            (export "cabi_realloc" (func 1)))"#;
+        let module_bytes = wat::parse_str(src).expect("wat compiles");
+
+        let mut code_range = None;
+        for payload in wasmparser::Parser::new(0).parse_all(&module_bytes) {
+            if let wasmparser::Payload::CodeSectionStart { range, .. } = payload.expect("payload") {
+                code_range = Some((range.start, range.end));
+            }
+        }
+        let code_range = code_range.expect("module has a code section");
+
+        let make_module = move || -> CoreModule {
+            CoreModule {
+                index: 0,
+                bytes: module_bytes.clone(),
+                types: vec![
+                    FuncType {
+                        params: vec![],
+                        results: vec![],
+                    },
+                    FuncType {
+                        params: vec![ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+                        results: vec![ValType::I32],
+                    },
+                ],
+                imports: vec![ModuleImport {
+                    module: "".to_string(),
+                    name: "0".to_string(),
+                    kind: ImportKind::Function(0),
+                }],
+                exports: vec![ModuleExport {
+                    name: "cabi_realloc".to_string(),
+                    kind: ExportKind::Function,
+                    index: 1,
+                }],
+                functions: vec![1],
+                memories: vec![MemoryType {
+                    memory64: false,
+                    shared: false,
+                    initial: 1,
+                    maximum: None,
+                }],
+                tables: Vec::new(),
+                globals: Vec::new(),
+                start: None,
+                data_count: None,
+                element_count: 0,
+                custom_sections: Vec::new(),
+                code_section_range: Some(code_range),
+                global_section_range: None,
+                element_section_range: None,
+                data_section_range: None,
+            }
+        };
+
+        let make_component = |module: CoreModule| -> ParsedComponent {
+            ParsedComponent {
+                name: None,
+                core_modules: vec![module],
+                imports: Vec::new(),
+                exports: Vec::new(),
+                types: Vec::new(),
+                instances: Vec::new(),
+                canonical_functions: Vec::new(),
+                sub_components: Vec::new(),
+                component_aliases: Vec::new(),
+                component_instances: Vec::new(),
+                core_entity_order: Vec::new(),
+                component_func_defs: Vec::new(),
+                component_instance_defs: Vec::new(),
+                component_type_defs: Vec::new(),
+                original_size: 0,
+                original_hash: String::new(),
+                depth_0_sections: Vec::new(),
+                p3_async_features: Vec::new(),
+            }
+        };
+
+        let components = vec![make_component(make_module()), make_component(make_module())];
+
+        let graph = DependencyGraph {
+            instantiation_order: vec![0, 1],
+            resolved_imports: HashMap::new(),
+            adapter_sites: Vec::new(),
+            module_resolutions: Vec::new(),
+            resource_graph: None,
+            stream_pair_graph: None,
+            reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
+            unresolved_imports: vec![
+                UnresolvedImport {
+                    component_idx: 0,
+                    module_idx: 0,
+                    module_name: "".to_string(),
+                    field_name: "0".to_string(),
+                    kind: ImportKind::Function(0),
+                    display_module: Some("wasi:io/error@0.2.6".to_string()),
+                    display_field: Some("drop".to_string()),
+                },
+                UnresolvedImport {
+                    component_idx: 1,
+                    module_idx: 0,
+                    module_name: "".to_string(),
+                    field_name: "0".to_string(),
+                    kind: ImportKind::Function(0),
+                    display_module: Some("wasi:io/error@0.2.6".to_string()),
+                    display_field: Some("drop".to_string()),
+                },
+            ],
+        };
+
+        let merger = Merger::new(MemoryStrategy::SharedMemory, true);
+        let merged = merger
+            .merge(&components, &graph)
+            .expect("a grow-free realloc must fuse under shared+rebase TODAY (no #298 needed)");
+
+        // Success under address-rebasing IS the grow-free proof: the rewriter
+        // rejects any reachable `memory.grow` (see the kill-criterion oracle),
+        // so a completed merge means no body grew memory. The fused core retains
+        // both realloc bodies (the suspenders #298 will later drop are belt here).
+        assert_eq!(
+            merged.functions.len(),
+            2,
+            "both grow-free realloc bodies survive the rebase fuse"
+        );
+    }
+
     // -- SR-31: Multiply-instantiated module detection -------------------------
 
     /// Helper to build a minimal ParsedComponent with given instances.

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -5377,26 +5377,39 @@ mod tests {
     /// carries **no** `memory.grow` already fuses under `--memory shared`
     /// (⟹ `address_rebasing`) **today**, with no #298 fix — because the
     /// rewriter only rejects `memory.grow`, nothing else about the allocator.
-    /// This is the same harness as the kill-criterion oracle, with the
-    /// `memory.grow` removed from the body; it must SUCCEED.
+    ///
+    /// This faithfully mirrors the **real** fork output shape (verified against
+    /// `pulseengine/wit-bindgen@4753871d`, the `cabi-realloc-extern` feature):
+    /// `cabi_realloc` stays **exported** (so the same build still links on a
+    /// composing host like wasmtime) but its body **forwards to an imported**
+    /// `__cabi_arena_realloc(old_ptr, old_len, align, new_len) -> ptr` — the
+    /// embedder-provided bounded arena that traps on exhaustion instead of
+    /// calling `memory.grow`. The arena import is left **unresolved** (gale, the
+    /// embedder, links it post-fuse over one policy for the whole image).
+    ///
+    /// This must SUCCEED and the fused core must (a) still export `cabi_realloc`
+    /// and (b) retain the `__cabi_arena_realloc` import (the embedder seam).
     ///
     /// So the two fixes are complementary: the fork's no-grow `cabi_realloc`
     /// unblocks the MCU path directly (belt), and #298's meld-side drop handles
     /// the mixed/un-elided case (suspenders).
     #[test]
-    fn test_298_no_grow_realloc_fuses_under_shared_rebase_today() {
+    fn test_298_fork_arena_realloc_fuses_under_shared_rebase_today() {
         use crate::parser::{FuncType, ModuleExport, ModuleImport, ParsedComponent};
         use crate::resolver::{DependencyGraph, UnresolvedImport};
 
-        // Identical to the kill-criterion oracle, but the cabi_realloc body has
-        // NO memory.grow (an arena-backed realloc just returns a pointer).
+        // The real fork shape: cabi_realloc forwards to the imported arena
+        // function; NO memory.grow anywhere.
         let src = r#"(module
-            (type (func))
             (type (func (param i32 i32 i32 i32) (result i32)))
-            (import "" "0" (func (type 0)))
+            (import "pulseengine:embedder/arena" "__cabi_arena_realloc" (func (type 0)))
             (memory 1)
-            (func (type 1)
-                i32.const 0)
+            (func (type 0)
+                local.get 0
+                local.get 1
+                local.get 2
+                local.get 3
+                call 0)
             (export "cabi_realloc" (func 1)))"#;
         let module_bytes = wat::parse_str(src).expect("wat compiles");
 
@@ -5412,27 +5425,21 @@ mod tests {
             CoreModule {
                 index: 0,
                 bytes: module_bytes.clone(),
-                types: vec![
-                    FuncType {
-                        params: vec![],
-                        results: vec![],
-                    },
-                    FuncType {
-                        params: vec![ValType::I32, ValType::I32, ValType::I32, ValType::I32],
-                        results: vec![ValType::I32],
-                    },
-                ],
+                types: vec![FuncType {
+                    params: vec![ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+                    results: vec![ValType::I32],
+                }],
                 imports: vec![ModuleImport {
-                    module: "".to_string(),
-                    name: "0".to_string(),
+                    module: "pulseengine:embedder/arena".to_string(),
+                    name: "__cabi_arena_realloc".to_string(),
                     kind: ImportKind::Function(0),
                 }],
                 exports: vec![ModuleExport {
                     name: "cabi_realloc".to_string(),
                     kind: ExportKind::Function,
-                    index: 1,
+                    index: 1, // imported arena func 0, defined cabi_realloc = wasm idx 1
                 }],
-                functions: vec![1],
+                functions: vec![0],
                 memories: vec![MemoryType {
                     memory64: false,
                     shared: false,
@@ -5486,41 +5493,69 @@ mod tests {
             stream_pair_graph: None,
             reexporter_components: Vec::new(),
             reexporter_resources: Vec::new(),
+            // The arena function is the embedder seam: gale provides it
+            // post-fuse, so it stays unresolved through fusion.
             unresolved_imports: vec![
                 UnresolvedImport {
                     component_idx: 0,
                     module_idx: 0,
-                    module_name: "".to_string(),
-                    field_name: "0".to_string(),
+                    module_name: "pulseengine:embedder/arena".to_string(),
+                    field_name: "__cabi_arena_realloc".to_string(),
                     kind: ImportKind::Function(0),
-                    display_module: Some("wasi:io/error@0.2.6".to_string()),
-                    display_field: Some("drop".to_string()),
+                    display_module: Some("pulseengine:embedder/arena".to_string()),
+                    display_field: Some("__cabi_arena_realloc".to_string()),
                 },
                 UnresolvedImport {
                     component_idx: 1,
                     module_idx: 0,
-                    module_name: "".to_string(),
-                    field_name: "0".to_string(),
+                    module_name: "pulseengine:embedder/arena".to_string(),
+                    field_name: "__cabi_arena_realloc".to_string(),
                     kind: ImportKind::Function(0),
-                    display_module: Some("wasi:io/error@0.2.6".to_string()),
-                    display_field: Some("drop".to_string()),
+                    display_module: Some("pulseengine:embedder/arena".to_string()),
+                    display_field: Some("__cabi_arena_realloc".to_string()),
                 },
             ],
         };
 
         let merger = Merger::new(MemoryStrategy::SharedMemory, true);
-        let merged = merger
-            .merge(&components, &graph)
-            .expect("a grow-free realloc must fuse under shared+rebase TODAY (no #298 needed)");
+        let merged = merger.merge(&components, &graph).expect(
+            "a fork arena-backed (grow-free) realloc must fuse under shared+rebase TODAY \
+             (no #298 needed)",
+        );
 
         // Success under address-rebasing IS the grow-free proof: the rewriter
         // rejects any reachable `memory.grow` (see the kill-criterion oracle),
-        // so a completed merge means no body grew memory. The fused core retains
-        // both realloc bodies (the suspenders #298 will later drop are belt here).
+        // so a completed merge means no body grew memory. Both cabi_realloc
+        // bodies survive (the suspenders #298 will later drop are belt here).
         assert_eq!(
             merged.functions.len(),
             2,
-            "both grow-free realloc bodies survive the rebase fuse"
+            "both arena-backed cabi_realloc bodies survive the rebase fuse"
+        );
+
+        // The fused core must still export cabi_realloc (kept present for a
+        // composing host) ...
+        assert!(
+            merged.exports.iter().any(|e| e.name == "cabi_realloc"),
+            "fused core keeps cabi_realloc exported (wasmtime-composability), \
+             got exports: {:?}",
+            merged.exports.iter().map(|e| &e.name).collect::<Vec<_>>()
+        );
+
+        // ... and must retain the __cabi_arena_realloc import — the embedder
+        // seam gale links post-fuse. Without it the fused core could not
+        // allocate, so meld must not drop or mis-wire it.
+        assert!(
+            merged
+                .imports
+                .iter()
+                .any(|i| i.name == "__cabi_arena_realloc"),
+            "fused core must retain the embedder arena import, got imports: {:?}",
+            merged
+                .imports
+                .iter()
+                .map(|i| format!("{}/{}", i.module, i.name))
+                .collect::<Vec<_>>()
         );
     }
 

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -5200,6 +5200,174 @@ mod tests {
         );
     }
 
+    /// #298 kill-criterion oracle (in-repo reproduction).
+    ///
+    /// Until now this failure was only reproducible *externally* — via gale's
+    /// `crates/gale-app-demo/dissolve.sh` on a real wit-bindgen component pair.
+    /// This pins it inside meld: fusing an all-scalar-boundary component pair in
+    /// the real MCU config (`SharedMemory` ⟹ `address_rebasing = true`, exactly
+    /// what `lib.rs` forces for shared memory) currently **hard-fails** because
+    /// the vestigial canonical-ABI allocator's `memory.grow` (here standing in
+    /// for `cabi_realloc → … → $sbrk → memory.grow`) reaches the address-rebase
+    /// rewriter, which rejects `memory.grow` (`rewriter.rs` `MemoryGrow` arm).
+    ///
+    /// The boundary between the two components is fully internalized and scalar,
+    /// so the allocator is provably dead — but the rewrite chokes on it *during
+    /// merge*, before any DCE/reachability pass could run. That ordering is the
+    /// crux of #298 (and why #298 ⟺ #299 are coupled).
+    ///
+    /// This asserts **today's** behavior (the hard-fail). When the #298
+    /// dead-allocator handling lands, this test goes red — at which point its
+    /// assertion must flip to the success criterion: merge succeeds, the fused
+    /// core exports **0** `cabi_realloc`, and contains **0** `memory.grow`.
+    #[test]
+    fn test_298_vestigial_grow_blocks_shared_rebase_fusion() {
+        use crate::parser::{FuncType, ModuleExport, ModuleImport, ParsedComponent};
+        use crate::resolver::{DependencyGraph, UnresolvedImport};
+
+        // A real core module whose exported `cabi_realloc` body contains a
+        // `memory.grow` — the canonical-ABI allocator meld must learn to drop.
+        let src = r#"(module
+            (type (func))
+            (type (func (param i32 i32 i32 i32) (result i32)))
+            (import "" "0" (func (type 0)))
+            (memory 1)
+            (func (type 1)
+                i32.const 1
+                memory.grow
+                drop
+                i32.const 0)
+            (export "cabi_realloc" (func 1)))"#;
+        let module_bytes = wat::parse_str(src).expect("wat compiles");
+
+        // Locate the code section payload range (the parser fills this in real
+        // runs; we mirror it so `extract_function_body` reads real bytes).
+        let mut code_range = None;
+        for payload in wasmparser::Parser::new(0).parse_all(&module_bytes) {
+            if let wasmparser::Payload::CodeSectionStart { range, .. } = payload.expect("payload") {
+                code_range = Some((range.start, range.end));
+            }
+        }
+        let code_range = code_range.expect("module has a code section");
+
+        let make_module = move || -> CoreModule {
+            CoreModule {
+                index: 0,
+                bytes: module_bytes.clone(),
+                types: vec![
+                    FuncType {
+                        params: vec![],
+                        results: vec![],
+                    },
+                    FuncType {
+                        params: vec![ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+                        results: vec![ValType::I32],
+                    },
+                ],
+                imports: vec![ModuleImport {
+                    module: "".to_string(),
+                    name: "0".to_string(),
+                    kind: ImportKind::Function(0),
+                }],
+                exports: vec![ModuleExport {
+                    name: "cabi_realloc".to_string(),
+                    kind: ExportKind::Function,
+                    index: 1, // imported func 0, defined func = wasm idx 1
+                }],
+                functions: vec![1], // one defined func, type 1
+                memories: vec![MemoryType {
+                    memory64: false,
+                    shared: false,
+                    initial: 1,
+                    maximum: None,
+                }],
+                tables: Vec::new(),
+                globals: Vec::new(),
+                start: None,
+                data_count: None,
+                element_count: 0,
+                custom_sections: Vec::new(),
+                code_section_range: Some(code_range),
+                global_section_range: None,
+                element_section_range: None,
+                data_section_range: None,
+            }
+        };
+
+        let make_component = |module: CoreModule| -> ParsedComponent {
+            ParsedComponent {
+                name: None,
+                core_modules: vec![module],
+                imports: Vec::new(),
+                exports: Vec::new(),
+                types: Vec::new(),
+                instances: Vec::new(),
+                canonical_functions: Vec::new(),
+                sub_components: Vec::new(),
+                component_aliases: Vec::new(),
+                component_instances: Vec::new(),
+                core_entity_order: Vec::new(),
+                component_func_defs: Vec::new(),
+                component_instance_defs: Vec::new(),
+                component_type_defs: Vec::new(),
+                original_size: 0,
+                original_hash: String::new(),
+                depth_0_sections: Vec::new(),
+                p3_async_features: Vec::new(),
+            }
+        };
+
+        let components = vec![make_component(make_module()), make_component(make_module())];
+
+        let graph = DependencyGraph {
+            instantiation_order: vec![0, 1],
+            resolved_imports: HashMap::new(),
+            adapter_sites: Vec::new(),
+            module_resolutions: Vec::new(),
+            resource_graph: None,
+            stream_pair_graph: None,
+            reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
+            unresolved_imports: vec![
+                UnresolvedImport {
+                    component_idx: 0,
+                    module_idx: 0,
+                    module_name: "".to_string(),
+                    field_name: "0".to_string(),
+                    kind: ImportKind::Function(0),
+                    display_module: Some("wasi:io/error@0.2.6".to_string()),
+                    display_field: Some("drop".to_string()),
+                },
+                UnresolvedImport {
+                    component_idx: 1,
+                    module_idx: 0,
+                    module_name: "".to_string(),
+                    field_name: "0".to_string(),
+                    kind: ImportKind::Function(0),
+                    display_module: Some("wasi:io/error@0.2.6".to_string()),
+                    display_field: Some("drop".to_string()),
+                },
+            ],
+        };
+
+        // Real MCU config: shared memory forces address rebasing.
+        let merger = Merger::new(MemoryStrategy::SharedMemory, true);
+        let result = merger.merge(&components, &graph);
+
+        // TODO(#298): when the dead-allocator handling lands, flip this to:
+        //   let merged = result.expect("fusion of a scalar boundary succeeds");
+        //   assert!(!merged.exports.iter().any(|e| e.name.starts_with("cabi_realloc")));
+        //   // and assert 0 memory.grow in the encoded core.
+        let err = result.expect_err(
+            "today: shared+rebase fusion must reject the vestigial allocator's memory.grow",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("memory.grow"),
+            "expected the memory.grow rebase rejection (the #298 coupling), got: {msg}"
+        );
+    }
+
     // -- SR-31: Multiply-instantiated module detection -------------------------
 
     /// Helper to build a minimal ParsedComponent with given instances.

--- a/meld-core/src/rewriter.rs
+++ b/meld-core/src/rewriter.rs
@@ -80,6 +80,14 @@ pub struct IndexMaps {
     pub memory_base_offset: u64,
     /// Whether address rebasing is enabled
     pub address_rebasing: bool,
+    /// #298: when set (only ever under the upstream vestigial-allocator
+    /// verdict + a proof that this function is dead), a `memory.grow` reached
+    /// during address rebasing is replaced with `unreachable` instead of
+    /// hard-failing. Sound ONLY for provably-dead code (it is never executed);
+    /// loom then DCEs the dead allocator. Defaults `false` — the conservative
+    /// hard-fail (current behavior) is preserved everywhere this is not
+    /// explicitly enabled by the gated wiring.
+    pub defer_grow_under_rebase: bool,
     /// Whether the memory uses 64-bit addressing
     pub memory64: bool,
     /// Initial memory size in pages for the module (used for rebased memory.size)
@@ -394,6 +402,14 @@ fn rewrite_operator(op: Operator<'_>, maps: &IndexMaps) -> Result<Vec<Instructio
         }
         MemoryGrow { mem, .. } => {
             if maps.address_rebasing {
+                if maps.defer_grow_under_rebase {
+                    // #298: the upstream verdict proved this allocator vestigial
+                    // and this function dead, so the grow is never executed.
+                    // Emitting `unreachable` lets the rebase pass complete (loom
+                    // DCEs the dead function) instead of hard-failing. Sound
+                    // ONLY because the function is provably unreachable.
+                    return Ok(vec![Instruction::Unreachable]);
+                }
                 return Err(Error::UnsupportedFeature(
                     "memory.grow not supported with address rebasing".to_string(),
                 ));
@@ -928,6 +944,30 @@ mod tests {
         let mut maps = IndexMaps::new();
         maps.address_rebasing = true;
 
+        assert!(rewrite_operator(Operator::MemoryGrow { mem: 0 }, &maps).is_err());
+    }
+
+    /// #298 part (b): with the (default-off) tolerant flag set, a `memory.grow`
+    /// reached during address rebasing is replaced with `unreachable` instead
+    /// of hard-failing — the deferred-dead-allocator path. Inert until the
+    /// gated wiring enables the flag; this pins the mechanism.
+    #[test]
+    fn test_rewrite_memory_grow_rebased_deferred_emits_unreachable() {
+        let mut maps = IndexMaps::new();
+        maps.address_rebasing = true;
+        maps.defer_grow_under_rebase = true;
+
+        let instrs = rewrite_operator(Operator::MemoryGrow { mem: 0 }, &maps).unwrap();
+        assert!(matches!(instrs.as_slice(), [Instruction::Unreachable]));
+    }
+
+    /// The flag is opt-in: rebasing WITHOUT it still hard-fails (the
+    /// conservative default must never silently relax).
+    #[test]
+    fn test_rewrite_memory_grow_rebased_default_still_fails() {
+        let mut maps = IndexMaps::new();
+        maps.address_rebasing = true;
+        assert!(!maps.defer_grow_under_rebase, "flag must default off");
         assert!(rewrite_operator(Operator::MemoryGrow { mem: 0 }, &maps).is_err());
     }
 

--- a/meld-core/tests/cross_component_call.rs
+++ b/meld-core/tests/cross_component_call.rs
@@ -149,6 +149,50 @@ fn test_cross_module_call() {
     assert_eq!(result, 7, "run() should return add(3, 4) = 7");
 }
 
+/// #304: fusing a real wac-composed two-component fixture (consumer → provider)
+/// internalizes the cross-component `compute` call, which is a same-memory
+/// scalar boundary → a pure identity Direct adapter. With `inline_adapters` on
+/// (the default), meld wires the caller's import **straight to the target**
+/// rather than through the forwarding thunk — no indirection interposed; the
+/// dead thunk is left for loom to DCE. Asserts the inline fired and the fused
+/// module still validates. (Behavioural equivalence is covered by
+/// `golden_e2e`'s Tier-B test on the same fixture.)
+#[test]
+fn test_304_identity_direct_adapter_is_inlined() {
+    let path = format!(
+        "{}/../tests/wit_bindgen/fixtures/compose/composed.wasm",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let Ok(composed) = std::fs::read(&path) else {
+        eprintln!("compose fixture absent ({path}); skipping");
+        return;
+    };
+
+    let mut fuser = Fuser::new(FuserConfig {
+        attestation: false,
+        component_provenance: false,
+        ..Default::default()
+    });
+    fuser
+        .add_component_named(&composed, Some("composed"))
+        .unwrap();
+
+    let (fused, stats) = fuser.fuse_with_stats().unwrap();
+
+    assert!(
+        stats.adapters_inlined >= 1,
+        "expected >=1 identity Direct adapter inlined when fusing the composed \
+         consumer→provider fixture, got {} (of {} adapters)",
+        stats.adapters_inlined,
+        stats.adapter_functions
+    );
+
+    // The fused output must still be valid wasm after the rewiring.
+    wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all())
+        .validate_all(&fused)
+        .expect("fused module must validate after identity-adapter inlining");
+}
+
 #[test]
 fn test_cross_module_call_with_different_args() {
     // Same structure but verify the actual function, not just a constant

--- a/meld-core/tests/multi_memory.rs
+++ b/meld-core/tests/multi_memory.rs
@@ -314,6 +314,76 @@ fn test_multi_memory_preserves_isolation() {
     );
 }
 
+/// #300: meld is the committed *structural-isolation* emitter for the
+/// dissolved library-OS (model 2 — one preserved wasm memory per component, so
+/// the MPU/PMP region boundary coincides with the semantic boundary). The
+/// existing tests cover N=2; this pins that the property **scales** to the
+/// realistic dissolved-OS shape (≥3 components, e.g. relay + kernel + app):
+/// fusing three single-memory components under `MultiMemory` must preserve
+/// **three distinct memories** (no collapse/merge) and keep every export
+/// callable, and the output must validate as multi-memory wasm. This is the
+/// stable structure synth#369/#404 lower (carry memidx → distinct native bases
+/// → one MPU region per memory).
+#[test]
+fn test_multi_memory_preserves_isolation_three_components() {
+    let component_a = build_single_module_component("get_a", "memory_a");
+    let component_b = build_single_module_component("get_b", "memory_b");
+    let component_c = build_single_module_component("get_c", "memory_c");
+
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        component_provenance: false,
+        address_rebasing: false,
+        preserve_names: false,
+        custom_sections: meld_core::CustomSectionHandling::Merge,
+        dwarf_handling: meld_core::DwarfHandling::Strip,
+        output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
+    };
+
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&component_a, Some("component-a"))
+        .unwrap();
+    fuser
+        .add_component_named(&component_b, Some("component-b"))
+        .unwrap();
+    fuser
+        .add_component_named(&component_c, Some("component-c"))
+        .unwrap();
+
+    let fused = fuser.fuse().unwrap();
+
+    let mut engine_config = Config::new();
+    engine_config.wasm_multi_memory(true);
+    let engine = Engine::new(&engine_config).unwrap();
+    // RuntimeModule::new validates the fused bytes as multi-memory wasm.
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    // One distinct memory per component must survive — the structural
+    // isolation invariant. A collapse to fewer would silently merge two
+    // components' address spaces (the failure model 2 exists to prevent).
+    let mem_count = count_memory_exports(&instance, &mut store);
+    assert_eq!(
+        mem_count, 3,
+        "fused module must export 3 distinct memories (one per component)"
+    );
+
+    for name in ["get_a", "get_b", "get_c"] {
+        let f = instance
+            .get_typed_func::<(), i32>(&mut store, name)
+            .unwrap();
+        assert_eq!(
+            f.call(&mut store, ()).unwrap(),
+            0,
+            "{name}() should return 0 (zero-initialized, isolated memory)"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Test 3: Result copy adapter (callee → caller memory)
 // ---------------------------------------------------------------------------

--- a/meld-core/tests/rebasing_end_to_end.rs
+++ b/meld-core/tests/rebasing_end_to_end.rs
@@ -199,3 +199,50 @@ fn test_address_rebasing_end_to_end() {
     let b_fill_region = read_shared(&memory, base + 8, 4);
     assert_eq!(b_fill_region, vec![0xBB, 0xBB, 0xBB, 0xBB]);
 }
+
+/// #298 real-artifact blocker — grounds the synthetic kill-criterion oracle
+/// (`merger::tests::test_298_vestigial_grow_blocks_shared_rebase_fusion`) on a
+/// **real** wit-bindgen component.
+///
+/// Stock wit-bindgen output links a growing allocator behind `cabi_realloc`
+/// (`cabi_realloc → … → $sbrk → memory.grow`). Every fixture in the corpus
+/// carries it: `strings-simple.wasm` exports `cabi_realloc` and contains
+/// `memory.grow`. So fusing it in the single-address-space MCU config
+/// (`SharedMemory` ⟹ `address_rebasing`) must currently hard-fail when the
+/// rebase rewriter reaches that `memory.grow` — exactly the blocker the fork's
+/// `cabi-realloc-extern` (arena-backed, no-grow) build removes, after which
+/// `test_298_fork_arena_realloc_fuses_under_shared_rebase_today` shows meld
+/// fuses the result.
+///
+/// This is the real-bytes proof that the embedded no-grow story is needed and
+/// that meld's blocker fires on actual wit-bindgen output, not just hand-built
+/// WAT. When #298's dead-allocator handling lands, this stays red until updated
+/// to assert the (now grow-free) success.
+#[test]
+fn test_298_real_wit_bindgen_component_blocks_shared_rebase() {
+    let path = format!(
+        "{}/../tests/wit_bindgen/fixtures/strings-simple.wasm",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let component = std::fs::read(&path).expect("strings-simple fixture present");
+
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::SharedMemory,
+        address_rebasing: true,
+        ..Default::default()
+    };
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&component, Some("strings-simple"))
+        .unwrap();
+
+    let err = fuser.fuse().expect_err(
+        "today: a real wit-bindgen component (cabi_realloc-backed memory.grow) \
+         must not fuse under shared+rebase",
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("memory.grow"),
+        "expected the memory.grow rebase rejection on a real wit-bindgen artifact, got: {msg}"
+    );
+}

--- a/safety/adr/ADR-4-inter-component-isolation-model.md
+++ b/safety/adr/ADR-4-inter-component-isolation-model.md
@@ -114,13 +114,41 @@ The **corruption-critical drop wiring is paused** — it is no longer on
 the priority path. Resume only if a specific target needs the secondary
 shared mode.
 
-## Open knob (not settled by this ADR)
+## `Auto`-default policy (resolved — maintainer decision)
 
-The `Auto` strategy (#172) currently prefers `SharedMemory` + rebasing
-when provably sound, else `MultiMemory`. With model 1 now *secondary*,
-whether `Auto` should keep that bias or whether structural-isolation
-targets should explicitly select `--memory multi` is a separate policy
-decision, still open.
+The `Auto` strategy (#172) prefers `SharedMemory` + rebasing when
+provably sound (no `memory.grow`, ≥2 input memories), else `MultiMemory`,
+with a runtime downgrade shared→multi if shared fusion refuses.
+
+**Decision: `Auto` is NOT flipped, and `Auto` is NOT the safety path.**
+Rationale (maintainer): *functional safety wants the isolation model to
+be **explicit**, not automatic — "if we flip Auto things automatically
+might get wrong."* An implicit/automatic choice of a safety-relevant
+property (which isolation model protects components from each other) is
+itself the hazard.
+
+Therefore:
+1. **Safety-critical / structural-isolation builds MUST select the
+   memory strategy explicitly** (`--memory multi` for model 2). Do not
+   rely on `Auto` to land the committed isolation model — relying on an
+   automatic resolution for a safety property is disallowed.
+2. **`Auto` is left unchanged** (a convenience for general, non-safety
+   fusion). Flipping its default to prefer `MultiMemory` was rejected:
+   it would silently change a safety-relevant property for every build
+   and regress size/efficiency for the common non-MCU case — i.e. it
+   trades one automatic-wrong for another.
+3. **Auditability backstop**: the *resolved* strategy + `address_rebasing`
+   are already recorded in the signed attestation
+   (`attestation.rs`, set from `memory_strategy_label()` after
+   resolution), so even when `Auto` is used the chosen model is explicit
+   and verifiable *in the artifact* — not silent post-hoc.
+
+Recommended follow-up (not in this ADR): when `Auto` resolves a strategy
+for an **attested** build, emit a `warn`-level note recommending an
+explicit `--memory` selection, so the implicit choice is loud at build
+time for safety builds. Deferred as a behavior change pending its own
+review (the shared→multi downgrade path means the warning must report
+the *final* strategy, not the initial pick).
 
 ## Rivet artifacts
 

--- a/safety/adr/ADR-4-inter-component-isolation-model.md
+++ b/safety/adr/ADR-4-inter-component-isolation-model.md
@@ -1,0 +1,141 @@
+---
+id: ADR-4
+type: design-question
+title: Inter-component memory-isolation model for the dissolved library-OS
+status: resolved
+gating-fixtures:
+  - multi_memory::test_multi_memory_separate_memories
+  - multi_memory::test_multi_memory_preserves_isolation
+  - multi_memory::test_multi_memory_preserves_isolation_three_components
+  - multi_memory::test_multi_memory_result_copy_adapter
+design-paths:
+  - model-1 — Single shared memory + embedder MPU-carve (rejected as the committed path; retained as a secondary mode)
+  - model-2 — Multi-memory; one preserved wasm memory per component = one MPU/PMP region (chosen)
+---
+
+# ADR-4 — Inter-component memory-isolation model for the dissolved library-OS
+
+## Context
+
+The cross-repo dissolved-library-OS work (gale#86, gale#404, synth#404,
+synth#369, meld#298, meld#299) must choose how fused components are
+isolated from one another on the MCU target (Cortex-M / PMP-class). The
+fusion-structure half of that choice is meld's, and gale#86's isolation
+design forks on it, so meld#300 raised it for an explicit decision.
+
+Two models were on the table (meld#300):
+
+1. **Single shared memory + MPU-carve.** `meld fuse --memory shared`
+   produces one linear memory; the embedder / TCB carves MPU
+   sub-regions per component by hand. Isolation is *configured*: a
+   miscomputed address lands in a neighbour's sub-range and only a
+   correct MPU programming catches it. This is what meld#298 / meld#299
+   were actively enabling (drop the vestigial canonical-ABI allocator so
+   `--memory shared` becomes viable; the lean ~544 B-class core).
+
+2. **Multi-memory → one native region per wasm memory.** meld preserves
+   each component's memory as a distinct linear memory; synth places each
+   at a distinct native base so the MPU/PMP region boundary *is* the
+   semantic boundary. Isolation is *structural*: a component cannot even
+   form a pointer into a neighbour's memory — the wasm memory index is
+   the capability.
+
+synth (synth#404) lowers whichever structure meld emits and will not be
+the blocker for model 2; it scoped the lowering work as: carry `memidx`
+through the IR instead of dropping it, place each wasm memory at a
+distinct native base, lower cross-memory ops explicitly (synth#369), and
+expose per-memory base/size so the embedder programs one MPU/PMP region
+per memory. synth is single-memory today, so model 1 is what is
+lowerable *now*; model 2 is forward-looking on the synth side.
+
+The MPU/PMP region cap (~8 on ARMv7-M, PMP similar) bounds the component
+count N under *either* model, so it is not a differentiator.
+
+## Decision
+
+**model-2 — multi-memory structural isolation is the committed
+dissolved-MCU path.** Isolation coincides with the semantic boundary by
+construction; this is the stronger story for the ASIL-D context gale
+targets (defence-by-construction, not defence-by-correct-MPU-config).
+Recorded in meld#300 (the maintainer's call resolves this design
+question).
+
+meld is **already on this side of the fork** and is not the blocker.
+`MemoryStrategy::MultiMemory` preserves each component's memory as a
+distinct region and emits the explicit cross-memory data movement that
+fusion across distinct memories requires — verified today by the gating
+fixtures:
+
+- `test_multi_memory_separate_memories` — a two-module component fuses to
+  **two** memories, one per original core module.
+- `test_multi_memory_preserves_isolation` — two separate components fuse
+  to **two distinct** memories, both exports callable.
+- `test_multi_memory_preserves_isolation_three_components` — the
+  invariant **scales** to the realistic dissolved-OS shape (≥3
+  components, e.g. relay + kernel + app): three distinct memories survive
+  with no collapse/merge of address spaces.
+- `test_multi_memory_result_copy_adapter` — cross-memory `(ptr, len)`
+  result data is copied callee→caller correctly.
+
+So the meld half of model 2 — emit N distinct memories + correct
+cross-memory ops, no rebasing/merging, per-memory sizes carried in the
+fused memory section — exists and is tested. The committed path's
+remaining work is **synth-side** (synth#369 cross-memory op lowering,
+synth#404 carry `memidx` + distinct native bases + per-memory base/size
+for MPU). meld keeps `MultiMemory` output stable as the lowering target
+and adjusts only if synth hits a structure it cannot consume.
+
+### Why not model-1 (kept as a secondary mode)
+
+model 1 is lean and lowerable on synth *today*, but its isolation is
+only as good as the embedder's MPU-carve — a miscomputed address is
+caught by hardware config rather than being unrepresentable. For the
+committed safety-critical path, structural isolation wins. model 1 is
+**retained as a secondary, optional mode** for targets that accept
+embedder-MPU-carve isolation in exchange for the smallest core.
+
+### Status of the secondary `--memory shared` path
+
+meld#298 / meld#299 are **reclassified secondary** (commented on both).
+The work already landed on branch `fix/298-dead-allocator-dce` is sound
+and stays for that secondary mode:
+
+- in-repo kill-criterion + real-artifact blocker oracles
+  (`merger::tests::test_298_vestigial_grow_blocks_shared_rebase_fusion`,
+  `rebasing_end_to_end::test_298_real_wit_bindgen_component_blocks_shared_rebase`);
+- proven compatibility with the fork's arena-backed no-grow
+  `cabi_realloc`
+  (`merger::tests::test_298_fork_arena_realloc_fuses_under_shared_rebase_today`);
+- the inert fail-safe vestigial-allocator verdict
+  (`Fuser::cabi_realloc_drop_provably_safe`, 4 gate oracles) and the
+  inert tolerant-rewriter flag (`IndexMaps::defer_grow_under_rebase`).
+
+The **corruption-critical drop wiring is paused** — it is no longer on
+the priority path. Resume only if a specific target needs the secondary
+shared mode.
+
+## Open knob (not settled by this ADR)
+
+The `Auto` strategy (#172) currently prefers `SharedMemory` + rebasing
+when provably sound, else `MultiMemory`. With model 1 now *secondary*,
+whether `Auto` should keep that bias or whether structural-isolation
+targets should explicitly select `--memory multi` is a separate policy
+decision, still open.
+
+## Rivet artifacts
+
+The committed model-2 path relies on the existing multi-memory
+correctness requirements rather than a new one: SR-9/SR-10 (memory and
+data/element index reindexing), SR-12 (multi-memory adapter generation
+for pointer-bearing types), SR-14 (correct source/destination memory
+indices in adapters), SR-16 (inner-pointer rewrite into the destination
+memory), SR-21/SR-23 (correct per-memory `canon lower` indices and
+import slots in multi-memory mode). These collectively pin "distinct
+memories preserved + cross-memory ops correct," which is exactly the
+structural-isolation guarantee.
+
+## References
+
+- meld#300 (the decision), meld#298, meld#299 (now secondary).
+- gale#86, gale#404 (isolation design that forked on this).
+- synth#404, synth#369 (the lowering work this commits synth to).

--- a/safety/adr/ADR-4-inter-component-isolation-model.md
+++ b/safety/adr/ADR-4-inter-component-isolation-model.md
@@ -143,12 +143,20 @@ Therefore:
    resolution), so even when `Auto` is used the chosen model is explicit
    and verifiable *in the artifact* — not silent post-hoc.
 
-Recommended follow-up (not in this ADR): when `Auto` resolves a strategy
-for an **attested** build, emit a `warn`-level note recommending an
-explicit `--memory` selection, so the implicit choice is loud at build
-time for safety builds. Deferred as a behavior change pending its own
-review (the shared→multi downgrade path means the warning must report
-the *final* strategy, not the initial pick).
+**Implemented**: when `Auto` resolves a strategy for an **attested**
+build, `Fuser::fuse` emits a `warn`-level note recommending an explicit
+`--memory` selection, so the implicit choice is loud at build time for
+safety builds. The warning reports the *final* strategy (after any
+shared→multi downgrade), not the initial pick, and fires only when
+attestation is enabled (the release/safety-build signal) to avoid noise
+on casual fusion. Log-only — no change to fusion behavior; the existing
+`auto_memory` tests confirm resolution is unchanged.
+
+Not done (a stricter option, if wanted later): *erroring* instead of
+warning when `Auto` is used on an attested build, behind an opt-in
+`require_explicit_memory_strategy` config — hard-enforcing "explicit, not
+auto." Deferred because erroring is a breaking change for existing
+`Auto`+attestation users and should be opt-in.
 
 ## Rivet artifacts
 

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1288,3 +1288,100 @@ artifacts:
         (async nested-param pointers dangling into caller memory) was closed in
         the same work.
       milestone: post-v0.31.0
+
+  - id: SR-42
+    type: requirement
+    title: Identity-trampoline adapter inlining
+    description: >
+      When a cross-component call edge resolves to a pure identity-trampoline
+      adapter (a `Direct` adapter whose body is exactly
+      `local.get*; call target; end` — no transcoding, no resource conversion,
+      no post-return), meld shall wire the caller's import directly to the
+      target function instead of interposing the forwarding thunk, when
+      `inline_adapters` is enabled (the default). The bypassed thunk is left
+      unreferenced for loom to DCE; no re-indexing is performed (all adapter
+      index maps are preserved). The inline condition is fail-safe: any
+      resource ops or any `callee_post_return` keeps the thunk (#304).
+    status: implemented
+    tags: [optimization, adapter, v0.34.0]
+    links:
+      - type: tracked-by
+        target: "#304"
+      - type: derives-from
+        target: SR-12
+    fields:
+      implementation:
+        - meld-core/src/adapter/fact.rs
+        - meld-core/src/adapter/mod.rs
+        - meld-core/src/lib.rs
+      verification-method: test
+      verification-description: >
+        cross_component_call::test_304_identity_direct_adapter_is_inlined fuses
+        the wac-composed consumer->provider fixture, asserts >=1 identity
+        adapter inlined (FusionStats.adapters_inlined) + the fused module
+        validates. Behaviour preserved across cross_component_call,
+        adapter_safety, runtime_intra_adapter, runtime_from_exports,
+        wit_bindgen_runtime (73), and golden_e2e Tier-B behavioural
+        equivalence on the same fixture. A clean-room adversarial review
+        (5 angles) returned SOUND; the guard<->trampoline-body coupling is
+        pinned by reciprocal invariant comments.
+      milestone: v0.34.0
+
+  - id: SR-43
+    type: requirement
+    title: Opaque-rep resource drop-teardown soundness
+    description: >
+      A fused 3-component re-exporter chain whose intermediate exports an
+      opaque-rep resource shall construct AND drop without trapping. Opaque-rep
+      removes the `& 7` alignment trap of the standard resource_floats fixture,
+      unmasking a separate drop-teardown memory fault. meld shall forward the
+      inner-handle drop and discriminate per-resource handle tables so the
+      construct+drop runtime path completes cleanly (#305).
+    status: proposed
+    tags: [bug, resource, opaque-rep, v0.35.0]
+    links:
+      - type: tracked-by
+        target: "#305"
+      - type: derives-from
+        target: SR-25
+    fields:
+      implementation:
+        - meld-core/src/merger.rs
+      verification-method: test
+      verification-description: >
+        PLANNED. Cherry-pick the fuse oracle
+        (wit_bindgen_runtime::test_fuse_wit_bindgen_resource_floats_opaque) from
+        feat/explore-I-opaque-rep, then upgrade it from fuse_only to a runtime
+        construct+drop test once the inner-handle drop forwarding +
+        per-resource handle-table discrimination land. Not yet implemented.
+      milestone: v0.35.0
+
+  - id: SR-44
+    type: requirement
+    title: Enforced requirement->verification->test traceability
+    description: >
+      The V-model right side shall be a machine-enforced rivet trace, not inert
+      YAML. Today `rivet validate` reports 0% requirement-coverage and there is
+      no test/verification artifact type, so every SR's "verified" status is
+      self-asserted in `traceability.yaml` rather than gated by a `verifies`
+      link to a test artifact (#303). meld shall: add a verification artifact
+      type + `verifies` links generated from the existing verification-status
+      test names; repair the 34 broken links (issue-refs mis-encoded as trace
+      links; host-controller and dangling-UCA references); and reconcile the
+      requirement-coverage rule with this project's STPA+requirements topology.
+    status: proposed
+    tags: [process, traceability, verification, v0.36.0]
+    links:
+      - type: tracked-by
+        target: "#303"
+    fields:
+      implementation:
+        - safety/requirements/traceability.yaml
+        - safety/stpa/ucas.yaml
+      verification-method: review
+      verification-description: >
+        PLANNED. Done when `rivet validate` is error-free and `rivet coverage`
+        reports requirement-coverage > 0% with every SR linked by `verifies` to
+        a test artifact. Partly gated on maintainer STPA judgment (host-
+        controller scope; intended UCAs for the dangling refs — #303 Class B/C).
+      milestone: v0.36.0


### PR DESCRIPTION
## Release v0.34.0 scope

Bundles the verified session work (SR-42, ADR-4, plan SR-43/44).

### Headline
- **#304 — identity-trampoline adapter inlining (SR-42).** Honors the previously-dead `inline_adapters` flag: a pure identity `Direct` adapter (`local.get*; call target; end`) is bypassed — the caller's import is wired straight to the target, the dead thunk left for loom to DCE. No re-index (all adapter index maps preserved). Fail-safe condition: `Direct && no resource ops && callee_post_return.is_none()`. New `FusionStats.adapters_inlined`.
- **#300 — multi-memory structural isolation committed as the dissolved-MCU model (ADR-4).** `Auto` left unchanged but a warning fires when it resolves a strategy on an attested build ("explicit, not auto" for functional safety). Multi-memory isolation verified to scale to N=3 components. `#298`/`#299` (shared-memory de-export) reclassified secondary; their oracle/verdict foundation rides along (inert, sound).

### Release plan (rivet)
- SR-42 [v0.34.0, implemented], SR-43 [v0.35.0, opaque-rep drop #305], SR-44 [v0.36.0, enforced traceability #303].

## Verification
- Full suite green per-commit (clippy + cargo test). Cross-component/adapter/runtime/e2e: `cross_component_call`, `adapter_safety`, `runtime_intra_adapter`, `runtime_from_exports`, `wit_bindgen_runtime` (73), `golden_e2e` (Tier-B behavioural equivalence).
- #304 (Tier-5: `adapter/fact.rs`, `lib.rs`) **clean-room adversarially verified — SOUND** across 5 angles; guard↔trampoline-body coupling pinned by reciprocal invariant comments. Awaiting the repo Mythos gate / `mythos-pass-done`.

## Falsification statement
If meld inlined a *non-identity* adapter (one that transcodes, converts resources, or runs post-return), the cross-component runtime suites would mis-execute or trap. They pass — including `golden_e2e` Tier-B behavioural equivalence on the real wac-composed consumer→provider fixture, where ≥1 identity adapter is inlined.

Refs: #304, #300, #298, #299. Plan: SR-42/43/44.