### PR TITLE
fix(326): reloc-driven shared-memory address rebasing (sound --memory shared)

### DIFF
--- a/meld-core/src/error.rs
+++ b/meld-core/src/error.rs
@@ -56,6 +56,26 @@ pub enum Error {
     #[error("memory strategy not supported: {0}")]
     MemoryStrategyUnsupported(String),
 
+    /// A core module must be placed at a non-zero shared-memory base but
+    /// carries no relocation metadata, so meld cannot rebase its absolute
+    /// addresses into the shared window (issue #326, ADR-6 path-F). Emitting
+    /// it unchanged would collide it with a prior module's addresses and
+    /// silently corrupt memory, so fusion hard-fails instead.
+    #[error(
+        "component '{component}' module {module} is placed at a non-zero shared-memory base but \
+         carries no relocation metadata (linking/reloc.*); its absolute addresses cannot be \
+         rebased safely. Rebuild it with relocations retained on the FINAL link \
+         (`-C link-arg=--emit-relocs`) — an unresolved relocatable object \
+         (`wasm-ld -r`) is NOT sufficient, its stored values are addends, not final \
+         addresses — or fuse without shared memory"
+    )]
+    MissingRelocMetadata {
+        /// Display name of the component that owns the offending module.
+        component: String,
+        /// The offending module's index within its component.
+        module: String,
+    },
+
     /// Adapter generation error
     #[error("adapter generation failed: {0}")]
     AdapterGeneration(String),

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -60,6 +60,7 @@ pub mod p3_bridge;
 pub mod p3_stream;
 pub mod parser;
 pub mod provenance;
+pub mod reloc;
 pub mod resolver;
 pub mod resource_graph;
 pub mod rewriter;

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -1022,6 +1022,10 @@ impl Fuser {
                 memory_initial_pages,
                 data_segment_base,
                 elem_segment_base,
+                // #326: this adapter-redirect re-rewrite runs with
+                // `memory_base_offset == 0` (no rebasing), so no reloc
+                // consumption is needed here.
+                None,
             );
 
             let import_func_count = module
@@ -1541,6 +1545,7 @@ impl Fuser {
                 None,
                 data_segment_base,
                 elem_segment_base,
+                None, // code_addr_relocs (#326): base 0, no rebasing on this pass
             );
             let import_func_count = module
                 .imports
