### PR TITLE
release: v0.34.0 — adapter inlining (#304) + multi-memory isolation commitment (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-06-23
+
+Adapter-inlining + isolation-model release. Honors the previously-dead
+`inline_adapters` flag and commits meld to multi-memory structural isolation as
+the dissolved-MCU path. The #304 Tier-5 change was clean-room adversarially
+verified (SOUND) and passed the PR-time Mythos delta-pass gate (4/4 files NO
+FINDINGS). Release plan landed in rivet (SR-42/43/44).
+
+**Falsification:** if meld inlined a *non-identity* adapter (one that transcodes,
+converts resources, or runs post-return), the cross-component runtime suites
+would mis-execute or trap. They pass — including `golden_e2e` Tier-B behavioural
+equivalence on the real wac-composed consumer→provider fixture, where ≥1 identity
+adapter is inlined.
+
+### Added
+
+- **#304 — identity-trampoline adapter inlining (SR-42).** When a cross-component
+  call edge resolves to a pure identity `Direct` adapter (`local.get*; call
+  target; end` — no transcoding, resource conversion, or post-return), the
+  caller's import is wired directly to the target instead of through the
+  forwarding thunk; the dead thunk is left for loom to DCE. No re-index (all
+  adapter index maps preserved). Fail-safe guard: `Direct && no resource ops &&
+  callee_post_return.is_none()`. New `FusionStats.adapters_inlined`.
+- **Release plan (rivet):** SR-42 [v0.34.0], SR-43 [v0.35.0, opaque-rep drop fix
+  #305], SR-44 [v0.36.0, enforced requirement→test traceability #303].
+
+### Changed
+
+- **#300 — multi-memory structural isolation committed as the dissolved-MCU
+  model (ADR-4).** `Auto` is unchanged but now emits a warning when it resolves a
+  memory strategy on an attested build ("explicit, not auto" for functional
+  safety). Multi-memory isolation verified to scale to N=3 components.
+  `#298`/`#299` (shared-memory de-export) reclassified secondary; their
+  oracle/verdict foundation rides along (inert, sound).
+
 ## [0.33.0] - 2026-06-17
 
 Depth-2 nested-string transcoding release: closes the last gap of the #272

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.33.0"
+version = "0.34.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1302,7 +1302,7 @@ artifacts:
       unreferenced for loom to DCE; no re-indexing is performed (all adapter
       index maps are preserved). The inline condition is fail-safe: any
       resource ops or any `callee_post_return` keeps the thunk (#304).
-    status: implemented
+    status: verified
     tags: [optimization, adapter, v0.34.0]
     links:
       - type: tracked-by


### PR DESCRIPTION
Release commit for **v0.34.0**: version bump 0.33.0→0.34.0 + CHANGELOG + SR-42 verified.

The feature code already merged via #306 (identity-trampoline adapter inlining #304; multi-memory isolation commitment #300/ADR-4; #298/#299 secondary foundation). This PR carries only the release metadata.

- Version: `0.33.0 → 0.34.0` (workspace.package)
- CHANGELOG: `[0.34.0]` entry with falsification statement
- SR-42 `implemented → verified`

On merge + green main CI → tag `v0.34.0` (triggers `release.yml` signing).

Refs #304, #300, #298. Plan SR-42/43/44.