### PR TITLE
test(resource): #305 — opaque-rep construct+drop runtime oracle (resolved, no meld fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -675,6 +675,14 @@ runtime_test!(
     "resource_aggregates"
 );
 runtime_test!(test_runtime_wit_bindgen_resource_floats, "resource_floats");
+// #305: opaque-rep re-exporter resource chain (built from wit-bindgen fork
+// feat/opaque-rep-attribute, with the user-supplied dtor). Fixture is gitignored
+// (~11 MB build artifact, regenerate per tests/wit_bindgen/README.md); the test
+// skips when absent. Runtime variant exercises construct+drop — the #305 trap.
+runtime_test!(
+    test_runtime_wit_bindgen_resource_floats_opaque,
+    "resource_floats_opaque"
+);
 runtime_test!(
     test_runtime_wit_bindgen_resource_borrow_in_record,
     "resource_borrow_in_record"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1334,10 +1334,14 @@ artifacts:
       A fused 3-component re-exporter chain whose intermediate exports an
       opaque-rep resource shall construct AND drop without trapping. Opaque-rep
       removes the `& 7` alignment trap of the standard resource_floats fixture,
-      unmasking a separate drop-teardown memory fault. meld shall forward the
-      inner-handle drop and discriminate per-resource handle tables so the
-      construct+drop runtime path completes cleanly (#305).
-    status: proposed
+      unmasking a separate drop-teardown memory fault. The fused chain shall
+      run construct+drop cleanly (#305). RESOLUTION: the trap was the
+      wit-bindgen-side opaque-rep destructor (missing inner-handle forwarding),
+      fixed by the fork's user-supplied dtor (feat/opaque-rep-attribute
+      51eca6b6). With that fixture, meld fuses the chain AND construct+drop runs
+      cleanly with no meld code change — the suspected meld handle-table
+      discrimination was not required.
+    status: verified
     tags: [bug, resource, opaque-rep, v0.35.0]
     links:
       - type: tracked-by
@@ -1349,11 +1353,12 @@ artifacts:
         - meld-core/src/merger.rs
       verification-method: test
       verification-description: >
-        PLANNED. Cherry-pick the fuse oracle
-        (wit_bindgen_runtime::test_fuse_wit_bindgen_resource_floats_opaque) from
-        feat/explore-I-opaque-rep, then upgrade it from fuse_only to a runtime
-        construct+drop test once the inner-handle drop forwarding +
-        per-resource handle-table discrimination land. Not yet implemented.
+        wit_bindgen_runtime::test_runtime_wit_bindgen_resource_floats_opaque
+        fuses the fork-built resource_floats_opaque composed component
+        (--output component) and runs construct+drop on wasmtime — passes
+        cleanly (163 KB fused, 695 funcs, 4 adapters). Fixture is gitignored
+        (~11 MB; regenerate per tests/wit_bindgen/README.md), so the test skips
+        in CI when absent and is the load-bearing local regression oracle.
       milestone: v0.35.0
 
   - id: SR-44

--- a/tests/wit_bindgen/README.md
+++ b/tests/wit_bindgen/README.md
@@ -71,3 +71,31 @@ per-fixture status notes.
 - Tests are tagged `manual` - they only run when explicitly requested
 - Phase 2 (TODO): Build from source once `rules_wasm_component` exports `@crates`
 - Baseline: wit-bindgen `v0.52.0` (see `proofs/DECISIONS.md`)
+
+## Opaque-rep variant (`resource_floats_opaque.wasm`) — #305
+
+A 3-component re-exporter chain whose intermediate exports a `Float` resource
+opted into **opaque-rep**, built from the **pulseengine/wit-bindgen fork**,
+branch `feat/opaque-rep-attribute` (commit `51eca6b6` or later — the
+"user-supplied dtor for opaque-rep export resources"). Opaque-rep returns the
+leaf's inner handle as the rep verbatim, skipping the `Box::into_raw` +
+`assume(ptr.is_aligned())` chain.
+
+The `.wasm` is **gitignored** (~11 MB build artifact); regenerate it:
+
+```bash
+git clone https://github.com/pulseengine/wit-bindgen /tmp/wit-bindgen-fork
+cd /tmp/wit-bindgen-fork && git checkout feat/opaque-rep-attribute
+cargo run --release --bin wit-bindgen -- test \
+  --artifacts /tmp/witbg-artifacts --languages rust \
+  tests/runtime/resource_floats_opaque
+cp /tmp/witbg-artifacts/resource_floats_opaque/composed-runner.rs-intermediate.rs-leaf.rs.wasm \
+   tests/wit_bindgen/fixtures/resource_floats_opaque.wasm
+```
+
+**#305 status: resolved.** The original drop-teardown trap was the
+wit-bindgen-side opaque-rep destructor (no inner-handle forwarding); the
+fork's user-supplied dtor fixes it. With that fixture, meld fuses the chain
+**and `construct+drop` runs cleanly** (`test_runtime_wit_bindgen_resource_floats_opaque`)
+— no meld handle-table change was needed. The runtime test pins it; it skips
+in CI when the fixture is absent (the 11 MB artifact is not committed).


### PR DESCRIPTION
Drove #305 to ground by **building the repro and running it**, rather than editing Tier-5 resource code blind.

## Outcome: #305 is resolved; meld needs no change
- Built `resource_floats_opaque.wasm` from the wit-bindgen fork `feat/opaque-rep-attribute` (`51eca6b6` — "user-supplied dtor for opaque-rep export resources").
- meld **fuses** the 3-component re-exporter chain (`--output component`, 163 KB, 695 funcs, 4 adapters) **and `construct+drop` runs cleanly on wasmtime.**
- The original drop-teardown trap was the **wit-bindgen-side opaque-rep destructor** (missing inner-handle forwarding); the fork's dtor fixes it. The suspected meld handle-table discrimination (`merger.rs`/`fact.rs`) was **not required** — verified empirically by running the repro.

## What this lands
- `test_runtime_wit_bindgen_resource_floats_opaque` — fuses + construct+drop regression oracle. Fixture is gitignored (~11 MB; recipe added to `tests/wit_bindgen/README.md`), so it **skips in CI when absent** and is the load-bearing local oracle (same posture as other large fixtures).
- SR-43 `proposed → verified`.
- `Cargo.lock` synced to 0.34.0 (v0.34 release bumped `Cargo.toml` only).

No meld code change ⇒ this is verification closure, not a versioned release. Closes #305.