### PR TITLE
test(e2e): Tier C — meld→kiln execution seam (#297), #[ignore]d on kiln#364

### DIFF
--- a/meld-core/tests/golden_e2e.rs
+++ b/meld-core/tests/golden_e2e.rs
@@ -412,3 +412,108 @@ fn tier_b_separate_inputs_internalise_link() {
 fn ls_cp_6_separate_inputs_internalise_link() {
     tier_b_separate_inputs_internalise_link();
 }
+
+// ---------------------------------------------------------------------------
+// Tier C (#297): execution on kiln — the safety-critical MCU-target runtime,
+// not just wasmtime. This is the "honest boundary" Tier A/B disclose.
+// ---------------------------------------------------------------------------
+
+/// Locate the `kilnd` binary: `MELD_KILND` override, else the conventional
+/// sibling-repo debug build. `None` (→ skip) when unavailable, mirroring the
+/// fixture-absent skips above.
+fn kilnd_path() -> Option<std::path::PathBuf> {
+    if let Ok(p) = std::env::var("MELD_KILND") {
+        let p = std::path::PathBuf::from(p);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let conv =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../kiln/target/debug/kilnd");
+    conv.exists().then_some(conv)
+}
+
+/// Run a `--component` wasm on `kilnd` and report whether kiln executed it
+/// successfully. `None` when kilnd is unavailable (→ skip). `tag` only
+/// disambiguates the temp file (no `Date`/rand in tests — the caller-supplied
+/// tag is unique per fixture+role). Uses `std::process::Command` fully
+/// qualified to avoid the `wasmtime_wasi::...::Command` import above.
+fn run_on_kiln(wasm: &[u8], tag: &str) -> Option<bool> {
+    let kilnd = kilnd_path()?;
+    let tmp = std::env::temp_dir().join(format!("meld_tierc_{tag}.wasm"));
+    std::fs::write(&tmp, wasm).ok()?;
+    let out = std::process::Command::new(&kilnd)
+        .arg(&tmp)
+        .arg("--component")
+        .arg("--wasi")
+        .output()
+        .ok()?;
+    let _ = std::fs::remove_file(&tmp);
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // kilnd prints an explicit success/failure line; exit code alone is
+    // unreliable across its run modes.
+    Some(combined.contains("executed successfully") && !combined.contains("Execution failed"))
+}
+
+/// Tier C (#297): a meld-fused component must EXECUTE on kiln — the
+/// safety-critical MCU-target runtime — not only under wasmtime (Tier A/B).
+///
+/// `#[ignore]`d: today kiln's component executor looks for a core-instance
+/// `_start` and cannot run meld's multi-core-module `--component` wrap (the
+/// stubs, fused, fixup and caller modules, with a deferred start); it fails
+/// with "No core instance exports _start". Filed as kiln#364. wasmtime runs
+/// the same artifact via `wasi:cli/run` (Tier A/B green), so meld's output is
+/// spec-valid. Un-ignore when kiln#364 lands; it then pins the meld-to-kiln
+/// behavioural seam green.
+#[test]
+#[ignore = "blocked on kiln#364: kilnd requires a core-instance _start; can't run meld's multi-core-module fused component"]
+fn tier_c_fused_executes_on_kiln() {
+    if kilnd_path().is_none() {
+        eprintln!("skipping Tier C: kilnd not found (set MELD_KILND or build ../../kiln)");
+        return;
+    }
+    let mut ran = 0usize;
+    for &name in &[
+        "release-0.2.0/hello_c_cli",
+        "release-0.2.0/hello_rust",
+        "release-0.2.0/hello_cpp_cli",
+    ] {
+        let Some(orig) = fixture_bytes(name) else {
+            continue;
+        };
+        let tag = name.replace('/', "_");
+        // Baseline: the unfused original must run on kiln, else a fused
+        // failure can't be attributed to fusion.
+        match run_on_kiln(&orig, &format!("{tag}_orig")) {
+            Some(true) => {}
+            Some(false) => {
+                eprintln!("[{name}] unfused original did not execute on kiln; skipping");
+                continue;
+            }
+            None => return, // kilnd vanished mid-run
+        }
+        let fused = fuse(
+            &orig,
+            name,
+            OutputFormat::Component,
+            MemoryStrategy::MultiMemory,
+        )
+        .expect("fusing a single command component must succeed");
+        let ok = run_on_kiln(&fused, &format!("{tag}_fused")).expect("kilnd available (checked)");
+        assert!(
+            ok,
+            "[{name}] meld-fused component must execute on kiln (kiln#364): \
+             the unfused original ran but the fused one did not"
+        );
+        ran += 1;
+    }
+    assert!(
+        ran > 0,
+        "Tier C exercised no command fixtures (corpus missing in {FIXTURES_DIR}?)"
+    );
+    eprintln!("Tier C: {ran} fused components executed on kiln ✓");
+}


### PR DESCRIPTION
## What

Closes the test side of **#297** — adds **Tier C** to `golden_e2e.rs`: execute a meld-fused component on **kiln** (the MCU-target runtime), not just wasmtime (Tier A/B). This is the "honest boundary" Tier A/B explicitly disclose ("NOT on the synth/kiln MCU target").

## The seam is currently broken — kiln#364

Standing up the test immediately surfaced a real meld→kiln interop blocker (grounded repro on #297):
- meld's fused `--component` output preserves the exact component WIT (`export wasi:cli/run@0.2.6`) and **runs under wasmtime** via the canonical entry (Tier A/B green).
- **kiln can't execute it**: its component runner looks for a core-instance `_start`, which meld's multi-core-module wrap (stubs / fused / fixup / caller, deferred start) doesn't expose → `✗ No core instance exports _start`.

Filed **kiln#364** (suggested fix: run components via their `wasi:cli/run` canonical entry, like wasmtime).

## This PR

- Tier C fuses a `wasi:cli` command fixture, runs it on `kilnd`, and asserts execution — with the **unfused original as the on-kiln baseline** so a fused failure is attributable to fusion (not a missing-fixture/kiln-absent case).
- **`#[ignore]`d** with the kiln#364 reason, so normal CI stays green. Verified it fails for *exactly* the documented cause (baseline ran on kiln, fused did not). **Un-ignore when kiln#364 lands** and it pins the meld→kiln seam green.
- `kilnd` located via `MELD_KILND` or the conventional `../../kiln` debug build; absent → skip.

Normal `golden_e2e` suite: 4 pass, Tier C `ignored`. clippy clean.

Refs: #297, kiln#364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)