### PR TITLE
fix(dwarf): remap DW_AT_location lists to the fused layout (#319 inc 3) — --verify CLEAN

### DIFF
--- a/meld-core/src/dwarf.rs
+++ b/meld-core/src/dwarf.rs
@@ -578,6 +578,9 @@ fn rewrite_debug_sections(
     // #319 inc 2: fix DW_AT_ranges lists (base-relative offsets that gimli
     // mis-routes through convert_address) from the read side.
     correct_die_ranges(&mut write_dwarf, &read_dwarf, remap);
+    // #319 inc 3: fix DW_AT_location lists (same base-relative offset bug as
+    // ranges, plus sentinel-derailed decode) from the read side.
+    correct_die_locations(&mut write_dwarf, &read_dwarf, remap);
     // #144 inc 3: the synthetic `<meld-adapter>` unit rides the SAME
     // write as the remapped original units, so every cross-section
     // offset is computed in one shared offset space (appending
@@ -774,6 +777,127 @@ fn correct_die_ranges<R: gimli::read::Reader<Offset = usize>>(
                     .get_mut(uid)
                     .get_mut(die_id)
                     .set(DW_AT_ranges, AttributeValue::RangeListRef(rid));
+            }
+        }
+    }
+}
+
+/// Rewrite every `DW_AT_location` **location list** to the fused layout
+/// (#319 inc 3). Location-list entries carry the same base-relative
+/// begin/end offsets as `.debug_ranges` (inc 2), so gimli mis-routes them
+/// through `convert_address` — the entry ranges land at garbage output
+/// offsets and, combined with the `0xFFFFFFFF`/`0xFFFFFFFE` sentinels,
+/// derail the whole list (`llvm-dwarfdump`: "Invalid DW_AT_location" /
+/// "Invalid DWARF expressions"). Fix it exactly like [`correct_die_ranges`]:
+/// resolve each list from the read side (`attr_locations`, base applied),
+/// `translate` the entry endpoints, and re-emit as `OffsetPair` relative to
+/// the output CU base — carrying the location **expression bytes verbatim**
+/// (WASM location expressions — `DW_OP_WASM_location`, `DW_OP_stack_value` —
+/// hold no code addresses; a data `DW_OP_addr` is unchanged under fusion,
+/// matching `convert_address`'s data passthrough). Bare exprloc
+/// `DW_AT_location`s are not lists (`attr_locations` → `None`) and are left
+/// to gimli. Unmappable entries are dropped; an emptied list deletes the
+/// attribute (LS-D-1).
+fn correct_die_locations<R: gimli::read::Reader<Offset = usize>>(
+    write_dwarf: &mut gimli::write::Dwarf,
+    read_dwarf: &gimli::read::Dwarf<R>,
+    remap: &AddressRemap,
+) {
+    use gimli::constants::{DW_AT_location, DW_AT_low_pc};
+    use gimli::write::{Address, AttributeValue, Expression, Location, LocationList};
+
+    let mut headers = read_dwarf.units();
+    let mut unit_idx = 0usize;
+    while let Ok(Some(header)) = headers.next() {
+        if unit_idx >= write_dwarf.units.count() {
+            break;
+        }
+        let uid = write_dwarf.units.id(unit_idx);
+        unit_idx += 1;
+        let unit = match read_dwarf.unit(header) {
+            Ok(u) => u,
+            Err(_) => continue,
+        };
+
+        let out_cu_base = {
+            let root = write_dwarf.units.get(uid).root();
+            match write_dwarf.units.get(uid).get(root).get(DW_AT_low_pc) {
+                Some(AttributeValue::Address(Address::Constant(a))) => *a as u32,
+                _ => continue,
+            }
+        };
+
+        let write_ids = {
+            let wunit = write_dwarf.units.get(uid);
+            let mut ids = Vec::new();
+            write_dies_preorder(wunit, wunit.root(), &mut ids);
+            ids
+        };
+
+        let mut entries = unit.entries();
+        let mut wi = 0usize;
+        while let Ok(Some((_, entry))) = entries.next_dfs() {
+            if wi >= write_ids.len() {
+                break;
+            }
+            let die_id = write_ids[wi];
+            wi += 1;
+
+            let loc_attr = match entry.attr_value(DW_AT_location) {
+                Ok(Some(v)) => v,
+                _ => continue,
+            };
+            // `attr_locations` returns `None` for a bare exprloc (not a list).
+            let mut locs = match read_dwarf.attr_locations(&unit, loc_attr) {
+                Ok(Some(l)) => l,
+                _ => continue,
+            };
+
+            let mut new_locs = Vec::new();
+            let mut aborted = false;
+            while let Ok(Some(le)) = locs.next() {
+                let (Some(ob), Some(oe)) = (
+                    remap.translate(le.range.begin as u32),
+                    remap.translate(le.range.end as u32),
+                ) else {
+                    continue; // unmappable (dropped/tombstoned) entry → drop
+                };
+                if ob < out_cu_base || oe <= ob {
+                    continue;
+                }
+                let bytes = match le.data.0.to_slice() {
+                    Ok(b) => b.into_owned(),
+                    Err(_) => {
+                        aborted = true;
+                        break;
+                    }
+                };
+                new_locs.push(Location::OffsetPair {
+                    begin: (ob - out_cu_base) as u64,
+                    end: (oe - out_cu_base) as u64,
+                    data: Expression::raw(bytes),
+                });
+            }
+            if aborted {
+                continue; // couldn't read an expression — leave gimli's output
+            }
+            if new_locs.is_empty() {
+                write_dwarf
+                    .units
+                    .get_mut(uid)
+                    .get_mut(die_id)
+                    .delete(DW_AT_location);
+            } else {
+                let lid = write_dwarf
+                    .units
+                    .get_mut(uid)
+                    .locations
+                    .add(LocationList(new_locs));
+                write_dwarf
+                    .units
+                    .get_mut(uid)
+                    .get_mut(die_id)
+                    .set(DW_AT_location, AttributeValue::LocationListRef(lid));
             }
         }
     }

--- a/meld-core/tests/dwarf_remap_witness.rs
+++ b/meld-core/tests/dwarf_remap_witness.rs
@@ -286,3 +286,73 @@ fn inc2_die_ranges_stay_within_enclosing_subprogram() {
     );
     eprintln!("inc2: {checked} DW_AT_ranges entries all contained in their subprogram");
 }
