### PR TITLE
release(v0.37.0): scry fusion premises (#314) + embedder passthrough (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,67 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-06-26
+
+Downstream-boundary release: meld now (a) emits machine-checkable **fusion
+premises** for scry's abstract interpreter and (b) **explicitly recognizes**
+embedder-provided passthrough imports for the gale#89 single-address-space MCU
+lowering. Both are inc-1 producer-side increments; the heavy analysis (scry's
+value-range work) and the component-wrap exposure stay downstream / tracked.
+
+**Falsification:** if meld's `component-provenance` section diverged from the
+SCPV v3 wire format scry consumes, scry's decoder would reject it — instead
+scry v2.0.0 decodes it byte-for-byte (scry#63), and the previously-dead
+meld↔scry boundary is live end-to-end. If `closed_world` were ever over-asserted
+(claimed for a core that still imports), scry's soundness assumption would break;
+it is the provably-sound zero-imports tautology, hardened through three
+adversarial Mythos findings. If an embedder seam in the `pulseengine:embedder`
+namespace were bound to a coincidental provider or rejected under strict
+resolution, `ls_r_17_*` would fail — it passes.
+
+### Added
+
+- **SCPV v3 fusion premises for scry (#313 inc 1, #314).** The
+  `component-provenance` custom section now carries `bounded_memory`
+  (`!uses(memory.grow)`) and `closed_world` (zero imports) premises in a
+  no_std/no-alloc-decodable binary format (43-byte header, little-endian).
+  scry's fixpoint tightens with these fusion-unique facts; meld does **not**
+  compute value ranges / constant args / dead params — those remain scry's
+  abstract interpretation (SR-45). scry v2.0.0 ships the matching consumer.
+- **Explicit embedder-passthrough recognition (#301 inc 1, #315).**
+  `EMBEDDER_PASSTHROUGH_NAMESPACE` (`pulseengine:embedder`) +
+  `is_embedder_passthrough()` — package-namespace match, version-tolerant, no
+  prefix false-positives. The resolver recognizes these embedder-provided seams
+  (e.g. `pulseengine:embedder/arena`'s `__cabi_arena_realloc`) as intentional
+  passthrough: never bound to a fusion-set provider, exempt from the strict-mode
+  unresolved-import error, preserved into the fused core for the embedder to bind
+  at native link / synth dissolve (gale#89). LS-R-17.
+
+### Changed
+
+- `provenance::to_bytes()` is now infallible (`Vec<u8>`) — the SCPV v3 binary
+  encoder cannot fail, so the fusion path no longer threads a serialization
+  `Result`.
+
+### Fixed
+
+- **SCPV decoder DoS (Mythos #314).** `from_bytes` bounds the entry-count
+  allocation by remaining input length, so a hostile `count = u32::MAX` can no
+  longer force a multi-GiB `Vec::with_capacity`.
+
+### Safety
+
+- **LS-R-17** (approved): embedder-provided import mis-bound or rejected during
+  fusion (UCA-R-3, H-1/H-3.1) — mitigated by explicit namespace recognition,
+  pinned by `ls_r_17_embedder_passthrough_survives_strict_resolution`.
+- `closed_world` reduced to the provably-sound zero-imports tautology after
+  three adversarial Mythos findings (two soundness over-assertions + the DoS).
+- **Carried gap:** `fuse --output component` (P2 wrap) still *rejects* embedder
+  passthrough imports at `component_wrap.rs:1084`; #301 inc 2 (an
+  `EmbedderPassthrough` arm) is tracked and needs a `wasm-tools#2`
+  `--import-passthrough` fixture to gate end-to-end. The core-module path
+  (the gale#89 lowering target) preserves them correctly.
+
 ## [0.36.0] - 2026-06-25
 
 Traceability-enforcement release (catches up the planned v0.35.0 — its SR-43

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.36.0"
+version = "0.37.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## v0.37.0 — downstream-boundary release

Bundles the two merged inc-1 producer increments:
- **#313 inc 1 (#314)** — SCPV v3 fusion premises (`bounded_memory`, `closed_world`) in `component-provenance`; meld↔scry boundary live end-to-end (scry v2.0.0 consumer, scry#63).
- **#301 inc 1 (#315)** — explicit `pulseengine:embedder` passthrough recognition for the gale#89 single-address-space MCU lowering (LS-R-17).

### Readiness audit
- `rivet validate`: **PASS** (70 pre-existing WARNING-level gaps from the v0.36 ASPICE tier).
- Full `meld-core` suite: all pass, 0 failed.
- Pre-release Mythos delta-pass (minor → Tier-5 + tier-4 since v0.36.0): satisfied by PR-time gates — provenance.rs + resolver.rs + merger.rs carry documented NO FINDINGS + `mythos-pass-done`; `closed_world` hardened through 3 adversarial findings (2 soundness over-assertions + a decoder DoS); lib.rs change is trivial wiring.
- CHANGELOG has falsification statement + disclosed carried gap (`fuse --output component` still rejects embedder passthrough — #301 inc 2, fixture-gated).

Version bump only (Cargo.toml/Cargo.lock) + CHANGELOG — no Tier-5 code touched, so no new Mythos surface. Tag `v0.37.0` on merge → release.yml produces signed assets + SBOM + compliance report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)