### PR TITLE
chore(release): v0.39.0 — DWARF .debug_line + name-section fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.39.0] - 2026-07-11
+
+Debug-info fidelity release: two independent correctness fixes to what the
+fused module reports about itself — the DWARF `.debug_line` table and the Wasm
+`name` section. Both close the "point at the right function/line or drop the
+entry, never point at the wrong one" invariant (SYS-7). No behaviour change to
+the executable core; only the debug/observability sections are corrected.
+
+This is the first slice of the v0.39.x line; the remaining MCU-lowering items
+(#326 dynamic-address rebasing, #299, #298, #334) are deferred to a following
+release.
+
+**Falsification:** if the `.debug_line` relocation regressed, every emitted row
+would no longer be guaranteed inside the fused code section —
+`dwarf_331_line_rows_within_code_section_multi_source` asserts on a real
+two-component fusion that every row address is `<=` the fused code-section end
+and the row set is non-empty; it would fail. If the `name` section were copied
+verbatim instead of index-remapped,
+`accumulate_remapped_function_names_remaps_and_drops_unmapped` would fail — it
+asserts a mapped entry is renumbered to its fused index and an unmapped entry is
+dropped.
+
+### Fixed
+
+- **DWARF `.debug_line` row addresses are now rebased through the offset map
+  (#331).** `DwarfHandling::Remap` previously relocated the DIE
+  `DW_AT_low_pc`/high-pc/range/location attributes (the #319 trilogy) but
+  carried each unit's line program over with *input-relative* row addresses, so
+  a debugger or `pulseengine/witness` MC/DC map resolved instructions to the
+  wrong source line (LS-D-1). `correct_line_programs` now rebuilds each unit's
+  line program, running every row address through the same
+  `AddressRemap::translate`, dropping any untranslatable row, and replicating
+  the file/directory table in gimli's add-order so `FileId`s stay aligned with
+  the DIE `decl_file` (including the DWARF v5 `file(0)`/`directory(0)` header
+  seeding). On the repro, the max `.debug_line` row moved from `0xF8` (past the
+  code) to `0xEC` (inside it) and `meld fuse --verify` is clean.
+- **`name` custom section is coalesced and index-remapped under
+  `--preserve-names` (#328).** Each input's `name` section was previously copied
+  verbatim, so `Name::Function` entries carried the input's local indices and
+  collided across inputs against the fused index space. The fuser now remaps
+  every function-name entry through `MergedModule::function_index_map`, drops
+  entries whose source index has no fused mapping, and emits a single coalesced
+  `name` section (deterministically ordered via a `BTreeMap`).
+
 ## [0.38.0] - 2026-07-10
 
 Correctness release: a **soundness fix** to the default memory strategy, a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.38.0"
+version = "0.39.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1556,3 +1556,92 @@ artifacts:
         a real wac-composed fusion emits `SCPV` magic with closed_world=true and
         bounded_memory = !uses(memory.grow)
         (component_provenance::v3_fusion_premises_present_on_real_fusion).
+
+  - id: SR-46
+    type: sw-req
+    title: DWARF .debug_line row addresses rebased through the offset map
+    description: >
+      When `DwarfHandling::Remap` relocates an input core module's debug
+      information, it shall rewrite every `.debug_line` line-program row
+      address to its fused code-section address using the SAME per-function
+      offset map (`AddressRemap::translate`) that relocates the DIE
+      `DW_AT_low_pc`/high-pc and range attributes — not leave the source
+      row addresses unrelocated. A row whose address cannot be translated
+      shall be dropped, never emitted pointing at the wrong instruction:
+      every emitted row address shall fall within the fused code section.
+      Before this fix the line-program was carried over with input-relative
+      addresses (max observed row 0xF8 against a fused code section ending
+      at 0xEC on the #331 repro), so a debugger or `pulseengine/witness`
+      MC/DC mapping resolved instructions to the wrong source line — the
+      LS-D-1 hazard. History: the DIE-attribute passes (#319 trilogy,
+      v0.38.0) already relocated low_pc/high_pc/ranges/locations; the
+      line-program was the remaining unrelocated section (#331).
+    status: verified
+    tags: [dwarf, debug-info, correctness, v0.39.0]
+    links:
+      - type: derives-from
+        target: SYS-7
+      - type: mitigates
+        target: LS-D-1
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/331"
+        kind: github
+        last-checked: 2026-07-11
+    release: v0.39.0
+    fields:
+      implementation:
+        - meld-core/src/dwarf.rs
+      verification-method: test
+      verification-description: >
+        `correct_line_programs` rebuilds each unit's line program, running
+        every source row address through `AddressRemap::translate` and
+        replicating the file/directory table in gimli's add-order so
+        `FileId`s coincide with the DIE `decl_file` (the v5 `file(0)`/
+        `directory(0)` header seeding is honoured — the latent off-by-one
+        Mythos caught and fixed in 02b70c5). Integration oracle
+        `dwarf_331_line_rows_within_code_section_multi_source`
+        (meld-core/tests/adapter_dwarf_e2e.rs): fuses two DWARF-bearing
+        components (hello_rust + hello_c_cli) and asserts every emitted
+        `.debug_line` row address is <= the fused code-section end and the
+        row set is non-empty. Manual evidence on the #331 repro: max
+        `.debug_line` row 0xF8 -> 0xEC (within code), `meld fuse --verify`
+        clean, both CUs preserved.
+
+  - id: SR-47
+    type: sw-req
+    title: Name section coalesced and index-remapped under --preserve-names
+    description: >
+      Under `--preserve-names`, the fused module shall carry a SINGLE
+      `name` custom section whose `Name::Function` entries are remapped
+      from each input's local function index to the fused function index
+      via `MergedModule::function_index_map`; an entry whose source index
+      has no fused mapping shall be DROPPED, never emitted against a
+      colliding or stale fused index. Before this fix each input's `name`
+      section was copied verbatim, so fused indices carried the wrong
+      names (or several inputs' name sections collided), mis-attributing
+      symbol names in any consumer that reads them (#328).
+    status: verified
+    tags: [names, debug-info, correctness, v0.39.0]
+    links:
+      - type: derives-from
+        target: SYS-7
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/328"
+        kind: github
+        last-checked: 2026-07-11
+    release: v0.39.0
+    fields:
+      implementation:
+        - meld-core/src/merger.rs
+        - meld-core/src/lib.rs
+      verification-method: test
+      verification-description: >
+        `accumulate_remapped_function_names` parses each input `name`
+        section (`wasmparser::NameSectionReader`), remaps `Name::Function`
+        entries through `function_index_map`, drops the unmapped, and
+        accumulates into `MergedModule::fused_function_names` (a BTreeMap
+        for deterministic order); `encode_output` emits one coalesced
+        `name` section from it. Unit oracle
+        `accumulate_remapped_function_names_remaps_and_drops_unmapped`
+        (meld-core/src/merger.rs) asserts a mapped entry is remapped to
+        its fused index and an unmapped entry is dropped.


### PR DESCRIPTION
Cut **v0.39.0** (0.38.0 → 0.39.0) — the first slice of the v0.39.x line.

## Scope
Two independent debug-info fidelity fixes (both already merged to main):

- **#331 — `.debug_line` row addresses rebased through the offset map** (SR-46, mitigates LS-D-1). `correct_line_programs` relocates every line-program row via `AddressRemap::translate`, drops untranslatable rows, and keeps the file/directory table aligned with the DIE `decl_file` (incl. the DWARF v5 `file(0)`/`directory(0)` header seeding). Repro: max `.debug_line` row `0xF8` → `0xEC` (inside code), `--verify` clean.
- **#328 — `name` section coalesced + index-remapped under `--preserve-names`** (SR-47). `Name::Function` entries remapped via `function_index_map`, unmapped dropped, emitted as one deterministic (`BTreeMap`) coalesced section.

Remaining MCU-lowering items (**#326** dynamic-address rebasing, **#299**, **#298**, **#334**) are deferred to a following release.

## Gate
- `rivet release status v0.39.0` → **Cuttable** (2 artifacts, both `verified`)
- `rivet validate` → **PASS**
- CHANGELOG `[0.39.0]` with falsification statements

## Falsification
If the `.debug_line` relocation regressed, `dwarf_331_line_rows_within_code_section_multi_source` (every row `<=` fused code-section end, non-empty) would fail. If the `name` section were copied verbatim, `accumulate_remapped_function_names_remaps_and_drops_unmapped` would fail.

Refs #331, #328, SR-46, SR-47, LS-D-1, SYS-7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)