### PR TITLE
test(e2e): re-point Tier-C kiln blocker to the durable umbrella kiln#375 (#297)

### DIFF
--- a/meld-core/tests/golden_e2e.rs
+++ b/meld-core/tests/golden_e2e.rs
@@ -462,23 +462,23 @@ fn run_on_kiln(wasm: &[u8], tag: &str) -> Option<bool> {
 /// Tier C (#297): a meld-fused component must EXECUTE on kiln — the
 /// safety-critical MCU-target runtime — not only under wasmtime (Tier A/B).
 ///
-/// `#[ignore]`d: kiln#364 (kilnd `wasi:cli/run` canonical entry, landed via
-/// kiln#374) removed the original `_start` gate — the unfused original command
-/// component now runs on kilnd. But a real meld-fused `--component` wrap (stubs,
-/// fused, fixup and caller core modules) fails one layer deeper:
-/// `[ComponentRuntime][E5DC2] wasi:cli/run export references an out-of-bounds
-/// component instance index`. The SAME fused artifact runs correctly on
-/// wasmtime 41 ("Hello wasm component world from C!", Tier A/B green), so meld's
-/// output is spec-valid and the defect is in kilnd's component-instance
-/// resolution for a multi-core-module component. Root-caused and tracked as
-/// kiln#382 (split from kiln#375): `resolve_command_entry` treats the run
-/// export's index as a defined-only index into `parsed.instances`, missing the
-/// `-K` instance-import offset (meld's fused component imports K=13 instances
-/// before the defined run instance, so it overruns). kiln#375 (cross-core user
-/// imports) is the *next* layer the seam hits once #382 lands. Un-ignore when
-/// kiln#382 lands (then #375 if it re-blocks); it pins the meld-to-kiln seam green.
+/// `#[ignore]`d: the meld→kiln seam runs a real meld-fused `--component` wrap
+/// (stubs, fused, fixup, caller core modules) on kilnd, and kiln has been
+/// clearing it one layer at a time — meld's output is spec-valid throughout
+/// (the SAME artifact runs on wasmtime 41: "Hello wasm component world from
+/// C!", Tier A/B green), so each blocker is kiln-side.
+///
+/// Progression (each resolved kiln-side, then the next layer surfaced):
+/// kiln#364 (`_start` gate) resolved via kiln#374; kiln#382 (E5DC2 — the
+/// `resolve_command_entry` `-K` instance-import offset) resolved in kiln v0.4.0;
+/// current blocker `[Runtime][E0BBB] Export not found` (the run export resolves
+/// but its function isn't found), tracked on the multi-core umbrella kiln#375.
+///
+/// Un-ignore when kiln#375 (and any E0BBB split) lands; it then pins the
+/// meld-to-kiln behavioural seam green. Pointed at the durable umbrella so it
+/// need not be re-pointed as kiln fixes each sub-layer.
 #[test]
-#[ignore = "blocked on kiln#382: kilnd's resolve_command_entry misses the -K instance-import offset, so the wasi:cli/run export resolves to an out-of-bounds component-instance index (E5DC2) for meld's multi-core fused component; then kiln#375 (cross-core user imports) is the next layer. kiln#364 (the _start gate) is resolved"]
+#[ignore = "blocked on kiln#375: meld-fused --component fails on kilnd with [Runtime][E0BBB] Export not found (the run export resolves but its function isn't found); the same artifact runs on wasmtime 41 so meld's output is spec-valid. kiln#364 (_start) and kiln#382 (E5DC2) are resolved; E0BBB is the current kiln-side layer, tracked on the multi-core umbrella kiln#375"]
 fn tier_c_fused_executes_on_kiln() {
     if kilnd_path().is_none() {
         eprintln!("skipping Tier C: kilnd not found (set MELD_KILND or build ../../kiln)");


### PR DESCRIPTION
## What
Re-points `tier_c_fused_executes_on_kiln`'s ignore reason off the now-**closed** kiln#382 to the durable umbrella **kiln#375**, with the full kiln-side layer progression documented. Test-annotation only; stays `#[ignore]`d.

## Why
kiln#382 (E5DC2) shipped in kiln v0.4.0, so the annotation referenced a closed issue. Re-verified on post-#382 kilnd: E5DC2 is gone (component "initialized and running"), but the run export now fails `[Runtime][E0BBB] Export not found`. Same `fused.wasm` still runs on wasmtime 41 → meld's output is spec-valid; E0BBB is the next kiln-side layer, on kiln#375. Pointing at the umbrella avoids re-pointing again as kiln clears each sub-layer.

Refs #297, kiln#375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)