### PR TITLE
test(e2e): re-point Tier-C kiln blocker to the precise E5DC2 issue kiln#382 (#297)

### DIFF
--- a/meld-core/tests/golden_e2e.rs
+++ b/meld-core/tests/golden_e2e.rs
@@ -470,12 +470,15 @@ fn run_on_kiln(wasm: &[u8], tag: &str) -> Option<bool> {
 /// component instance index`. The SAME fused artifact runs correctly on
 /// wasmtime 41 ("Hello wasm component world from C!", Tier A/B green), so meld's
 /// output is spec-valid and the defect is in kilnd's component-instance
-/// resolution for a multi-core-module component — tracked in kiln#375
-/// (multi-core instantiation; E5DC2 flagged as a possibly-distinct, earlier
-/// failure than its user-import linking). Un-ignore when kiln#375 lands; it
-/// then pins the meld-to-kiln behavioural seam green.
+/// resolution for a multi-core-module component. Root-caused and tracked as
+/// kiln#382 (split from kiln#375): `resolve_command_entry` treats the run
+/// export's index as a defined-only index into `parsed.instances`, missing the
+/// `-K` instance-import offset (meld's fused component imports K=13 instances
+/// before the defined run instance, so it overruns). kiln#375 (cross-core user
+/// imports) is the *next* layer the seam hits once #382 lands. Un-ignore when
+/// kiln#382 lands (then #375 if it re-blocks); it pins the meld-to-kiln seam green.
 #[test]
-#[ignore = "blocked on kiln#375: kilnd's wasi:cli/run export resolution reports an out-of-bounds component instance index (E5DC2) for meld's multi-core-module fused component; kiln#364 (the _start gate) is resolved"]
+#[ignore = "blocked on kiln#382: kilnd's resolve_command_entry misses the -K instance-import offset, so the wasi:cli/run export resolves to an out-of-bounds component-instance index (E5DC2) for meld's multi-core fused component; then kiln#375 (cross-core user imports) is the next layer. kiln#364 (the _start gate) is resolved"]
 fn tier_c_fused_executes_on_kiln() {
     if kilnd_path().is_none() {
         eprintln!("skipping Tier C: kilnd not found (set MELD_KILND or build ../../kiln)");


### PR DESCRIPTION
## What
Re-points the Tier-C meld→kiln test (`tier_c_fused_executes_on_kiln`, #297) from kiln#375 to the more precise **kiln#382**, the root-caused E5DC2 issue kiln split out of #375. Test-annotation only; stays `#[ignore]`d.

## Why
kiln#382 pinpoints the defect: `resolve_command_entry` treats the `wasi:cli/run` export's index as a *defined-only* index into `parsed.instances`, missing the `-K` instance-import offset. **Corroborated from the meld side** — the fused `hello_c_cli --component --memory multi` wrap imports **K=13 instances** before the defined run instance, so `export.idx` (~13+) overruns the defined-only vector → `[ComponentRuntime][E5DC2] ...out-of-bounds component instance index`. The same `fused.wasm` runs clean on wasmtime 41, so meld's output is spec-valid; the defect is kiln-side.

Dependency chain for #297 is now precise:
1. ~~kiln#364~~ (`_start` gate) — resolved by kiln#374.
2. **kiln#382** (E5DC2, `-K` offset) — the immediate blocker (this PR points here).
3. kiln#375 (cross-core user imports) — the next layer once #382 lands.

kiln#382 itself names `tier_c_fused_executes_on_kiln` as what its fix un-blocks.

## Verification
- Pre-commit gate green (fmt, clippy, cargo-test).
- Test remains `#[ignore]`d; un-ignores when kiln#382 lands.

Refs #297, kiln#382, kiln#375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)