+
+/// #319 inc 3: no `DW_AT_location` location-list entry may have an
+/// out-of-module range in the remapped output. Location-list entries carry
+/// base-relative begin/end offsets identical to `.debug_ranges` (inc 2);
+/// before the fix gimli mis-routed those offsets through `convert_address`,
+/// producing garbage ranges (e.g. `[0x905993c0, …)`) that derailed the
+/// list decode (`llvm-dwarfdump`: "Invalid DW_AT_location" / "Invalid DWARF
+/// expressions"). This fuses the fixture and asserts every location-list
+/// entry's range lies within the fused module's byte length — a garbage
+/// remap (≈2.4 GiB begin) fails; a correct fused-code offset (< a few MiB)
+/// passes.
+#[test]
+fn inc3_location_list_ranges_stay_in_module() {
+    if !std::path::Path::new(RANGES_FIXTURE).is_file() {
+        eprintln!("skipping: fixture not found at {RANGES_FIXTURE}");
+        return;
+    }
+    let input = std::fs::read(RANGES_FIXTURE).expect("read fixture");
+    let fused = fuse_remap(&input);
+    // Generous upper bound: no real fused-code address exceeds the whole
+    // module size; the pre-fix garbage (~0x905993c0) blows past it.
+    let bound = fused.len() as u64;
+    let sections = debug_sections(&fused);
+    assert!(
+        sections.contains_key(".debug_info"),
+        "expected remapped DWARF"
+    );
+
+    let endian = gimli::LittleEndian;
+    let load = |id: gimli::SectionId| -> Result<gimli::EndianSlice<'_, gimli::LittleEndian>, gimli::Error> {
+        let data = sections.get(id.name()).map(|v| v.as_slice()).unwrap_or(&[]);
+        Ok(gimli::EndianSlice::new(data, endian))
+    };
+    let dwarf = gimli::Dwarf::load(load).expect("load output dwarf");
+
+    let mut checked = 0usize;
+    let mut units = dwarf.units();
+    while let Some(header) = units.next().expect("unit header") {
+        let unit = dwarf.unit(header).expect("parse unit");
+        let mut entries = unit.entries();
+        while let Some((_, entry)) = entries.next_dfs().expect("dfs walk") {
+            let Some(loc) = entry
+                .attr_value(gimli::constants::DW_AT_location)
+                .expect("location attr")
+            else {
+                continue;
+            };
+            // Only location LISTS (a bare exprloc → None).
+            let Some(mut locs) = dwarf.attr_locations(&unit, loc).expect("attr_locations") else {
+                continue;
+            };
+            while let Some(le) = locs.next().expect("loc entry") {
+                assert!(
+                    le.range.begin <= le.range.end && le.range.end <= bound,
+                    "inc3: DW_AT_location entry range [{:#x},{:#x}) is out of the \
+                     fused module (len {bound:#x}) — a base-relative location \
+                     offset was remapped as an absolute address (#319)",
+                    le.range.begin,
+                    le.range.end
+                );
+                checked += 1;
+            }
+        }
+    }
+    assert!(
+        checked > 0,
+        "expected at least one DW_AT_location list entry to check"
+    );
+    eprintln!("inc3: {checked} DW_AT_location list entries all within the fused module");
+}