@@ -1783,6 +1788,14 @@ impl Fuser {
                 .iter()
                 .filter(|(name, _)| {
                     if !self.config.preserve_names && name == "name" {
+                        return false;
+                    }
+                    // #326: `linking` + `reloc.*` metadata describes each INPUT
+                    // module's own section layout; after fusion the section
+                    // indices/offsets they name are stale (and, where address
+                    // rebasing consumed them, already applied). Never emit them
+                    // on the fused module.
+                    if name == "linking" || name.starts_with("reloc.") {
                         return false;
                     }
                     // Only PassThrough emits raw per-input `.debug_*`

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -1248,6 +1248,7 @@ impl Merger {
                     None,  // memory_initial_pages
                     data_segment_base,
                     elem_segment_base,
+                    None, // code_addr_relocs (rebasing off in this re-rewrite pass)
                 );
                 let import_func_count = module
                     .imports
@@ -1884,6 +1885,52 @@ impl Merger {
         let memory_base_offset = shared_memory_plan
             .and_then(|plan| plan.bases.get(&(comp_idx, mod_idx)).copied())
             .unwrap_or(0);
+
+        // #326: relocation-driven address rebasing. A module placed at a
+        // non-zero shared-memory base has its absolute addresses shifted by
+        // that base; the `reloc.CODE` MEMORY_ADDR sites name exactly which
+        // `i32.const`/`memarg` immediates encode those addresses.
+        //
+        // Path-F (ADR-6): if such a module carries NO reloc metadata we cannot
+        // find its absolute addresses, so emitting it unchanged would collide
+        // it with a prior module and silently corrupt memory. Hard-fail —
+        // BUT only when the module actually performs *direct* (non-bulk)
+        // memory access. A module whose every memory touch is a bulk-memory op
+        // (`memory.copy/fill/init`) is safe without relocs: the rewriter
+        // rebases those ops' runtime address operands dynamically
+        // (`append_rebased_address`), so no baked-in absolute address can hide.
+        let mut data_addr_relocs: Vec<crate::reloc::RelocEntry> = Vec::new();
+        let code_addr_relocs = if self.address_rebasing {
+            let has_reloc = crate::reloc::has_reloc_metadata(&module.custom_sections);
+            if memory_base_offset != 0 && !has_reloc && module_has_direct_memory_access(module)? {
+                return Err(Error::MissingRelocMetadata {
+                    component: component_display_name(components, comp_idx),
+                    module: mod_idx.to_string(),
+                });
+            }
+            if has_reloc {
+                let info = crate::reloc::parse_reloc_info(&module.custom_sections)?;
+                // #326 Finding B: a memory64 module emits 8-byte inline data
+                // pointers (`R_WASM_MEMORY_ADDR_I64`) we cannot rebase; the
+                // segment placement would move while the pointers stay stale —
+                // silent corruption. Reject rather than emit a wrong module.
+                if info.has_unhandled_data_addr_relocs() {
+                    return Err(Error::UnsupportedFeature(format!(
+                        "component '{}' module {mod_idx}: shared-memory rebasing of \
+                         non-32-bit inline data pointers (memory64 reloc.DATA) is not \
+                         supported (#326)",
+                        component_display_name(components, comp_idx),
+                    )));
+                }
+                data_addr_relocs = info.data_memory_addr_entries();
+                Some(info.code_memory_addr_offsets())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let module_memory = if self.address_rebasing {
             module_memory_type(module)?
         } else {
@@ -1921,6 +1968,7 @@ impl Merger {
             memory_initial_pages,
             data_segment_base,
             elem_segment_base,
+            code_addr_relocs,
         );
 
         // Second pass: extract and rewrite function bodies
@@ -2203,9 +2251,26 @@ impl Merger {
             merged.elements.push(reindexed);
         }
 
-        // Parse and merge data segments with reindexing
+        // Parse and merge data segments with reindexing.
         let data_segments = crate::segments::parse_data_segments(module)?;
-        for segment in data_segments {
+        for mut segment in data_segments {
+            // #326 Part C: rebase absolute pointers baked into a data segment's
+            // payload. `reloc.DATA` MEMORY_ADDR_I32 sites name the 4-byte LE
+            // pointers; each segment's `content_offset` places its bytes in the
+            // same data-section-content coordinate space as those sites.
+            if memory_base_offset != 0 && !data_addr_relocs.is_empty() {
+                let base = u32::try_from(memory_base_offset).map_err(|_| {
+                    Error::MemoryStrategyUnsupported(
+                        "shared memory base offset exceeds 32-bit address space".to_string(),
+                    )
+                })?;
+                crate::reloc::rebase_data_segment_pointers(
+                    &mut segment.data,
+                    segment.content_offset,
+                    &data_addr_relocs,
+                    base,
+                );
+            }
             let reindexed = crate::segments::reindex_data_segment(&segment, &index_maps)?;
             merged.data_segments.push(reindexed);
         }
@@ -2930,6 +2995,86 @@ fn convert_global_type(
     }
 }
 
+/// Display name for a component (its declared name, else `component-<idx>`).
+/// Used in #326 diagnostics.
+fn component_display_name(components: &[ParsedComponent], comp_idx: usize) -> String {
+    components
+        .get(comp_idx)
+        .and_then(|c| c.name.clone())
+        .unwrap_or_else(|| format!("component-{comp_idx}"))
+}
+
+/// Whether `module` performs any *direct* (non-bulk) linear-memory access — an
+/// `i32.load`/`i32.store` family instruction whose effective address may embed
+/// a baked-in absolute address.
+///
+/// Bulk-memory ops (`memory.copy`/`fill`/`init`) are deliberately excluded: the
+/// rewriter rebases their runtime address operands dynamically
+/// ([`crate::rewriter`]'s `append_rebased_address`), so a module whose only
+/// memory touches are bulk ops is safe to place at a non-zero shared-memory
+/// base even without relocation metadata. This is what lets #326's path-F gate
+/// fire precisely — on modules that could hide an un-rebased absolute address —
+/// without rejecting the (safe) bulk-only case.
+///
+/// KNOWN LIMITATION (#326 Finding A, tracked follow-up): this catches an
+/// address embedded in a load/store, but NOT an `i32.const`/`i64.const` whose
+/// value is itself an absolute address used purely as a *value* (handed to an
+/// imported `memcpy`/`fd_write` or returned across the module boundary) with no
+/// direct access. Such a no-reloc module still slips the gate. A sound fix
+/// needs data-flow (a bare const is indistinguishable from an integer, and
+/// bulk-op-consumed consts ARE safe — rejecting all consts regresses the
+/// legitimate bulk-only case, `test_address_rebasing_end_to_end`). Note this
+/// residual gap does NOT affect the supported path: `--emit-relocs` inputs
+/// carry reloc metadata, so their address consts are rebased via `reloc.CODE`.
+fn module_has_direct_memory_access(module: &CoreModule) -> Result<bool> {
+    let Some((start, end)) = module.code_section_range else {
+        return Ok(false);
+    };
+    let code_bytes = &module.bytes[start..end];
+    let reader = wasmparser::CodeSectionReader::new(wasmparser::BinaryReader::new(code_bytes, 0))?;
+    for body in reader {
+        let body = body?;
+        for op in body.get_operators_reader()? {
+            if is_direct_memory_access(&op?) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// True for the standard integer/float load & store operators (the ones that
+/// carry a `memarg`). See [`module_has_direct_memory_access`].
+fn is_direct_memory_access(op: &wasmparser::Operator<'_>) -> bool {
+    use wasmparser::Operator::*;
+    matches!(
+        op,
+        I32Load { .. }
+            | I64Load { .. }
+            | F32Load { .. }
+            | F64Load { .. }
+            | I32Load8S { .. }
+            | I32Load8U { .. }
+            | I32Load16S { .. }
+            | I32Load16U { .. }
+            | I64Load8S { .. }
+            | I64Load8U { .. }
+            | I64Load16S { .. }
+            | I64Load16U { .. }
+            | I64Load32S { .. }
+            | I64Load32U { .. }
+            | I32Store { .. }
+            | I64Store { .. }
+            | F32Store { .. }
+            | F64Store { .. }
+            | I32Store8 { .. }
+            | I32Store16 { .. }
+            | I64Store8 { .. }
+            | I64Store16 { .. }
+            | I64Store32 { .. }
+    )
+}
+
 /// Build IndexMaps for a module from the merger's index maps
 ///
 /// This creates a local view of index remappings for a specific module,
@@ -2947,12 +3092,14 @@ pub(crate) fn build_index_maps_for_module(
     memory_initial_pages: Option<u64>,
     data_segment_base: u32,
     elem_segment_base: u32,
+    code_addr_relocs: Option<std::collections::HashSet<u32>>,
 ) -> IndexMaps {
     let mut maps = IndexMaps::new();
     maps.address_rebasing = address_rebasing;
     maps.memory_base_offset = memory_base_offset;
     maps.memory64 = memory64;
     maps.memory_initial_pages = memory_initial_pages;
+    maps.code_addr_relocs = code_addr_relocs;
 
     // Build function map (including imported functions)
     let import_func_count = module
@@ -3817,6 +3964,7 @@ mod tests {
             None,
             0,
             0,
+            None,
         );
         assert_eq!(maps_a.remap_memory(0), 0);
 
@@ -3832,6 +3980,7 @@ mod tests {
             None,
             0,
             0,
+            None,
         );
         assert_eq!(maps_b.remap_memory(0), 1);
     }

--- a/meld-core/src/p3_async.rs
+++ b/meld-core/src/p3_async.rs
@@ -1366,6 +1366,7 @@ fn shift_function_indices(
             memory_initial_pages,
             data_segment_base,
             elem_segment_base,
+            None, // code_addr_relocs (#326): adapter/shim re-rewrite, no relocs
         );
 
         let import_func_count = module

--- a/meld-core/src/p3_bridge.rs
+++ b/meld-core/src/p3_bridge.rs
@@ -400,6 +400,7 @@ pub fn emit_stream_bridge(
             memory_initial_pages,
             data_segment_base,
             elem_segment_base,
+            None, // code_addr_relocs (#326): adapter/shim re-rewrite, no relocs
         );
 
         let import_func_count = module

--- a/meld-core/src/reloc.rs
+++ b/meld-core/src/reloc.rs
@@ -1,0 +1,693 @@
+//! # Relocation-metadata reader (`linking` + `reloc.*` custom sections)
+//!
+//! meld fuses WebAssembly components into a shared linear memory but does not
+//! yet rebase a component's absolute addresses (issue #326). The fix consumes
+//! each input's `linking` + `reloc.*` metadata to find and rewrite the byte
+//! sites that encode memory addresses / relocatable indices.
+//!
+//! `wasmparser` 0.246 no longer exposes reloc/linking readers (they were
+//! dropped from modern versions), so meld hand-parses the raw custom-section
+//! bytes. meld already retains custom sections as `Vec<(String, Vec<u8>)>`
+//! (see [`crate::parser::ParsedComponent::custom_sections`]), so this reader
+//! takes those bytes directly.
+//!
+//! ## Wire format (verified empirically against `wasm-tools`-produced bytes)
+//!
+//! This module was reverse-engineered from a real relocatable core produced by
+//! the LLVM/`wasm-tools` toolchain. The exact `reloc.CODE` body observed was:
+//!
+//! ```text
+//! 03 04  04 3e 03 20  04 58 03 00  03 84 01 04 00  03 90 01 04 00
+//! ^^ ^^  \_________/  \_________/  \____________/  \____________/
+//! |  |    entry 0      entry 1        entry 2          entry 3
+//! |  count = 4
+//! target-section index = 3  (the CODE section)
+//! ```
+//!
+//! Findings that matter for the parser:
+//!
+//! * **A target-section-index prefix IS present.** The body is
+//!   `target_section: varuint32`, then `count: varuint32`, then `count`
+//!   entries. This is the LLVM/`wasm-tools` layout (the "historical variant"
+//!   the tool-conventions doc mentions); it is NOT the bare `count`-first
+//!   layout. Confirmed because the first byte `0x03` equals the index of the
+//!   code section and `wasm-tools objdump` labels it `section 3`.
+//! * **Each entry is** `type: u8`, `offset: varuint32`, `index: varuint32`,
+//!   and — only for the memory-address / offset relocation types — an
+//!   `addend: varint32` (signed LEB128).
+//! * **The addend is always emitted for memory-address types, even when 0.**
+//!   The two `MemoryAddrLeb` entries above carry an explicit `00` addend byte;
+//!   it is an *encoded* zero, not an absent field. Both the LEB and the SLEB
+//!   memory-address forms carry the addend identically — presence is keyed on
+//!   the relocation *type*, not on LEB-vs-SLEB encoding.
+//!
+//! ## Scope (issue #326, increment 1)
+//!
+//! This is a pure, side-effect-free reader. It does not touch the
+//! fusion/rewriter/merger path — consuming these entries to actually rebase
+//! addresses is increment 2.
+
+use crate::{Error, Result};
+
+/// A relocation type code, as defined by the WebAssembly tool-conventions
+/// `Linking.md`. The memory-address / offset variants (the ones meld must
+/// rebase) are modelled precisely; every other code is preserved verbatim as
+/// [`RelocType::Other`] so that unknown or newer types never panic the parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelocType {
+    /// `R_WASM_FUNCTION_INDEX_LEB` = 0
+    FunctionIndexLeb,
+    /// `R_WASM_TABLE_INDEX_SLEB` = 1
+    TableIndexSleb,
+    /// `R_WASM_TABLE_INDEX_I32` = 2
+    TableIndexI32,
+    /// `R_WASM_MEMORY_ADDR_LEB` = 3
+    MemoryAddrLeb,
+    /// `R_WASM_MEMORY_ADDR_SLEB` = 4
+    MemoryAddrSleb,
+    /// `R_WASM_MEMORY_ADDR_I32` = 5
+    MemoryAddrI32,
+    /// `R_WASM_TYPE_INDEX_LEB` = 6
+    TypeIndexLeb,
+    /// `R_WASM_GLOBAL_INDEX_LEB` = 7
+    GlobalIndexLeb,
+    /// `R_WASM_FUNCTION_OFFSET_I32` = 8
+    FunctionOffsetI32,
+    /// `R_WASM_SECTION_OFFSET_I32` = 9
+    SectionOffsetI32,
+    /// `R_WASM_TAG_INDEX_LEB` = 10
+    TagIndexLeb,
+    /// `R_WASM_MEMORY_ADDR_REL_SLEB` = 11
+    MemoryAddrRelSleb,
+    /// `R_WASM_TABLE_INDEX_REL_SLEB` = 12
+    TableIndexRelSleb,
+    /// Any relocation type code this reader does not model explicitly. The raw
+    /// byte is preserved. Addend presence for these is inferred from the
+    /// tool-conventions code ranges (see [`RelocType::has_addend`]).
+    Other(u8),
+}
+
+impl RelocType {
+    /// Decode a raw relocation-type byte.
+    pub fn from_code(code: u8) -> Self {
+        match code {
+            0 => RelocType::FunctionIndexLeb,
+            1 => RelocType::TableIndexSleb,
+            2 => RelocType::TableIndexI32,
+            3 => RelocType::MemoryAddrLeb,
+            4 => RelocType::MemoryAddrSleb,
+            5 => RelocType::MemoryAddrI32,
+            6 => RelocType::TypeIndexLeb,
+            7 => RelocType::GlobalIndexLeb,
+            8 => RelocType::FunctionOffsetI32,
+            9 => RelocType::SectionOffsetI32,
+            10 => RelocType::TagIndexLeb,
+            11 => RelocType::MemoryAddrRelSleb,
+            12 => RelocType::TableIndexRelSleb,
+            other => RelocType::Other(other),
+        }
+    }
+
+    /// The raw relocation-type byte.
+    pub fn code(self) -> u8 {
+        match self {
+            RelocType::FunctionIndexLeb => 0,
+            RelocType::TableIndexSleb => 1,
+            RelocType::TableIndexI32 => 2,
+            RelocType::MemoryAddrLeb => 3,
+            RelocType::MemoryAddrSleb => 4,
+            RelocType::MemoryAddrI32 => 5,
+            RelocType::TypeIndexLeb => 6,
+            RelocType::GlobalIndexLeb => 7,
+            RelocType::FunctionOffsetI32 => 8,
+            RelocType::SectionOffsetI32 => 9,
+            RelocType::TagIndexLeb => 10,
+            RelocType::MemoryAddrRelSleb => 11,
+            RelocType::TableIndexRelSleb => 12,
+            RelocType::Other(code) => code,
+        }
+    }
+
+    /// Whether this relocation targets an absolute linear-memory address — the
+    /// class meld must rebase when collapsing inputs into a shared memory.
+    pub fn is_memory_addr(self) -> bool {
+        matches!(
+            self,
+            RelocType::MemoryAddrLeb
+                | RelocType::MemoryAddrSleb
+                | RelocType::MemoryAddrI32
+                | RelocType::MemoryAddrRelSleb
+        ) || matches!(self, RelocType::Other(c) if is_memory_addr_code(c))
+    }
+
+    /// Whether an entry of this type carries a trailing `addend: varint32`.
+    ///
+    /// Per tool-conventions this is the memory-address family plus the
+    /// function/section *offset* relocations. The 64-bit variants (codes
+    /// 14–25) are included so that a module built for `wasm64` still parses,
+    /// even though meld does not model those variants by name.
+    pub fn has_addend(self) -> bool {
+        match self {
+            RelocType::MemoryAddrLeb
+            | RelocType::MemoryAddrSleb
+            | RelocType::MemoryAddrI32
+            | RelocType::FunctionOffsetI32
+            | RelocType::SectionOffsetI32
+            | RelocType::MemoryAddrRelSleb => true,
+            RelocType::Other(c) => code_has_addend(c),
+            _ => false,
+        }
+    }
+}
+
+/// Is this raw code one of the `MEMORY_ADDR_*` relocation types (incl. 64-bit)?
+fn is_memory_addr_code(code: u8) -> bool {
+    matches!(code, 3 | 4 | 5 | 11 | 14 | 15 | 16 | 19 | 21 | 23 | 25)
+}
+
+/// Does this raw code carry a trailing `addend`? Covers the memory-address
+/// family and the function/section offset relocations, 32- and 64-bit.
+fn code_has_addend(code: u8) -> bool {
+    matches!(
+        code,
+        // 32-bit: MEMORY_ADDR_{LEB,SLEB,I32}, FUNCTION_OFFSET_I32,
+        // SECTION_OFFSET_I32, MEMORY_ADDR_REL_SLEB.
+        3 | 4 | 5 | 8 | 9 | 11
+        // 64-bit: MEMORY_ADDR_{LEB64,SLEB64,I64}, MEMORY_ADDR_REL_SLEB64,
+        // FUNCTION_OFFSET_I64, MEMORY_ADDR_TLS_SLEB,
+        // MEMORY_ADDR_LOCREL_I32, MEMORY_ADDR_TLS_SLEB64.
+        | 14 | 15 | 16 | 19 | 20 | 21 | 23 | 25
+    )
+}
+
+/// A single relocation entry: a site in the target section whose encoded value
+/// must be adjusted when the referenced symbol moves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RelocEntry {
+    /// The relocation type.
+    pub ty: RelocType,
+    /// Byte offset of the relocation site within the target section's payload.
+    pub offset: u32,
+    /// Symbol index into the `linking` section's symbol table.
+    pub index: u32,
+    /// Constant added to the symbol's address/value. Meaningful only when
+    /// [`RelocType::has_addend`] is true; 0 otherwise.
+    pub addend: i32,
+}
+
+/// Which section a `reloc.*` custom section targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RelocTarget {
+    /// `reloc.CODE`
+    Code,
+    /// `reloc.DATA`
+    Data,
+    /// Any other `reloc.<NAME>` target (the `<NAME>` suffix is preserved).
+    Other(String),
+}
+
+/// A decoded `reloc.<SECTION>` custom section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelocSection {
+    /// Which section these relocations apply to.
+    pub target: RelocTarget,
+    /// The target section's index within the module, as encoded in the reloc
+    /// section's leading `target_section` field.
+    pub target_section_index: u32,
+    /// The relocation entries, in file order.
+    pub entries: Vec<RelocEntry>,
+}
+
+/// A raw, still-encoded `linking` subsection `(id, bytes)`. Increment 1 exposes
+/// these verbatim; the symbol-table decode (needed later to resolve an entry's
+/// `index` to a symbol) is deferred to increment 2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkingSubsection {
+    /// Subsection id (e.g. 5 = `WASM_SEGMENT_INFO`, 8 = `WASM_SYMBOL_TABLE`).
+    pub id: u8,
+    /// Raw subsection payload bytes.
+    pub bytes: Vec<u8>,
+}
+
+/// Well-known `linking` subsection ids (tool-conventions `Linking.md`).
+pub mod linking_subsection {
+    /// `WASM_SEGMENT_INFO`
+    pub const SEGMENT_INFO: u8 = 5;
+    /// `WASM_INIT_FUNCS`
+    pub const INIT_FUNCS: u8 = 6;
+    /// `WASM_COMDAT_INFO`
+    pub const COMDAT_INFO: u8 = 7;
+    /// `WASM_SYMBOL_TABLE`
+    pub const SYMBOL_TABLE: u8 = 8;
+}
+
+/// The relocation metadata extracted from one module's custom sections.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RelocInfo {
+    /// The `linking` section version, if a `linking` section was present.
+    /// Expected to be 2.
+    pub linking_version: Option<u32>,
+    /// Raw `linking` subsections, in file order (empty if no `linking`).
+    pub linking_subsections: Vec<LinkingSubsection>,
+    /// The decoded `reloc.*` sections.
+    pub sections: Vec<RelocSection>,
+}
+
+/// Errors from relocation-metadata parsing.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RelocError {
+    /// A LEB128 value ran past the end of the buffer or overflowed.
+    #[error("truncated or malformed LEB128 while parsing {context}")]
+    BadLeb {
+        /// Where the failure happened.
+        context: &'static str,
+    },
+    /// The buffer ended before a required field could be read.
+    #[error("unexpected end of {section} section at byte {offset}")]
+    UnexpectedEof {
+        /// Which section was being parsed.
+        section: String,
+        /// Byte offset at which the buffer was exhausted.
+        offset: usize,
+    },
+    /// The `linking` section version was not the expected value 2.
+    #[error("unsupported linking version {found} (expected 2)")]
+    UnsupportedLinkingVersion {
+        /// The version byte that was found.
+        found: u32,
+    },
+}
+
+impl From<RelocError> for Error {
+    fn from(e: RelocError) -> Self {
+        Error::ParseError(e.to_string())
+    }
+}
+
+/// Read an unsigned LEB128 `u32` from `data[*pos..]`, advancing `*pos`.
+fn read_uleb32(data: &[u8], pos: &mut usize, context: &'static str) -> Result<u32> {
+    let mut result: u32 = 0;
+    let mut shift = 0u32;
+    loop {
+        let byte = *data.get(*pos).ok_or(RelocError::BadLeb { context })?;
+        *pos += 1;
+        result |= ((byte & 0x7f) as u32)
+            .checked_shl(shift)
+            .ok_or(RelocError::BadLeb { context })?;
+        if byte & 0x80 == 0 {
+            return Ok(result);
+        }
+        shift += 7;
+        if shift >= 32 {
+            return Err(RelocError::BadLeb { context }.into());
+        }
+    }
+}
+
+/// Read a signed LEB128 `i32` from `data[*pos..]`, advancing `*pos`.
+fn read_sleb32(data: &[u8], pos: &mut usize, context: &'static str) -> Result<i32> {
+    let mut result: i32 = 0;
+    let mut shift = 0u32;
+    loop {
+        let byte = *data.get(*pos).ok_or(RelocError::BadLeb { context })?;
+        *pos += 1;
+        result |= ((byte & 0x7f) as i32)
+            .checked_shl(shift)
+            .ok_or(RelocError::BadLeb { context })?;
+        shift += 7;
+        if byte & 0x80 == 0 {
+            // Sign-extend if the sign bit of the final group is set.
+            if shift < 32 && (byte & 0x40) != 0 {
+                result |= !0i32 << shift;
+            }
+            return Ok(result);
+        }
+        if shift >= 32 {
+            return Err(RelocError::BadLeb { context }.into());
+        }
+    }
+}
+
+/// True if any `linking` or `reloc.*` custom section is present. Cheap probe
+/// used to decide whether address-rebasing metadata exists at all.
+pub fn has_reloc_metadata(custom_sections: &[(String, Vec<u8>)]) -> bool {
+    custom_sections
+        .iter()
+        .any(|(name, _)| name == "linking" || name.starts_with("reloc."))
+}
+
+/// Parse the `linking` + `reloc.*` custom sections captured by meld's parser
+/// into structured [`RelocInfo`].
+///
+/// Modules with no such sections yield an empty (`Default`) `RelocInfo`.
+pub fn parse_reloc_info(custom_sections: &[(String, Vec<u8>)]) -> Result<RelocInfo> {
+    let mut info = RelocInfo::default();
+
+    for (name, bytes) in custom_sections {
+        if name == "linking" {
+            let (version, subsections) = parse_linking(bytes)?;
+            info.linking_version = Some(version);
+            info.linking_subsections = subsections;
+        } else if let Some(suffix) = name.strip_prefix("reloc.") {
+            info.sections.push(parse_reloc_section(suffix, bytes)?);
+        }
+    }
+
+    Ok(info)
+}
+
+/// Parse a `linking` custom-section body: `version: varuint32` then a sequence
+/// of `(id: u8, size: varuint32, bytes)` subsections.
+fn parse_linking(body: &[u8]) -> Result<(u32, Vec<LinkingSubsection>)> {
+    let mut pos = 0usize;
+    let version = read_uleb32(body, &mut pos, "linking version")?;
+    if version != 2 {
+        return Err(RelocError::UnsupportedLinkingVersion { found: version }.into());
+    }
+
+    let mut subsections = Vec::new();
+    while pos < body.len() {
+        let id = body[pos];
+        pos += 1;
+        let size = read_uleb32(body, &mut pos, "linking subsection size")? as usize;
+        let end = pos
+            .checked_add(size)
+            .ok_or_else(|| RelocError::UnexpectedEof {
+                section: "linking".to_string(),
+                offset: pos,
+            })?;
+        let sub_bytes = body
+            .get(pos..end)
+            .ok_or_else(|| RelocError::UnexpectedEof {
+                section: "linking".to_string(),
+                offset: pos,
+            })?
+            .to_vec();
+        subsections.push(LinkingSubsection {
+            id,
+            bytes: sub_bytes,
+        });
+        pos = end;
+    }
+
+    Ok((version, subsections))
+}
+
+/// Parse one `reloc.<suffix>` custom-section body:
+/// `target_section: varuint32`, `count: varuint32`, then `count` entries of
+/// `type: u8`, `offset: varuint32`, `index: varuint32`,
+/// and `addend: varint32` (only when the type carries one).
+fn parse_reloc_section(suffix: &str, body: &[u8]) -> Result<RelocSection> {
+    let target = match suffix {
+        "CODE" => RelocTarget::Code,
+        "DATA" => RelocTarget::Data,
+        other => RelocTarget::Other(other.to_string()),
+    };
+
+    let mut pos = 0usize;
+    let target_section_index = read_uleb32(body, &mut pos, "reloc target section")?;
+    let count = read_uleb32(body, &mut pos, "reloc count")?;
+
+    let mut entries = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let type_byte = *body.get(pos).ok_or_else(|| RelocError::UnexpectedEof {
+            section: format!("reloc.{suffix}"),
+            offset: pos,
+        })?;
+        pos += 1;
+        let ty = RelocType::from_code(type_byte);
+        let offset = read_uleb32(body, &mut pos, "reloc entry offset")?;
+        let index = read_uleb32(body, &mut pos, "reloc entry index")?;
+        let addend = if ty.has_addend() {
+            read_sleb32(body, &mut pos, "reloc entry addend")?
+        } else {
+            0
+        };
+        entries.push(RelocEntry {
+            ty,
+            offset,
+            index,
+            addend,
+        });
+    }
+
+    Ok(RelocSection {
+        target,
+        target_section_index,
+        entries,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    const SPIKE_DIR: &str = "/tmp/spike326";
+
+    /// Ground-truth `reloc.CODE` entries, from `wasm-tools objdump`.
+    fn expected_entries() -> Vec<RelocEntry> {
+        vec![
+            RelocEntry {
+                ty: RelocType::MemoryAddrSleb,
+                offset: 62,
+                index: 3,
+                addend: 32,
+            },
+            RelocEntry {
+                ty: RelocType::MemoryAddrSleb,
+                offset: 88,
+                index: 3,
+                addend: 0,
+            },
+            RelocEntry {
+                ty: RelocType::MemoryAddrLeb,
+                offset: 132,
+                index: 4,
+                addend: 0,
+            },
+            RelocEntry {
+                ty: RelocType::MemoryAddrLeb,
+                offset: 144,
+                index: 4,
+                addend: 0,
+            },
+        ]
+    }
+
+    /// Minimal custom-section extractor for a raw core module: walks the
+    /// top-level section list and collects `(name, body)` for id-0 sections.
+    /// Kept local so the test does not depend on the full meld parser.
+    fn extract_custom_sections(module: &[u8]) -> Vec<(String, Vec<u8>)> {
+        assert!(module.len() >= 8, "not a wasm module");
+        assert_eq!(&module[0..4], b"\0asm", "bad magic");
+        let mut pos = 8usize; // skip magic + version
+        let mut out = Vec::new();
+        while pos < module.len() {
+            let id = module[pos];
+            pos += 1;
+            let mut p = pos;
+            let size = read_uleb32(module, &mut p, "section size").expect("section size") as usize;
+            let payload_start = p;
+            let payload_end = payload_start + size;
+            if id == 0 {
+                // Custom section: name is a length-prefixed string.
+                let mut np = payload_start;
+                let name_len = read_uleb32(module, &mut np, "name len").expect("name len") as usize;
+                let name = String::from_utf8(module[np..np + name_len].to_vec()).expect("utf8");
+                let body = module[np + name_len..payload_end].to_vec();
+                out.push((name, body));
+            }
+            pos = payload_end;
+        }
+        out
+    }
+
+    /// Find the first embedded core module inside a component by locating the
+    /// nested `\0asm\x01\0\0\0` magic that starts a core module. Good enough
+    /// for the single-core spike fixtures.
+    fn embedded_core_module(component: &[u8]) -> Vec<u8> {
+        let magic = b"\0asm\x01\0\0\0";
+        // The component itself starts with the same magic; skip the first one.
+        let mut search_from = 8;
+        while let Some(rel) = find_subslice(&component[search_from..], magic) {
+            let start = search_from + rel;
+            // Heuristic: the core module we want carries reloc metadata.
+            let candidate = &component[start..];
+            if find_subslice(candidate, b"reloc.CODE").is_some() {
+                return candidate.to_vec();
+            }
+            search_from = start + 8;
+        }
+        panic!("no embedded core module with reloc.CODE found");
+    }
+
+    fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack.windows(needle.len()).position(|w| w == needle)
+    }
+
+    #[test]
+    fn parse_reloc_code_matches_spike_fixture() {
+        let path = format!("{SPIKE_DIR}/reloc.wasm");
+        if !Path::new(&path).exists() {
+            eprintln!("skipping: fixture {path} absent");
+            return;
+        }
+        let module = std::fs::read(&path).expect("read reloc.wasm");
+        let customs = extract_custom_sections(&module);
+        assert!(has_reloc_metadata(&customs));
+
+        let info = parse_reloc_info(&customs).expect("parse");
+        assert_eq!(info.linking_version, Some(2));
+        assert_eq!(info.sections.len(), 1);
+        let sec = &info.sections[0];
+        assert_eq!(sec.target, RelocTarget::Code);
+        assert_eq!(sec.entries, expected_entries());
+    }
+
+    #[test]
+    fn reloc_metadata_survives_component_new() {
+        let path = format!("{SPIKE_DIR}/reloc.component.wasm");
+        if !Path::new(&path).exists() {
+            eprintln!("skipping: fixture {path} absent");
+            return;
+        }
+        let component = std::fs::read(&path).expect("read reloc.component.wasm");
+        let core = embedded_core_module(&component);
+        let customs = extract_custom_sections(&core);
+        assert!(has_reloc_metadata(&customs));
+
+        let info = parse_reloc_info(&customs).expect("parse");
+        assert_eq!(info.linking_version, Some(2));
+        let code = info
+            .sections
+            .iter()
+            .find(|s| s.target == RelocTarget::Code)
+            .expect("reloc.CODE present");
+        assert_eq!(code.entries, expected_entries());
+    }
+
+    #[test]
+    fn has_reloc_metadata_false_for_baseline() {
+        let path = format!("{SPIKE_DIR}/baseline.component.wasm");
+        if !Path::new(&path).exists() {
+            eprintln!("skipping: fixture {path} absent");
+            return;
+        }
+        let component = std::fs::read(&path).expect("read baseline.component.wasm");
+        // Scan the whole component for any reloc/linking custom section by
+        // extracting customs from every embedded core module we can find.
+        let magic = b"\0asm\x01\0\0\0";
+        let mut any_reloc = false;
+        let mut from = 8;
+        while let Some(rel) = find_subslice(&component[from..], magic) {
+            let start = from + rel;
+            let customs = extract_custom_sections(&component[start..]);
+            if has_reloc_metadata(&customs) {
+                any_reloc = true;
+            }
+            let info = parse_reloc_info(&customs).expect("parse baseline");
+            assert!(info.sections.is_empty());
+            from = start + 8;
+        }
+        assert!(!any_reloc, "baseline must carry no reloc metadata");
+    }
+
+    /// The real gate: a hand-built `reloc.CODE` buffer, no file dependency.
+    #[test]
+    fn parse_hand_built_reloc_bytes() {
+        // target_section = 3, count = 2, then two entries.
+        //   entry 0: MemoryAddrSleb(4) offset=62 index=3 addend=32
+        //   entry 1: MemoryAddrLeb(3)  offset=132 index=4 addend=0
+        let body: &[u8] = &[
+            0x03, // target section index = 3 (CODE)
+            0x02, // count = 2
+            // entry 0
+            0x04, // MemoryAddrSleb
+            0x3e, // offset = 62
+            0x03, // index = 3
+            0x20, // addend = 32 (sleb)
+            // entry 1
+            0x03, // MemoryAddrLeb
+            0x84, 0x01, // offset = 132 (uleb)
+            0x04, // index = 4
+            0x00, // addend = 0 (sleb, explicit zero)
+        ];
+        let customs = vec![("reloc.CODE".to_string(), body.to_vec())];
+
+        assert!(has_reloc_metadata(&customs));
+        let info = parse_reloc_info(&customs).expect("parse hand-built");
+        assert_eq!(info.linking_version, None);
+        assert_eq!(info.sections.len(), 1);
+        let sec = &info.sections[0];
+        assert_eq!(sec.target, RelocTarget::Code);
+        assert_eq!(sec.target_section_index, 3);
+        assert_eq!(
+            sec.entries,
+            vec![
+                RelocEntry {
+                    ty: RelocType::MemoryAddrSleb,
+                    offset: 62,
+                    index: 3,
+                    addend: 32,
+                },
+                RelocEntry {
+                    ty: RelocType::MemoryAddrLeb,
+                    offset: 132,
+                    index: 4,
+                    addend: 0,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn index_only_types_have_no_addend() {
+        // FunctionIndexLeb(0) and GlobalIndexLeb(7) carry NO addend; the next
+        // byte after `index` is the following entry's type, not an addend.
+        let body: &[u8] = &[
+            0x03, // target section index
+            0x02, // count = 2
+            0x00, 0x05, 0x01, // FunctionIndexLeb offset=5 index=1 (no addend)
+            0x07, 0x0a, 0x02, // GlobalIndexLeb   offset=10 index=2 (no addend)
+        ];
+        let customs = vec![("reloc.CODE".to_string(), body.to_vec())];
+        let info = parse_reloc_info(&customs).expect("parse");
+        let entries = &info.sections[0].entries;
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].ty, RelocType::FunctionIndexLeb);
+        assert_eq!(entries[0].addend, 0);
+        assert_eq!(entries[1].ty, RelocType::GlobalIndexLeb);
+        assert_eq!(entries[1].offset, 10);
+        assert_eq!(entries[1].index, 2);
+    }
+
+    #[test]
+    fn negative_addend_sign_extends() {
+        // addend = -1 encodes as 0x7f in sleb128.
+        let body: &[u8] = &[0x00, 0x01, 0x04, 0x00, 0x00, 0x7f];
+        let customs = vec![("reloc.CODE".to_string(), body.to_vec())];
+        let info = parse_reloc_info(&customs).expect("parse");
+        assert_eq!(info.sections[0].entries[0].addend, -1);
+    }
+
+    #[test]
+    fn reloc_type_predicates() {
+        assert!(RelocType::MemoryAddrLeb.is_memory_addr());
+        assert!(RelocType::MemoryAddrSleb.has_addend());
+        assert!(RelocType::MemoryAddrLeb.has_addend());
+        assert!(!RelocType::FunctionIndexLeb.has_addend());
+        assert!(!RelocType::FunctionIndexLeb.is_memory_addr());
+        assert!(RelocType::from_code(4) == RelocType::MemoryAddrSleb);
+        assert!(matches!(RelocType::from_code(200), RelocType::Other(200)));
+        assert_eq!(RelocType::Other(200).code(), 200);
+    }
+
+    #[test]
+    fn empty_custom_sections_yield_empty_info() {
+        let info = parse_reloc_info(&[]).expect("parse");
+        assert!(info.sections.is_empty());
+        assert_eq!(info.linking_version, None);
+        assert!(!has_reloc_metadata(&[]));
+    }
+}

--- a/meld-core/src/reloc.rs
+++ b/meld-core/src/reloc.rs
@@ -253,6 +253,96 @@ pub struct RelocInfo {
     pub sections: Vec<RelocSection>,
 }
 
+impl RelocInfo {
+    /// Code-section-content byte offsets of every `R_WASM_MEMORY_ADDR_*` site
+    /// recorded in `reloc.CODE`.
+    ///
+    /// Each offset points at the relocatable immediate inside a function body
+    /// — the LEB of an `i32.const`/`i64.const` address literal, or the LEB
+    /// `offset` field of a load/store `memarg`. These are exactly the sites
+    /// the fuser must rebase by the shared-memory base. The coordinate space
+    /// is the code section's *content* (the bytes a `CodeSectionReader`
+    /// consumes, starting at the function-count prefix), which is the same
+    /// space `OperatorsReader::into_iter_with_offsets()` reports when the code
+    /// section is parsed from its content start.
+    pub fn code_memory_addr_offsets(&self) -> std::collections::HashSet<u32> {
+        self.sections
+            .iter()
+            .filter(|s| s.target == RelocTarget::Code)
+            .flat_map(|s| s.entries.iter())
+            .filter(|e| e.ty.is_memory_addr())
+            .map(|e| e.offset)
+            .collect()
+    }
+
+    /// `reloc.DATA` `R_WASM_MEMORY_ADDR_I32` entries — the 4-byte little-endian
+    /// absolute pointers embedded in data-segment payloads that must be
+    /// rebased. Only the `I32` form embeds an inline pointer in a data section;
+    /// the LEB/SLEB memory-address forms only appear in code.
+    pub fn data_memory_addr_entries(&self) -> Vec<RelocEntry> {
+        self.sections
+            .iter()
+            .filter(|s| s.target == RelocTarget::Data)
+            .flat_map(|s| s.entries.iter())
+            .filter(|e| matches!(e.ty, RelocType::MemoryAddrI32))
+            .copied()
+            .collect()
+    }
+
+    /// Whether any `reloc.DATA` entry embeds a memory address that
+    /// [`data_memory_addr_entries`](Self::data_memory_addr_entries) does NOT
+    /// handle — i.e. a non-`I32` inline data pointer (the 8-byte
+    /// `R_WASM_MEMORY_ADDR_I64`/`_LEB64`/`_SLEB64` forms a `memory64` module
+    /// emits). Those pointers would be left un-rebased while the segment
+    /// placement *is* rebased, silently corrupting memory, so the caller must
+    /// reject rather than emit a plausible-but-wrong module (#326 Finding B,
+    /// LS-D-1). `MemoryAddrI32` is the only inline-data form we can rebase.
+    pub fn has_unhandled_data_addr_relocs(&self) -> bool {
+        self.sections
+            .iter()
+            .filter(|s| s.target == RelocTarget::Data)
+            .flat_map(|s| s.entries.iter())
+            .any(|e| e.ty.is_memory_addr() && !matches!(e.ty, RelocType::MemoryAddrI32))
+    }
+}
+
+/// Rebase the absolute little-endian `u32` pointers embedded in one data
+/// segment's payload by `base`.
+///
+/// `segment_content_start` is the byte offset of this segment's payload within
+/// the data-section content — the same coordinate space `reloc.DATA` entry
+/// offsets use. Each entry whose site falls inside
+/// `[segment_content_start, segment_content_start + payload.len())` has its
+/// 4-byte little-endian pointer read, `base` added (wrapping), and the result
+/// written back. Entries outside this segment are ignored (they belong to
+/// another segment). Passive/`.bss` segments with no inline pointers simply
+/// see no matching entries.
+pub fn rebase_data_segment_pointers(
+    payload: &mut [u8],
+    segment_content_start: u32,
+    entries: &[RelocEntry],
+    base: u32,
+) {
+    for entry in entries {
+        if !matches!(entry.ty, RelocType::MemoryAddrI32) {
+            continue;
+        }
+        let Some(rel) = entry.offset.checked_sub(segment_content_start) else {
+            continue;
+        };
+        let rel = rel as usize;
+        let Some(slot) = payload.get_mut(rel..rel + 4) else {
+            continue;
+        };
+        let mut buf = [0u8; 4];
+        buf.copy_from_slice(slot);
+        // The reloc addend is already folded into the stored value by the
+        // toolchain, so rebasing is a straight `+ base`.
+        let rebased = u32::from_le_bytes(buf).wrapping_add(base);
+        slot.copy_from_slice(&rebased.to_le_bytes());
+    }
+}
+
 /// Errors from relocation-metadata parsing.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum RelocError {
@@ -444,6 +534,49 @@ mod tests {
     use std::path::Path;
 
     const SPIKE_DIR: &str = "/tmp/spike326";
+
+    /// #326 Finding B: a `memory64` `reloc.DATA` entry embeds an 8-byte pointer
+    /// (`MemoryAddrI64`, wire code 16 → `RelocType::Other(16)`) that the
+    /// 4-byte-only rebasing cannot handle, so `has_unhandled_data_addr_relocs`
+    /// must flag it; an `I32` inline pointer must NOT be flagged.
+    #[test]
+    fn unhandled_data_addr_relocs_flags_non_i32_pointers() {
+        let i64_data = RelocInfo {
+            linking_version: Some(2),
+            linking_subsections: vec![],
+            sections: vec![RelocSection {
+                target: RelocTarget::Data,
+                target_section_index: 0,
+                entries: vec![RelocEntry {
+                    ty: RelocType::from_code(16), // R_WASM_MEMORY_ADDR_I64
+                    offset: 0,
+                    index: 0,
+                    addend: 0,
+                }],
+            }],
+        };
+        assert!(i64_data.has_unhandled_data_addr_relocs());
+        // The I64 form is a memory address but NOT a rebasable inline pointer,
+        // so it is excluded from the handled-entries list.
+        assert!(i64_data.data_memory_addr_entries().is_empty());
+
+        let i32_data = RelocInfo {
+            linking_version: Some(2),
+            linking_subsections: vec![],
+            sections: vec![RelocSection {
+                target: RelocTarget::Data,
+                target_section_index: 0,
+                entries: vec![RelocEntry {
+                    ty: RelocType::MemoryAddrI32,
+                    offset: 0,
+                    index: 0,
+                    addend: 0,
+                }],
+            }],
+        };
+        assert!(!i32_data.has_unhandled_data_addr_relocs());
+        assert_eq!(i32_data.data_memory_addr_entries().len(), 1);
+    }
 
     /// Ground-truth `reloc.CODE` entries, from `wasm-tools objdump`.
     fn expected_entries() -> Vec<RelocEntry> {
@@ -689,5 +822,80 @@ mod tests {
         assert!(info.sections.is_empty());
         assert_eq!(info.linking_version, None);
         assert!(!has_reloc_metadata(&[]));
+    }
+
+    /// The MEMORY_ADDR code sites the fuser must rebase are exactly the
+    /// `is_memory_addr()` entries' offsets — index-only relocations (function
+    /// index, etc.) are excluded.
+    #[test]
+    fn code_memory_addr_offsets_selects_only_memory_addr_sites() {
+        // MemoryAddrSleb@62, MemoryAddrLeb@132, plus a non-address
+        // FunctionIndexLeb@5 that must NOT appear.
+        let body: &[u8] = &[
+            0x03, // target section = CODE
+            0x03, // count = 3
+            0x04, 0x3e, 0x03, 0x20, // MemoryAddrSleb off=62 idx=3 add=32
+            0x00, 0x05, 0x01, // FunctionIndexLeb off=5 idx=1 (no addend)
+            0x03, 0x84, 0x01, 0x04, 0x00, // MemoryAddrLeb off=132 idx=4 add=0
+        ];
+        let customs = vec![("reloc.CODE".to_string(), body.to_vec())];
+        let info = parse_reloc_info(&customs).expect("parse");
+        let offsets = info.code_memory_addr_offsets();
+        assert_eq!(offsets.len(), 2);
+        assert!(offsets.contains(&62));
+        assert!(offsets.contains(&132));
+        assert!(!offsets.contains(&5), "index reloc must be excluded");
+    }
+
+    /// #326 Part C: a `reloc.DATA` `MEMORY_ADDR_I32` entry names a 4-byte LE
+    /// absolute pointer inside a data segment's payload; consuming it adds the
+    /// shared-memory base to that pointer. The spike's `.bss` symbols are
+    /// zero-init so no real `reloc.DATA` appears — this hand-built case pins
+    /// the mechanism directly.
+    #[test]
+    fn rebase_data_segment_pointer_adds_base() {
+        // reloc.DATA: target=DATA(=index 5 here, arbitrary), count=1,
+        // MemoryAddrI32(5) off=8 idx=0 add=0.
+        let body: &[u8] = &[
+            0x05, // target section index (DATA)
+            0x01, // count = 1
+            0x05, // MemoryAddrI32
+            0x08, // offset = 8 (data-section-content relative)
+            0x00, // symbol index = 0
+            0x00, // addend = 0
+        ];
+        let customs = vec![("reloc.DATA".to_string(), body.to_vec())];
+        let info = parse_reloc_info(&customs).expect("parse");
+        let entries = info.data_memory_addr_entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].offset, 8);
+
+        // A segment whose payload begins at content offset 6 and holds an
+        // absolute pointer 0x00000010 (=16) at bytes [2..6] — i.e. content
+        // offset 8, matching the reloc. Base = 0x10000 (one page).
+        let mut payload = vec![0xAA, 0xBB, 0x10, 0x00, 0x00, 0x00, 0xCC];
+        rebase_data_segment_pointers(&mut payload, 6, &entries, 0x1_0000);
+        // Pointer at [2..6] rebased from 16 → 16 + 65536.
+        let ptr = u32::from_le_bytes([payload[2], payload[3], payload[4], payload[5]]);
+        assert_eq!(ptr, 16 + 0x1_0000);
+        // Surrounding bytes are untouched.
+        assert_eq!(payload[0], 0xAA);
+        assert_eq!(payload[1], 0xBB);
+        assert_eq!(payload[6], 0xCC);
+    }
+
+    /// A `reloc.DATA` entry that points outside a given segment's payload must
+    /// not touch that segment (it belongs to a different segment).
+    #[test]
+    fn rebase_data_segment_pointer_ignores_out_of_range() {
+        let entries = vec![RelocEntry {
+            ty: RelocType::MemoryAddrI32,
+            offset: 100,
+            index: 0,
+            addend: 0,
+        }];
+        let mut payload = vec![1u8, 0, 0, 0];
+        rebase_data_segment_pointers(&mut payload, 0, &entries, 0x1_0000);
+        assert_eq!(payload, vec![1u8, 0, 0, 0], "out-of-range site untouched");
     }
 }

--- a/meld-core/src/rewriter.rs
+++ b/meld-core/src/rewriter.rs
@@ -94,6 +94,23 @@ pub struct IndexMaps {
     pub memory_initial_pages: Option<u64>,
     /// Scratch locals used for address rebasing
     pub rebase_locals: Option<RebaseLocals>,
+    /// #326: code-section-content byte offsets of this module's
+    /// `R_WASM_MEMORY_ADDR_*` `reloc.CODE` sites (see
+    /// [`crate::reloc::RelocInfo::code_memory_addr_offsets`]).
+    ///
+    /// Present ⟺ the module carries relocation metadata AND address rebasing
+    /// is active. Its presence flips two behaviours during rewriting, so that
+    /// each absolute address is rebased **exactly once**:
+    ///
+    /// * an `i32.const`/`i64.const` address literal flagged by one of these
+    ///   sites has `memory_base_offset` added to its value, and
+    /// * `memarg` offset rebasing switches from the legacy *blanket* form (add
+    ///   the base to every load/store offset) to *reloc-driven* (add it only
+    ///   to the flagged `memarg`s), leaving genuine struct-field offsets alone.
+    ///
+    /// `None` preserves the zero-cost legacy path exactly: no const rebasing,
+    /// and blanket `memarg` rebasing (a no-op when `memory_base_offset == 0`).
+    pub code_addr_relocs: Option<std::collections::HashSet<u32>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -260,32 +277,106 @@ fn rewrite_operators(
     let mut new_offset: u32 = 0;
     let mut base_old: Option<usize> = None;
 
-    for res in reader.into_iter_with_offsets() {
-        let (op, old_pos) = res?;
-        let instrs = rewrite_operator(op, maps)?;
-        if let Some(m) = map.as_mut() {
-            // First operator's absolute position defines the
-            // instruction-stream base; subsequent offsets are relative.
-            let base = *base_old.get_or_insert(old_pos);
-            m.entries.push(InstrOffset {
-                old: (old_pos - base) as u32,
-                new: new_offset,
-            });
-        }
-        for instr in &instrs {
-            if map.is_some() {
-                let mut buf = Vec::new();
-                instr.encode(&mut buf);
-                new_offset = new_offset.saturating_add(buf.len() as u32);
+    match maps.code_addr_relocs.as_ref() {
+        // #326: reloc-driven rebasing needs each operator's END offset to test
+        // whether a MEMORY_ADDR reloc site falls on its immediate, so
+        // materialize the operator stream with positions and look one ahead.
+        // A site at code-relative `r` belongs to the operator whose byte range
+        // `[old_pos, op_end)` contains it. Only the flagged operator is
+        // rebased.
+        Some(relocs) if !relocs.is_empty() => {
+            let ops: Vec<(Operator<'_>, usize)> = reader
+                .into_iter_with_offsets()
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            let ends: Vec<usize> = ops
+                .iter()
+                .skip(1)
+                .map(|(_, pos)| *pos)
+                .chain(std::iter::once(usize::MAX))
+                .collect();
+            for ((op, old_pos), op_end) in ops.into_iter().zip(ends) {
+                let addr_reloc = relocs
+                    .iter()
+                    .any(|&r| (r as usize) >= old_pos && (r as usize) < op_end);
+                emit_operator(
+                    op,
+                    old_pos,
+                    addr_reloc,
+                    maps,
+                    func,
+                    &mut map,
+                    &mut new_offset,
+                    &mut base_old,
+                )?;
             }
-            func.instruction(instr);
+        }
+        _ => {
+            for res in reader.into_iter_with_offsets() {
+                let (op, old_pos) = res?;
+                emit_operator(
+                    op,
+                    old_pos,
+                    false,
+                    maps,
+                    func,
+                    &mut map,
+                    &mut new_offset,
+                    &mut base_old,
+                )?;
+            }
         }
     }
     Ok(map)
 }
 
-/// Convert a wasmparser operator to wasm-encoder instruction with index remapping
-fn rewrite_operator(op: Operator<'_>, maps: &IndexMaps) -> Result<Vec<Instruction<'static>>> {
+/// Rewrite one operator and append it (and any expansion) to `func`, updating
+/// the optional [`InstrOffsetMap`]. `addr_reloc` is true when a MEMORY_ADDR
+/// `reloc.CODE` site lands on this operator's immediate (see
+/// [`IndexMaps::code_addr_relocs`]).
+#[allow(clippy::too_many_arguments)]
+fn emit_operator(
+    op: Operator<'_>,
+    old_pos: usize,
+    addr_reloc: bool,
+    maps: &IndexMaps,
+    func: &mut Function,
+    map: &mut Option<InstrOffsetMap>,
+    new_offset: &mut u32,
+    base_old: &mut Option<usize>,
+) -> Result<()> {
+    let instrs = rewrite_operator(op, maps, addr_reloc)?;
+    if let Some(m) = map.as_mut() {
+        // First operator's absolute position defines the
+        // instruction-stream base; subsequent offsets are relative.
+        let base = *base_old.get_or_insert(old_pos);
+        m.entries.push(InstrOffset {
+            old: (old_pos - base) as u32,
+            new: *new_offset,
+        });
+    }
+    for instr in &instrs {
+        if map.is_some() {
+            let mut buf = Vec::new();
+            instr.encode(&mut buf);
+            *new_offset = new_offset.saturating_add(buf.len() as u32);
+        }
+        func.instruction(instr);
+    }
+    Ok(())
+}
+
+/// Convert a wasmparser operator to wasm-encoder instruction with index remapping.
+///
+/// `addr_reloc` is true when a `R_WASM_MEMORY_ADDR_*` `reloc.CODE` site lands
+/// on this operator's relocatable immediate (#326). It only ever matters under
+/// address rebasing: it selects the `i32.const`/`i64.const` address literals
+/// and the load/store `memarg`s whose offset must be shifted by the
+/// shared-memory base. It is always `false` on the legacy (no-reloc) path.
+fn rewrite_operator(
+    op: Operator<'_>,
+    maps: &IndexMaps,
+    addr_reloc: bool,
+) -> Result<Vec<Instruction<'static>>> {
     use Operator::*;
 
     let instr = match op {
@@ -353,29 +444,29 @@ fn rewrite_operator(op: Operator<'_>, maps: &IndexMaps) -> Result<Vec<Instructio
         ElemDrop { elem_index } => Instruction::ElemDrop(maps.remap_elem(elem_index)),
 
         // Memory operations - need memory index remapping
-        I32Load { memarg } => Instruction::I32Load(convert_memarg(memarg, maps)?),
-        I64Load { memarg } => Instruction::I64Load(convert_memarg(memarg, maps)?),
-        F32Load { memarg } => Instruction::F32Load(convert_memarg(memarg, maps)?),
-        F64Load { memarg } => Instruction::F64Load(convert_memarg(memarg, maps)?),
-        I32Load8S { memarg } => Instruction::I32Load8S(convert_memarg(memarg, maps)?),
-        I32Load8U { memarg } => Instruction::I32Load8U(convert_memarg(memarg, maps)?),
-        I32Load16S { memarg } => Instruction::I32Load16S(convert_memarg(memarg, maps)?),
-        I32Load16U { memarg } => Instruction::I32Load16U(convert_memarg(memarg, maps)?),
-        I64Load8S { memarg } => Instruction::I64Load8S(convert_memarg(memarg, maps)?),
-        I64Load8U { memarg } => Instruction::I64Load8U(convert_memarg(memarg, maps)?),
-        I64Load16S { memarg } => Instruction::I64Load16S(convert_memarg(memarg, maps)?),
-        I64Load16U { memarg } => Instruction::I64Load16U(convert_memarg(memarg, maps)?),
-        I64Load32S { memarg } => Instruction::I64Load32S(convert_memarg(memarg, maps)?),
-        I64Load32U { memarg } => Instruction::I64Load32U(convert_memarg(memarg, maps)?),
-        I32Store { memarg } => Instruction::I32Store(convert_memarg(memarg, maps)?),
-        I64Store { memarg } => Instruction::I64Store(convert_memarg(memarg, maps)?),
-        F32Store { memarg } => Instruction::F32Store(convert_memarg(memarg, maps)?),
-        F64Store { memarg } => Instruction::F64Store(convert_memarg(memarg, maps)?),
-        I32Store8 { memarg } => Instruction::I32Store8(convert_memarg(memarg, maps)?),
-        I32Store16 { memarg } => Instruction::I32Store16(convert_memarg(memarg, maps)?),
-        I64Store8 { memarg } => Instruction::I64Store8(convert_memarg(memarg, maps)?),
-        I64Store16 { memarg } => Instruction::I64Store16(convert_memarg(memarg, maps)?),
-        I64Store32 { memarg } => Instruction::I64Store32(convert_memarg(memarg, maps)?),
+        I32Load { memarg } => Instruction::I32Load(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Load { memarg } => Instruction::I64Load(convert_memarg(memarg, maps, addr_reloc)?),
+        F32Load { memarg } => Instruction::F32Load(convert_memarg(memarg, maps, addr_reloc)?),
+        F64Load { memarg } => Instruction::F64Load(convert_memarg(memarg, maps, addr_reloc)?),
+        I32Load8S { memarg } => Instruction::I32Load8S(convert_memarg(memarg, maps, addr_reloc)?),
+        I32Load8U { memarg } => Instruction::I32Load8U(convert_memarg(memarg, maps, addr_reloc)?),
+        I32Load16S { memarg } => Instruction::I32Load16S(convert_memarg(memarg, maps, addr_reloc)?),
+        I32Load16U { memarg } => Instruction::I32Load16U(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Load8S { memarg } => Instruction::I64Load8S(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Load8U { memarg } => Instruction::I64Load8U(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Load16S { memarg } => Instruction::I64Load16S(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Load16U { memarg } => Instruction::I64Load16U(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Load32S { memarg } => Instruction::I64Load32S(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Load32U { memarg } => Instruction::I64Load32U(convert_memarg(memarg, maps, addr_reloc)?),
+        I32Store { memarg } => Instruction::I32Store(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Store { memarg } => Instruction::I64Store(convert_memarg(memarg, maps, addr_reloc)?),
+        F32Store { memarg } => Instruction::F32Store(convert_memarg(memarg, maps, addr_reloc)?),
+        F64Store { memarg } => Instruction::F64Store(convert_memarg(memarg, maps, addr_reloc)?),
+        I32Store8 { memarg } => Instruction::I32Store8(convert_memarg(memarg, maps, addr_reloc)?),
+        I32Store16 { memarg } => Instruction::I32Store16(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Store8 { memarg } => Instruction::I64Store8(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Store16 { memarg } => Instruction::I64Store16(convert_memarg(memarg, maps, addr_reloc)?),
+        I64Store32 { memarg } => Instruction::I64Store32(convert_memarg(memarg, maps, addr_reloc)?),
         MemorySize { mem, .. } => {
             if maps.address_rebasing {
                 let pages = maps.memory_initial_pages.ok_or_else(|| {
@@ -427,9 +518,25 @@ fn rewrite_operator(op: Operator<'_>, maps: &IndexMaps) -> Result<Vec<Instructio
             return rewrite_memory_fill(mem, maps);
         }
 
-        // Constants
-        I32Const { value } => Instruction::I32Const(value),
-        I64Const { value } => Instruction::I64Const(value),
+        // Constants. #326: an `i32.const`/`i64.const` flagged by a
+        // MEMORY_ADDR `reloc.CODE` site is an absolute linear-memory address
+        // baked into the code; add the shared-memory base to its value so it
+        // points into this module's rebased window. Bare integer constants
+        // (never flagged) are emitted verbatim.
+        I32Const { value } => {
+            if maps.address_rebasing && addr_reloc {
+                Instruction::I32Const(value.wrapping_add(maps.memory_base_offset as i32))
+            } else {
+                Instruction::I32Const(value)
+            }
+        }
+        I64Const { value } => {
+            if maps.address_rebasing && addr_reloc {
+                Instruction::I64Const(value.wrapping_add(maps.memory_base_offset as i64))
+            } else {
+                Instruction::I64Const(value)
+            }
+        }
         F32Const { value } => Instruction::F32Const(f32::from_bits(value.bits()).into()),
         F64Const { value } => Instruction::F64Const(f64::from_bits(value.bits()).into()),
 
@@ -681,7 +788,13 @@ fn append_rebased_address(
     local_index: u32,
 ) -> Result<()> {
     instrs.push(Instruction::LocalGet(local_index));
-    if maps.memory_base_offset != 0 {
+    // #326: this is the legacy *access-point* rebasing — it adds the base to a
+    // bulk-memory op's runtime address operand. Under reloc-driven (*source-
+    // point*) rebasing the operand is already rebased at its origin
+    // (`i32.const` / `reloc.DATA`), so applying it again here would
+    // double-count. Skip it whenever the module carries reloc metadata; keep it
+    // for the legacy no-reloc path.
+    if maps.memory_base_offset != 0 && maps.code_addr_relocs.is_none() {
         instrs.push(base_const_instruction(maps)?);
         instrs.push(base_add_instruction(maps));
     }
@@ -716,14 +829,28 @@ fn convert_block_type(bt: WpBlockType, maps: &IndexMaps) -> Result<BlockType> {
     })
 }
 
-/// Convert wasmparser MemArg to wasm-encoder MemArg
-fn convert_memarg(ma: WpMemArg, maps: &IndexMaps) -> Result<MemArg> {
-    let offset =
-        ma.offset
-            .checked_add(maps.memory_base_offset)
-            .ok_or(Error::UnsupportedFeature(
-                "memory offset overflow during rebasing".to_string(),
-            ))?;
+/// Convert wasmparser MemArg to wasm-encoder MemArg.
+///
+/// The static `offset` field of a load/store is rebased by
+/// `memory_base_offset` when it encodes an absolute address. #326 makes this
+/// precise: when the module carries reloc metadata
+/// ([`IndexMaps::code_addr_relocs`] is `Some`), the offset is rebased **only**
+/// when `addr_reloc` says a MEMORY_ADDR site lands on it — genuine struct-field
+/// offsets are left alone, and an accompanying rebased `i32.const` address is
+/// not double-counted. With no reloc metadata the legacy blanket behaviour is
+/// kept (rebase every offset — a no-op when `memory_base_offset == 0`).
+fn convert_memarg(ma: WpMemArg, maps: &IndexMaps, addr_reloc: bool) -> Result<MemArg> {
+    let rebase = match maps.code_addr_relocs {
+        Some(_) => addr_reloc,
+        None => true,
+    };
+    let base = if rebase { maps.memory_base_offset } else { 0 };
+    let offset = ma
+        .offset
+        .checked_add(base)
+        .ok_or(Error::UnsupportedFeature(
+            "memory offset overflow during rebasing".to_string(),
+        ))?;
     Ok(MemArg {
         offset,
         align: ma.align as u32,
@@ -858,6 +985,7 @@ mod tests {
                 dst_mem: 0,
             },
             &maps,
+            false,
         )
         .unwrap();
 
@@ -885,7 +1013,7 @@ mod tests {
             value: 3,
         });
 
-        let instrs = rewrite_operator(Operator::MemoryFill { mem: 0 }, &maps).unwrap();
+        let instrs = rewrite_operator(Operator::MemoryFill { mem: 0 }, &maps, false).unwrap();
 
         assert!(
             instrs
@@ -914,6 +1042,7 @@ mod tests {
                 mem: 0,
             },
             &maps,
+            false,
         )
         .unwrap();
 
@@ -935,7 +1064,7 @@ mod tests {
         maps.memory64 = false;
         maps.memory_initial_pages = Some(3);
 
-        let instrs = rewrite_operator(Operator::MemorySize { mem: 0 }, &maps).unwrap();
+        let instrs = rewrite_operator(Operator::MemorySize { mem: 0 }, &maps, false).unwrap();
         assert!(matches!(instrs.as_slice(), [Instruction::I32Const(3)]));
     }
 
@@ -944,7 +1073,7 @@ mod tests {
         let mut maps = IndexMaps::new();
         maps.address_rebasing = true;
 
-        assert!(rewrite_operator(Operator::MemoryGrow { mem: 0 }, &maps).is_err());
+        assert!(rewrite_operator(Operator::MemoryGrow { mem: 0 }, &maps, false).is_err());
     }
 
     /// #298 part (b): with the (default-off) tolerant flag set, a `memory.grow`
@@ -957,7 +1086,7 @@ mod tests {
         maps.address_rebasing = true;
         maps.defer_grow_under_rebase = true;
 
-        let instrs = rewrite_operator(Operator::MemoryGrow { mem: 0 }, &maps).unwrap();
+        let instrs = rewrite_operator(Operator::MemoryGrow { mem: 0 }, &maps, false).unwrap();
         assert!(matches!(instrs.as_slice(), [Instruction::Unreachable]));
     }
 
@@ -968,7 +1097,7 @@ mod tests {
         let mut maps = IndexMaps::new();
         maps.address_rebasing = true;
         assert!(!maps.defer_grow_under_rebase, "flag must default off");
-        assert!(rewrite_operator(Operator::MemoryGrow { mem: 0 }, &maps).is_err());
+        assert!(rewrite_operator(Operator::MemoryGrow { mem: 0 }, &maps, false).is_err());
     }
 
     #[test]
@@ -1080,7 +1209,7 @@ mod tests {
     #[test]
     fn test_rewrite_call_remaps_function_index() {
         let maps = make_test_maps();
-        let instrs = rewrite_operator(Operator::Call { function_index: 0 }, &maps).unwrap();
+        let instrs = rewrite_operator(Operator::Call { function_index: 0 }, &maps, false).unwrap();
         assert_eq!(instrs.len(), 1);
         assert!(
             matches!(instrs[0], Instruction::Call(5)),
@@ -1099,6 +1228,7 @@ mod tests {
                 table_index: 0,
             },
             &maps,
+            false,
         )
         .unwrap();
         assert_eq!(instrs.len(), 1);
@@ -1118,7 +1248,8 @@ mod tests {
     fn test_rewrite_global_get_set_remaps() {
         let maps = make_test_maps();
 
-        let get_instrs = rewrite_operator(Operator::GlobalGet { global_index: 0 }, &maps).unwrap();
+        let get_instrs =
+            rewrite_operator(Operator::GlobalGet { global_index: 0 }, &maps, false).unwrap();
         assert_eq!(get_instrs.len(), 1);
         assert!(
             matches!(get_instrs[0], Instruction::GlobalGet(7)),
@@ -1126,7 +1257,8 @@ mod tests {
             get_instrs[0]
         );
 
-        let set_instrs = rewrite_operator(Operator::GlobalSet { global_index: 0 }, &maps).unwrap();
+        let set_instrs =
+            rewrite_operator(Operator::GlobalSet { global_index: 0 }, &maps, false).unwrap();
         assert_eq!(set_instrs.len(), 1);
         assert!(
             matches!(set_instrs[0], Instruction::GlobalSet(7)),
@@ -1140,7 +1272,7 @@ mod tests {
         let maps = make_test_maps();
 
         // TableGet
-        let instrs = rewrite_operator(Operator::TableGet { table: 0 }, &maps).unwrap();
+        let instrs = rewrite_operator(Operator::TableGet { table: 0 }, &maps, false).unwrap();
         assert_eq!(instrs.len(), 1);
         assert!(
             matches!(instrs[0], Instruction::TableGet(3)),
@@ -1149,7 +1281,7 @@ mod tests {
         );
 
         // TableSet
-        let instrs = rewrite_operator(Operator::TableSet { table: 0 }, &maps).unwrap();
+        let instrs = rewrite_operator(Operator::TableSet { table: 0 }, &maps, false).unwrap();
         assert_eq!(instrs.len(), 1);
         assert!(
             matches!(instrs[0], Instruction::TableSet(3)),
@@ -1158,7 +1290,7 @@ mod tests {
         );
 
         // TableGrow
-        let instrs = rewrite_operator(Operator::TableGrow { table: 0 }, &maps).unwrap();
+        let instrs = rewrite_operator(Operator::TableGrow { table: 0 }, &maps, false).unwrap();
         assert_eq!(instrs.len(), 1);
         assert!(
             matches!(instrs[0], Instruction::TableGrow(3)),
@@ -1167,7 +1299,7 @@ mod tests {
         );
 
         // TableSize
-        let instrs = rewrite_operator(Operator::TableSize { table: 0 }, &maps).unwrap();
+        let instrs = rewrite_operator(Operator::TableSize { table: 0 }, &maps, false).unwrap();
         assert_eq!(instrs.len(), 1);
         assert!(
             matches!(instrs[0], Instruction::TableSize(3)),
@@ -1176,7 +1308,7 @@ mod tests {
         );
 
         // TableFill
-        let instrs = rewrite_operator(Operator::TableFill { table: 0 }, &maps).unwrap();
+        let instrs = rewrite_operator(Operator::TableFill { table: 0 }, &maps, false).unwrap();
         assert_eq!(instrs.len(), 1);
         assert!(
             matches!(instrs[0], Instruction::TableFill(3)),
@@ -1197,6 +1329,7 @@ mod tests {
                 src_table: 1,
             },
             &maps,
+            false,
         )
         .unwrap();
         assert_eq!(instrs.len(), 1);
@@ -1226,6 +1359,7 @@ mod tests {
                 src_mem: 1,
             },
             &maps,
+            false,
         )
         .unwrap();
 
@@ -1255,6 +1389,7 @@ mod tests {
                 },
             },
             &maps,
+            false,
         )
         .unwrap();
         assert_eq!(instrs.len(), 1);
@@ -1279,6 +1414,7 @@ mod tests {
                 },
             },
             &maps,
+            false,
         )
         .unwrap();
         assert_eq!(instrs.len(), 1);
@@ -1298,7 +1434,8 @@ mod tests {
     fn test_rewrite_ref_func_remaps() {
         let maps = make_test_maps();
 
-        let instrs = rewrite_operator(Operator::RefFunc { function_index: 0 }, &maps).unwrap();
+        let instrs =
+            rewrite_operator(Operator::RefFunc { function_index: 0 }, &maps, false).unwrap();
         assert_eq!(instrs.len(), 1);
         assert!(
             matches!(instrs[0], Instruction::RefFunc(5)),

--- a/meld-core/src/segments.rs
+++ b/meld-core/src/segments.rs
@@ -127,6 +127,11 @@ pub struct ParsedDataSegment {
     pub mode: DataSegmentMode_,
     /// Raw data bytes
     pub data: Vec<u8>,
+    /// Byte offset of this segment's payload (`data`) bytes within the data
+    /// section's *content* — the coordinate space `reloc.DATA` entry offsets
+    /// use (#326 Part C). Lets the fuser locate which absolute pointers inside
+    /// `data` a `reloc.DATA` site names, to rebase them for shared memory.
+    pub content_offset: u32,
 }
 
 /// Data segment mode
@@ -288,9 +293,15 @@ pub fn parse_data_segments(module: &CoreModule) -> Result<Vec<ParsedDataSegment>
             wasmparser::DataKind::Passive => DataSegmentMode_::Passive,
         };
 
+        // `data.range` covers this whole segment entry within the section
+        // content (base-0 reader); the payload bytes are its final `len` bytes,
+        // so their start is `range.end - len` — the data-section-content offset
+        // that `reloc.DATA` sites are relative to.
+        let content_offset = (data.range.end - data.data.len()) as u32;
         segments.push(ParsedDataSegment {
             mode,
             data: data.data.to_vec(),
+            content_offset,
         });
     }
 
@@ -745,6 +756,7 @@ mod tests {
                 offset_value: Some(ConstExprValue::I32(10)),
             },
             data: vec![1, 2, 3],
+            content_offset: 0,
         };
 
         let mut maps = IndexMaps::new();
@@ -774,6 +786,7 @@ mod tests {
                 offset_value: None,
             },
             data: vec![1],
+            content_offset: 0,
         };
 
         let mut maps = IndexMaps::new();
@@ -880,6 +893,7 @@ mod tests {
                 offset_value: Some(ConstExprValue::I32(0)),
             },
             data: vec![0xAA, 0xBB],
+            content_offset: 0,
         };
 
         let mut maps = IndexMaps::new();
@@ -909,6 +923,7 @@ mod tests {
                 offset_value: None,
             },
             data: vec![0xFF],
+            content_offset: 0,
         };
 
         let mut maps = IndexMaps::new();

--- a/meld-core/tests/rebasing_end_to_end.rs
+++ b/meld-core/tests/rebasing_end_to_end.rs
@@ -1,8 +1,8 @@
 use meld_core::{Fuser, FuserConfig, MemoryStrategy};
 use wasm_encoder::{
-    CodeSection, Component, DataCountSection, DataSection, DataSegment, DataSegmentMode,
-    ExportKind, ExportSection, Function, FunctionSection, Instruction, MemorySection, MemoryType,
-    Module, ModuleSection, TypeSection,
+    CodeSection, Component, CustomSection, DataCountSection, DataSection, DataSegment,
+    DataSegmentMode, ExportKind, ExportSection, Function, FunctionSection, Instruction, MemArg,
+    MemorySection, MemoryType, Module, ModuleSection, TypeSection, ValType,
 };
 use wasmtime::{Config, Engine, Instance, Module as RuntimeModule, Store};
 
@@ -236,13 +236,331 @@ fn test_298_real_wit_bindgen_component_blocks_shared_rebase() {
         .add_component_named(&component, Some("strings-simple"))
         .unwrap();
 
-    let err = fuser.fuse().expect_err(
-        "today: a real wit-bindgen component (cabi_realloc-backed memory.grow) \
-         must not fuse under shared+rebase",
-    );
+    let err = fuser
+        .fuse()
+        .expect_err("a real wit-bindgen component must not fuse under shared+rebase");
     let msg = err.to_string();
+    // The invariant this pins is that a real wit-bindgen artifact is REJECTED
+    // under shared+rebase — the corruption meld must not silently emit. There
+    // are now two hard-fail gates and either satisfies the invariant:
+    //   * the #298 `memory.grow` rebase rejection (the vestigial allocator), or
+    //   * #326's path-F `MissingRelocMetadata`: this artifact's non-base module
+    //     carries no relocation metadata yet does direct memory access, so its
+    //     absolute addresses cannot be rebased safely. That gate is checked at
+    //     merge time, *before* the rewriter reaches the `memory.grow`, so on
+    //     this fixture #326 now fires first.
     assert!(
-        msg.contains("memory.grow"),
-        "expected the memory.grow rebase rejection on a real wit-bindgen artifact, got: {msg}"
+        msg.contains("memory.grow") || msg.contains("relocation metadata"),
+        "expected shared+rebase to reject the real wit-bindgen artifact \
+         (memory.grow or missing-reloc-metadata), got: {msg}"
+    );
+}
+
+// ─── #326: relocation-driven address rebasing ──────────────────────────────
+
+const RELOC_ADDR: i32 = 0x100;
+const RELOC_VAL: i32 = 0xAB;
+
+/// The base module (component-a): a 1-page shared memory exported as "memory".
+/// It occupies window `[0, 64KiB)`, so the reloc module below is placed at base
+/// 64KiB. No code ⟹ no direct memory access ⟹ no relocs required (base 0).
+fn build_reloc_base_module() -> Module {
+    let mut exports = ExportSection::new();
+    exports.export("memory", ExportKind::Memory, 0);
+
+    let mut module = Module::new();
+    module.section(&shared_memory_section()).section(&exports);
+    module
+}
+
+/// Add the sections of the reloc module: a 1-page shared memory and three
+/// functions. `b_store` writes `RELOC_VAL` through the **absolute** address
+/// `RELOC_ADDR`; `b_load` reads it back; `b_get_addr` simply RETURNS the
+/// absolute address literal. Every `i32.const RELOC_ADDR` is a site the
+/// synthetic `reloc.CODE` MEMORY_ADDR entry flags.
+///
+/// `b_get_addr` is the real discriminator: it uses the address as a *value*
+/// (as canonical-ABI code does when it takes `&BUF` to hand to `memcpy`), where
+/// there is no load/store `memarg` for the legacy access-point rebasing to
+/// "accidentally" compensate. Pre-fix it returns the un-rebased `RELOC_ADDR`
+/// (pointing into component-a's window); post-fix it returns `base+RELOC_ADDR`.
+/// The store/load `memarg` offsets are 0 (genuine, not addresses) so they must
+/// NOT be rebased — proving const-rebase and (conditional) memarg-rebase do not
+/// double-count.
+fn add_reloc_module_sections(module: &mut Module) {
+    let mut types = TypeSection::new();
+    types.ty().function([], []); // type 0: b_store: () -> ()
+    types.ty().function([], [ValType::I32]); // type 1: () -> i32
+
+    let mut functions = FunctionSection::new();
+    functions.function(0);
+    functions.function(1);
+    functions.function(1);
+
+    let mut exports = ExportSection::new();
+    exports.export("b_store", ExportKind::Func, 0);
+    exports.export("b_load", ExportKind::Func, 1);
+    exports.export("b_get_addr", ExportKind::Func, 2);
+
+    let zero_memarg = MemArg {
+        offset: 0,
+        align: 0,
+        memory_index: 0,
+    };
+
+    let mut code = CodeSection::new();
+    let mut store = Function::new([]);
+    store.instruction(&Instruction::I32Const(RELOC_ADDR)); // absolute address (reloc-flagged)
+    store.instruction(&Instruction::I32Const(RELOC_VAL));
+    store.instruction(&Instruction::I32Store8(zero_memarg));
+    store.instruction(&Instruction::End);
+    code.function(&store);
+
+    let mut load = Function::new([]);
+    load.instruction(&Instruction::I32Const(RELOC_ADDR)); // absolute address (reloc-flagged)
+    load.instruction(&Instruction::I32Load8U(zero_memarg));
+    load.instruction(&Instruction::End);
+    code.function(&load);
+
+    let mut get_addr = Function::new([]);
+    get_addr.instruction(&Instruction::I32Const(RELOC_ADDR)); // returned as a VALUE (reloc-flagged)
+    get_addr.instruction(&Instruction::End);
+    code.function(&get_addr);
+
+    module
+        .section(&types)
+        .section(&functions)
+        .section(&shared_memory_section())
+        .section(&exports)
+        .section(&code);
+}
+
+fn write_uleb(out: &mut Vec<u8>, mut v: u32) {
+    loop {
+        let mut byte = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if v == 0 {
+            break;
+        }
+    }
+}
+
+/// Parse `module_bytes` and return the code-section-content byte offset of the
+/// immediate of every `i32.const flag_value` — the coordinate space a
+/// `reloc.CODE` MEMORY_ADDR entry uses (`opcode_pos - code_content_start + 1`,
+/// matching how meld's rewriter walks operators over the sliced code section).
+fn find_i32const_reloc_offsets(module_bytes: &[u8], flag_value: i32) -> Vec<u32> {
+    let mut code_start = None;
+    let mut offsets = Vec::new();
+    for payload in wasmparser::Parser::new(0).parse_all(module_bytes) {
+        match payload.expect("payload") {
+            wasmparser::Payload::CodeSectionStart { range, .. } => code_start = Some(range.start),
+            wasmparser::Payload::CodeSectionEntry(body) => {
+                let cs = code_start.expect("code section start seen first");
+                for item in body
+                    .get_operators_reader()
+                    .expect("operators")
+                    .into_iter_with_offsets()
+                {
+                    let (op, pos) = item.expect("operator");
+                    if let wasmparser::Operator::I32Const { value } = op
+                        && value == flag_value
+                    {
+                        offsets.push((pos - cs + 1) as u32);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    offsets
+}
+
+/// Build a `reloc.CODE` custom-section body flagging each offset as a
+/// `MemoryAddrSleb` site (`type=4, offset, index=0, addend=0`).
+fn build_reloc_code_body(offsets: &[u32]) -> Vec<u8> {
+    let mut body = Vec::new();
+    write_uleb(&mut body, 3); // target section index (cosmetic — consumer ignores it)
+    write_uleb(&mut body, offsets.len() as u32);
+    for &off in offsets {
+        body.push(4u8); // R_WASM_MEMORY_ADDR_SLEB
+        write_uleb(&mut body, off);
+        write_uleb(&mut body, 0); // symbol index
+        body.push(0u8); // addend = 0 (sleb)
+    }
+    body
+}
+
+/// The reloc module wrapped as a component. Built in two passes: a dry build to
+/// locate the address-literal offsets, then the real build with a `linking`
+/// (version 2) and `reloc.CODE` custom section appended. Custom sections sit
+/// after the code section, so appending them does not shift the offsets found
+/// in the dry pass.
+fn build_reloc_component() -> Vec<u8> {
+    let mut dry = Module::new();
+    add_reloc_module_sections(&mut dry);
+    let dry_bytes = dry.finish();
+    let offsets = find_i32const_reloc_offsets(&dry_bytes, RELOC_ADDR);
+    assert_eq!(offsets.len(), 3, "three i32.const address literals to flag");
+    let reloc_code = build_reloc_code_body(&offsets);
+
+    let mut module = Module::new();
+    add_reloc_module_sections(&mut module);
+    module.section(&CustomSection {
+        name: "linking".into(),
+        data: vec![0x02].into(), // version 2, no subsections
+    });
+    module.section(&CustomSection {
+        name: "reloc.CODE".into(),
+        data: reloc_code.into(),
+    });
+    build_component(module)
+}
+
+/// True if the core module `bytes` carries a top-level custom section `name`.
+fn has_custom_section(bytes: &[u8], name: &str) -> bool {
+    wasmparser::Parser::new(0)
+        .parse_all(bytes)
+        .any(|p| matches!(p, Ok(wasmparser::Payload::CustomSection(r)) if r.name() == name))
+}
+
+/// #326 behavioural oracle: fusing a relocatable module into shared memory at a
+/// non-zero base must rebase its absolute `i32.const` addresses.
+///
+/// The discriminator is `b_get_addr`, which returns the absolute address of the
+/// module's `BUF` as a *value* (what canonical-ABI code does when it takes
+/// `&BUF` to pass to `memcpy`). `b_store` first writes `0xAB` at that address.
+///
+/// * BEFORE the reloc-consumer fix the `i32.const RELOC_ADDR` is left
+///   un-rebased, so `b_get_addr` returns `RELOC_ADDR` (0x100) — an address in
+///   component-a's window. `read_shared` at that returned address reads `0`
+///   (component-a never wrote there): the two assertions below FAIL.
+///   (Note: `b_store`'s own byte still lands at `base+RELOC_ADDR` even pre-fix
+///   because the legacy *access-point* rebasing rebases the store's `memarg`
+///   offset — which is exactly why a store-and-read-back oracle would NOT
+///   distinguish, and why the discriminator uses the address as a value.)
+/// * AFTER the fix `b_get_addr` returns `base+RELOC_ADDR`, and `read_shared` at
+///   that address reads back the `0xAB` written by `b_store`.
+#[test]
+fn test_326_reloc_const_rebasing_end_to_end() {
+    let component_a = build_component(build_reloc_base_module());
+    let component_b = build_reloc_component();
+
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::SharedMemory,
+        address_rebasing: true,
+        ..Default::default()
+    };
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&component_a, Some("component-a"))
+        .unwrap();
+    fuser
+        .add_component_named(&component_b, Some("component-b"))
+        .unwrap();
+
+    let fused = fuser.fuse().unwrap();
+
+    // Part C: the consumed reloc/linking metadata must not survive fusion.
+    assert!(
+        !has_custom_section(&fused, "reloc.CODE"),
+        "reloc.CODE must be stripped from the fused output"
+    );
+    assert!(
+        !has_custom_section(&fused, "linking"),
+        "linking must be stripped from the fused output"
+    );
+
+    let mut engine_config = Config::new();
+    engine_config.wasm_threads(true);
+    engine_config.shared_memory(true);
+    engine_config.wasm_bulk_memory(true);
+
+    let engine = Engine::new(&engine_config).unwrap();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    let b_store = instance
+        .get_typed_func::<(), ()>(&mut store, "b_store")
+        .unwrap();
+    let b_load = instance
+        .get_typed_func::<(), i32>(&mut store, "b_load")
+        .unwrap();
+    let b_get_addr = instance
+        .get_typed_func::<(), i32>(&mut store, "b_get_addr")
+        .unwrap();
+
+    b_store.call(&mut store, ()).unwrap();
+
+    let memory = instance
+        .get_shared_memory(&mut store, "memory")
+        .expect("shared memory export not found");
+    let base = WASM_PAGE_SIZE; // component-b is placed at page 1
+
+    // DISCRIMINATOR 1: the address literal, used as a value, must be rebased.
+    let addr = b_get_addr.call(&mut store, ()).unwrap();
+    assert_eq!(
+        addr,
+        (base + RELOC_ADDR as usize) as i32,
+        "b_get_addr must return the REBASED address base+0x100 (pre-fix: 0x100)"
+    );
+
+    // DISCRIMINATOR 2 (behavioural): the address the module computes for BUF
+    // must actually point at the byte `b_store` wrote. Pre-fix `addr` is 0x100
+    // (component-a's window, never written) so this reads 0.
+    let via_addr = read_shared(&memory, addr as usize, 1);
+    assert_eq!(
+        via_addr,
+        vec![RELOC_VAL as u8],
+        "the module's computed BUF address must point at the written byte"
+    );
+
+    // Sanity: the store landed at the rebased window and `b_load` reads it back.
+    // (These pass pre-fix too, via the legacy access-point memarg rebasing.)
+    assert_eq!(
+        read_shared(&memory, base + RELOC_ADDR as usize, 1),
+        vec![RELOC_VAL as u8]
+    );
+    assert_eq!(b_load.call(&mut store, ()).unwrap(), RELOC_VAL);
+}
+
+/// #326 Part A (path-F): a module doing direct memory access, placed at a
+/// non-zero shared-memory base but carrying NO relocation metadata, cannot have
+/// its absolute addresses rebased safely, so fusion must hard-fail with
+/// `MissingRelocMetadata` rather than silently emit a colliding module.
+#[test]
+fn test_326_shared_rebase_without_relocs_hard_errors() {
+    let component_a = build_component(build_reloc_base_module());
+
+    // Same direct-memory module as the oracle, but WITHOUT the reloc.CODE /
+    // linking custom sections.
+    let mut module = Module::new();
+    add_reloc_module_sections(&mut module);
+    let component_b = build_component(module);
+
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::SharedMemory,
+        address_rebasing: true,
+        ..Default::default()
+    };
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&component_a, Some("component-a"))
+        .unwrap();
+    fuser
+        .add_component_named(&component_b, Some("non-relocatable"))
+        .unwrap();
+
+    let err = fuser
+        .fuse()
+        .expect_err("shared+rebase of a non-relocatable direct-memory module must fail");
+    assert!(
+        matches!(err, meld_core::Error::MissingRelocMetadata { .. }),
+        "expected MissingRelocMetadata, got: {err:?}"
     );
 }

--- a/safety/adr/ADR-6-shared-memory-address-relocation.md
+++ b/safety/adr/ADR-6-shared-memory-address-relocation.md
@@ -81,10 +81,17 @@ metadata, `--memory shared` stays a hard error (path-F) rather than silently
 corrupting — never a plausible-but-wrong output (LS-D-1 discipline).
 
 path-E is **rejected** (component pipeline cannot carry PIC). The producer cost
-of path-D is a build helper on the gale side (rustc hardcodes
-`--export=__heap_base/__data_end --gc-sections`, which fights `--relocatable`;
-producing a relocatable core needs `--emit=obj` + manual `wasm-ld -r`) — filed
-as gale#168.
+of path-D is a single build flag: **`cargo rustc … -- -C link-arg=--emit-relocs`**
+keeps `reloc.CODE`/`reloc.DATA` in the *final linked* module — a valid,
+self-contained core (table + memory defined, no dangling imports) that also
+carries `linking` v2 + `reloc.*`. This is strictly better than the `--emit=obj`
+→ `wasm-ld -r` route the spike used: a relocatable *object* is under-linked and
+`wasm-tools component new` rejects it (dangling `env::__indirect_function_table`),
+whereas `--emit-relocs` yields a linked module `component new` accepts, importing
+neither `__memory_base` nor `memory` as globals (so it stays inside the no-PIC
+contract). Verified gale-side across all six gust:os cores and through
+`wac plug` — the composite carries one `reloc.CODE` + `linking` per inner core,
+so every core's metadata reaches meld unstripped (gale#168, RESOLVED gale-side).
 
 Locus of fix: **hybrid** — meld consumes; the producer must emit relocatable
 cores. Oracle: the gating fixtures above, derived from the spike, reproducing

--- a/safety/adr/ADR-6-shared-memory-address-relocation.md
+++ b/safety/adr/ADR-6-shared-memory-address-relocation.md
@@ -1,0 +1,102 @@
+---
+id: ADR-6
+type: design-question
+title: Address relocation for the shared-memory fusion mode
+status: resolved
+gating-fixtures:
+  - rebasing_end_to_end::reloc_326_static_addr_rebased_shared
+  - rebasing_end_to_end::reloc_326_data_pointer_rebased_shared
+design-paths:
+  - path-D — relocatable inputs; meld consumes `linking` + `reloc.CODE`/`reloc.DATA` and rebases every `R_WASM_MEMORY_ADDR_*` site by the module's shared-memory base (chosen)
+  - path-E — PIC / dylink inputs; meld assigns each module a window and supplies `__memory_base` (rejected — `wasm-tools component new` refuses a core that imports memory/base globals)
+  - path-F — refuse; keep `--memory shared` a hard error on non-relocatable inputs, force multi-memory (retained as the fallback when path-D's metadata is absent)
+---
+
+# ADR-6 — Address relocation for the shared-memory fusion mode
+
+## Context
+
+ADR-4 chose **multi-memory** as the committed isolation model and retained
+**single shared memory** (`meld fuse --memory shared`) as a *secondary* mode
+for the single-address-space MCU lowering (gale Pixhawk / gust:os, meld#298,
+meld#299). meld#326 proved that secondary mode is **unsound**: when meld places
+component *k*'s linear memory at base `Bₖ` in the shared space, component *k*'s
+code still computes addresses as if its memory started at 0. The rewriter today
+rebases only the *static* memarg offset and bulk-memory operands — never the
+*dynamic* address operand of ordinary loads/stores, nor absolute `i32.const`
+address literals. So any component that writes through a computed pointer
+silently collides with a neighbour.
+
+gale supplied two runtime datapoints (meld#326, qemu-cortex-m3):
+
+1. **`list<u8>` buffer content** — `log.line(b"gust:os up\n")` delivers 11 bytes
+   but the first 7 read as 0; the canonical-ABI `cabi_realloc` `memcpy` source
+   address is not rebased.
+2. **`static mut` persistence** — `DONE[0] = true` is written but the next
+   `poll` reads it back `false`; a store to a `static mut` at an absolute
+   `i32.const` address lands in the wrong window. This proves the defect is not
+   buffer-specific — it corrupts *any* provider that writes into fused shared
+   memory. Only stateless-read providers (gust:os/time) escape.
+
+This is the LS-M-11 hazard. The gate shipped in v0.38.0 (Auto → multi-memory)
+mitigates it by *avoiding* shared mode; ADR-6 decides how to make shared mode
+*correct* when a caller genuinely needs the single address space.
+
+## The design space and the spike
+
+A finished non-PIC, reloc-stripped module cannot be relocated: the information
+saying "*this* `i32.const` is an address" was destroyed by `wasm-ld` at final
+link, and no heuristic recovers it soundly (an address is indistinguishable
+from an integer). This matches the whole ecosystem — every tool that shares one
+linear memory requires **either** PIC inputs (Emscripten MAIN/SIDE_MODULE,
+`wasm-tools component link`, `dylink.0`) **or** relocation metadata (`wasm-ld`
+on object files). So the real question is an *input contract*, and it forks D/E/F.
+
+A spike (`/tmp/spike326`, a gale-shaped `#![no_std]` cdylib reproducing both
+datapoints) settled it empirically:
+
+- **path-E (PIC) is architecturally excluded.** `wasm-tools component new`
+  refuses a PIC/dylink core: *"failed to resolve import `env::__memory_base` …
+  module is only allowed to import functions."* A Component-Model core may
+  import only functions; a dylink library imports `memory`/`__memory_base`/
+  `__table_base` as globals. A PIC core therefore can never become a component.
+- **path-D (relocatable) survives.** A relocatable core (`--emit=obj` →
+  `wasm-ld -r`, carrying `linking` v2 + `reloc.CODE`) passes `component new`
+  **byte-for-byte** — the reloc entries (`MemoryAddrSleb`/`MemoryAddrLeb`, and
+  `_I32` in `reloc.DATA` for initialised data) reach meld intact.
+- **meld already preserves this metadata.** meld 0.39.0 copies both inputs'
+  `linking` + `reloc.CODE` verbatim through fusion; it simply does not *consume*
+  them, so the offsets go stale against the merged code section. The fix is
+  *consume + apply*, not *acquire*.
+
+## Decision — path-D (relocatable), with path-F as the fallback
+
+meld's sound `--memory shared` input contract is **relocatable inputs**. meld
+consumes `linking` + `reloc.CODE`/`reloc.DATA`, translates each relocation site
+through the rewriter's existing `offset_map` (the same `AddressRemap` seam the
+#331 DWARF `.debug_line` fix uses to locate code offsets in the rewritten
+body), adds the module's `memory_base` to every `R_WASM_MEMORY_ADDR_SLEB`/
+`_LEB`/`_I32` operand, and strips the consumed relocs. When an input lacks the
+metadata, `--memory shared` stays a hard error (path-F) rather than silently
+corrupting — never a plausible-but-wrong output (LS-D-1 discipline).
+
+path-E is **rejected** (component pipeline cannot carry PIC). The producer cost
+of path-D is a build helper on the gale side (rustc hardcodes
+`--export=__heap_base/__data_end --gc-sections`, which fights `--relocatable`;
+producing a relocatable core needs `--emit=obj` + manual `wasm-ld -r`) — filed
+as gale#168.
+
+Locus of fix: **hybrid** — meld consumes; the producer must emit relocatable
+cores. Oracle: the gating fixtures above, derived from the spike, reproducing
+both gale datapoints under a fused shared memory.
+
+## References
+
+- meld#326 (corruption + the two gale datapoints + spike result)
+- meld#334 (companion: unify `__stack_pointer` globals + DCE the dead trampoline)
+- meld#298 / meld#299 (the MCU-lowering cluster shared mode serves)
+- gale#168 (producer-side relocatable build helper)
+- WebAssembly/tool-conventions `Linking.md` (`linking` v2, `reloc.*`, R_WASM_MEMORY_ADDR_*)
+- WebAssembly/tool-conventions `DynamicLinking.md` (PIC ABI — why path-E can't be a component)
+- ADR-4 (parent isolation model; shared is its retained secondary mode)
+- LS-M-11 (the hazard this makes correct); SR-37 (the v0.38.0 gate mitigation)

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1645,3 +1645,56 @@ artifacts:
         `accumulate_remapped_function_names_remaps_and_drops_unmapped`
         (meld-core/src/merger.rs) asserts a mapped entry is remapped to
         its fused index and an unmapped entry is dropped.
+
+  - id: SR-48
+    type: sw-req
+    title: Sound shared-memory fusion via relocation-metadata consumption
+    description: >
+      When `meld fuse --memory shared` places a component's linear memory at a
+      non-zero base in the shared address space, it shall produce a semantically
+      correct output OR fail — never a plausible-but-wrong one (LS-M-11, LS-D-1).
+      Because a finished non-PIC module bakes absolute addresses with no way to
+      recover which constants are addresses, meld shall relocate a component's
+      addresses ONLY from its relocation metadata: it shall consume the input's
+      `linking` (v2) + `reloc.CODE`/`reloc.DATA` custom sections, translate each
+      relocation site through the rewriter's `offset_map`, add the module's
+      shared-memory `memory_base` to every `R_WASM_MEMORY_ADDR_SLEB`/`_LEB`/`_I32`
+      operand (code literals AND data-section pointers), and strip the consumed
+      relocations from the output. When a `--memory shared` input lacks this
+      metadata (non-relocatable / PIC-stripped), meld shall HARD-ERROR rather
+      than emit an un-rebased colliding module. PIC/dylink inputs are out of
+      scope: a Component-Model core may import only functions, so
+      `wasm-tools component new` rejects a core importing `memory`/`__memory_base`
+      globals (ADR-6, path-E rejected). This supersedes, for the shared path,
+      the pending "inject addr + memory_base at every load/store" idea in SR-37's
+      history — that is unsound (it cannot distinguish pointers from integers,
+      nor same-module from cross-module pointers).
+    status: proposed
+    tags: [memory-strategy, shared-memory, relocation, mcu, v0.40.0]
+    links:
+      - type: derives-from
+        target: SYS-6
+      - type: mitigates
+        target: LS-M-11
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/326"
+        kind: github
+        last-checked: 2026-07-11
+    release: v0.40.0
+    fields:
+      implementation:
+        - meld-core/src/rewriter.rs
+        - meld-core/src/segments.rs
+        - meld-core/src/merger.rs
+      verification-method: test
+      verification-description: >
+        PLANNED (prototype on feat/326-reloc-consumer). Oracle fixtures from the
+        /tmp/spike326 spike reproduce both gale datapoints under a fused shared
+        memory: `reloc_326_static_addr_rebased_shared` (a `static mut` store at
+        an absolute `i32.const` persists across calls after rebasing — datapoint
+        B) and `reloc_326_data_pointer_rebased_shared` (a computed-pointer copy
+        preserves content — datapoint A). Negative control: a `--memory shared`
+        input WITHOUT `reloc.*` metadata hard-errors rather than emitting a
+        colliding module. Done when both oracles pass, the control errors, and
+        the fused output carries no stale `reloc.*` sections.
+


### PR DESCRIPTION
Makes `meld fuse --memory shared` **sound** for relocatable inputs by consuming their relocation metadata to rebase absolute addresses into each module's shared-memory window — fixing the meld#326 silent memory corruption (gale's gust:os buffer + `static mut` datapoints).

## What it does
- **Contract (ADR-6 / SR-48):** input = **relocatable** (`linking` + `reloc.*`, produced by `-C link-arg=--emit-relocs`). PIC is architecturally excluded (`wasm-tools component new` refuses core modules importing memory/`__memory_base` globals). Settled by a spike (see #326 comment); gale-side producer resolved (gale#168, one flag).
- **Reader (increment 1):** `reloc.rs` hand-parses `linking` v2 + `reloc.CODE`/`reloc.DATA` (wasmparser 0.246 dropped these readers). Verified the metadata survives `component new` byte-for-byte.
- **Consumer (increment 2, Tier-5):** per module, translate each `R_WASM_MEMORY_ADDR_*` site through the rewriter `offset_map` (the #331 AddressRemap seam), add the module's `memory_base` to the `i32.const`/`i64.const` literal (code) or 4-byte LE pointer (data), strip consumed relocs. memarg rebasing switched blanket→reloc-driven (also fixes latent over-rebasing of struct-field offsets). No-reloc + non-zero-base + direct memory access → **hard-error** (path-F), never silent corruption.

## Verification (isolated target)
- **457 lib + 4 integration tests green.** Key oracles: `test_326_reloc_const_rebasing_end_to_end` (address rebased at **runtime** via wasmtime), `test_326_shared_rebase_without_relocs_hard_errors` (path-F), and the pre-existing `test_address_rebasing_end_to_end` (bulk-only dynamic rebasing) still green. clippy + fmt clean.

## Mythos discover pass (Tier-5)
Core rebasing arithmetic verified **sound** (coordinate alignment across all functions, rebase-exactly-once, LEB/overflow, reloc-type filtering). Three gate/scope findings, all resolved:
- **A** (value-as-pointer gate miss) — naive fix regresses the legitimate bulk-only case (empirically confirmed), so reverted to a documented KNOWN LIMITATION + **#339** (needs data-flow-aware gate). Does NOT affect `--emit-relocs` inputs (their consts are rebased via `reloc.CODE`).
- **B** (memory64 8-byte data pointers) — reject via `has_unhandled_data_addr_relocs` (+ unit test) rather than mis-rebase.
- **C** — corrected the `MissingRelocMetadata` message (`--emit-relocs` on final link; a `wasm-ld -r` object is addends-only).

## Falsification
If reloc rebasing regressed, `test_326_reloc_const_rebasing_end_to_end` (asserts the address literal equals `base + addr` at runtime) fails. If path-F regressed, `test_326_shared_rebase_without_relocs_hard_errors` fails. If the bulk path regressed, `test_address_rebasing_end_to_end` fails.

Refs #326, #334, #339, gale#168, ADR-6, SR-48, LS-M-11, SYS-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)