### PR TITLE
release(v0.36.0): traceability-enforcement — ASPICE V closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-06-25
+
+Traceability-enforcement release (catches up the planned v0.35.0 — its SR-43
+opaque-rep work ships here). No library code change: this release closes the
+ASPICE V-model so requirement→verification is a typed, mechanically-enforced
+trace rather than a rendered matrix. `rivet validate` goes from 77 errors to
+**PASS (0 errors)** on the #570-fixed rivet (shipped in rivet v0.19.0).
+
+**Falsification:** if any requirement lacked a typed verification backlink, or
+any STPA/derives-from link pointed at a wrong-typed or missing target, `rivet
+validate` would FAIL. It passes — every one of the 44 sw-reqs and 11
+system-reqs carries a `verifies` backlink, 0 requirement-verification gaps.
+
+### Added
+
+- **Full ASPICE SWE/SYS tier migration (SR-44, #311).** New upstream tier —
+  2 stakeholder-reqs + 11 system-reqs (`safety/requirements/system-requirements.yaml`).
+  All 44 safety requirements flipped `requirement`→`sw-req`, each `derived-from`
+  its system-req. STPA trace preserved on the sw-reqs (ADR-5 option A):
+  `LS-*`→`mitigates`, `CC-*/SC-*`→`addresses-constraint` (declared in the new
+  `schemas/meld-local.yaml`), GitHub-issue refs→`cited-source`.
+- **Typed verification layer.** 44 `sw-verification` (SWE.6) +
+  11 `sys-verification` (SYS.5) artifacts, each `verifies` its requirement,
+  grounded in the existing tests/proofs (and the `golden_e2e` behavioural-
+  equivalence harness for the system tier).
+- **ADR-5** records the migration plan; **SR-43 opaque-rep drop oracle (#309)**
+  and the **verification matrix (#308)** / **multi-memory lowering contract
+  (#310, #300)** ship in this release.
+- **3 STPA UCAs authored** (`UCA-F-2`/`UCA-F-3`/`UCA-CP-1`) that loss scenarios
+  referenced but were never defined.
+
+### Changed
+
+- `compliance.yml` rivet pin bumped v0.15.0→v0.19.0 (carries the #570 parser
+  fix + aspice@0.2.0) so the release compliance report consumes the new schema.
+
+### Dependencies
+
+- Requires rivet ≥ v0.19.0 to validate the artifact graph (the #570 YAML-parser
+  fix; before it, `rivet validate` silently dropped trace edges and reported a
+  false PASS).
+
 ## [0.34.0] - 2026-06-23
 
 Adapter-inlining + isolation-model release. Honors the previously-dead

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.34.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.34.0"
+version = "0.36.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1453,7 +1453,7 @@ artifacts:
       cleanly with no meld code change — the suspected meld handle-table
       discrimination was not required.
     status: verified
-    tags: [bug, resource, opaque-rep, v0.35.0]
+    tags: [bug, resource, opaque-rep, v0.36.0]
     links:
       - type: derives-from
         target: SYS-5


### PR DESCRIPTION
## v0.36.0 — traceability-enforcement release

Cuts the traceability milestone now that #311 (full ASPICE SWE/SYS tier migration) is merged. **No library code change since v0.34.0** — this release closes the ASPICE V-model: `rivet validate` goes **77 errors → PASS (0 errors)**, every one of the 44 sw-reqs + 11 system-reqs carries a typed verification backlink.

Catches up the planned **v0.35.0** (its SR-43 opaque-rep oracle, #309, ships here; SR-43 retagged v0.36.0). Also bundles #308 (verification matrix) and #310/#300 (multi-memory lowering contract).

### Changes
- `Cargo.toml` / `Cargo.lock`: 0.34.0 → 0.36.0
- `CHANGELOG.md`: [0.36.0] entry with falsification statement
- `safety-requirements.yaml`: SR-43 release tag v0.35.0 → v0.36.0 (ships in this release)

### Dependency note
Requires **rivet ≥ v0.19.0** (the #570 YAML-parser fix). `compliance.yml` already bumped to v0.19.0 in #311.

Tag `v0.36.0` to be applied on green main after merge; release.yml then produces the signed/SBOM'd assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)