### PR DESCRIPTION
## What
**Final increment for #319** — takes the fused DWARF to `llvm-dwarfdump --verify` **clean** (`No errors.`).

Stacks on #320 (inc 1, merged) + #321 (inc 2). The residual "Invalid DW_AT_location" / "Invalid DWARF expressions" errors were the **same base-relative-offset bug as inc 2**, in `.debug_loc` location lists: gimli mis-routes each entry's begin/end (base-relative offsets) through `convert_address` → garbage ranges (e.g. `[0x905993c0,…)`) which, with the `0xFFFFFFFF`/`0xFFFFFFFE` sentinels, derail the list decode.

## Fix
`correct_die_locations` — the `correct_die_ranges` analogue for location lists: resolve each list from the read side (`attr_locations`, base applied), `translate` the entry endpoints to the fused layout, re-emit as `Location::OffsetPair` relative to the output CU base, carrying the **location expression bytes verbatim** (WASM location exprs — `DW_OP_WASM_location` / `DW_OP_stack_value` — hold no code addresses; a data `DW_OP_addr` is unchanged under fusion, matching `convert_address`'s data passthrough). Bare exprloc locations aren't lists (`attr_locations` → `None`) and are left to gimli. Unmappable entries dropped; emptied list deletes `DW_AT_location` (LS-D-1).

## Effect — #319 complete
| | original | inc 1 | inc 2 | **inc 3** |
|---|---|---|---|---|
| overlapping | 480 | 0 | 0 | 0 |
| not-contained | 534 | 11 | 0 | 0 |
| invalid-expr / loc | 18 / 17 | 18 / 17 | 18 / 17 | **0 / 0** |
| **records+variants total** | **1049** | 46 | 35 | **0 — `No errors.`** |

records-only likewise → `No errors.`

## Test
`inc3_location_list_ranges_stay_in_module` — fuses `records.wasm`, asserts every `DW_AT_location` list entry's range lies within the fused module (the ~2.4 GiB garbage begin failed before). 3 witness/inc2/inc3 + 24 dwarf unit tests pass.

Refs: #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)