### PR TITLE
feat(334): MCU-dissolve fixups — coalesce __stack_pointer globals + DCE dead import shim

### DIFF
--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -53,6 +53,7 @@ pub mod component_wrap;
 pub mod custom_merge;
 pub mod dwarf;
 mod error;
+pub mod mcu_dissolve;
 pub mod memory_probe;
 pub mod merger;
 pub mod p3_async;
@@ -714,6 +715,21 @@ impl Fuser {
         // the adapter trampolines instead of calling the target directly.
         if !adapters.is_empty() {
             stats.adapters_inlined = self.wire_adapter_indices(&mut merged, &adapters, &graph)?;
+        }
+
+        // Step 3.6: #334 MCU-dissolve fixups (SR-49, `--memory shared` only).
+        //
+        // Coalesce the N per-provider `__stack_pointer` globals into one
+        // shared shadow stack, and drop the vestigial lowered-import shim's
+        // keep-alive export so the downstream
+        // `synth --native-pointer-abi --shadow-stack-size` dissolve proceeds
+        // without gale's hand WAT surgery. Runs AFTER adapter wiring (so
+        // direct-call flattening is already reflected in the bodies) and
+        // BEFORE encoding (so all three encode passes, DWARF remap, and the
+        // attestation/provenance hashes see the coalesced module). The
+        // non-shared paths never reach here, keeping their output unchanged.
+        if self.config.memory_strategy == MemoryStrategy::SharedMemory {
+            mcu_dissolve::dissolve_fixups(&mut merged, &self.components)?;
         }
 
         // Step 4: Encode output module.

--- a/meld-core/src/mcu_dissolve.rs
+++ b/meld-core/src/mcu_dissolve.rs
@@ -1,0 +1,515 @@
+//! MCU-dissolve fixups for the `--memory shared` path (#334, SR-49).
+//!
+//! `meld fuse --memory shared` flattens a wac-composed multi-provider
+//! Component-Model node into one shared-memory core module. Two artifacts
+//! survive that flattening and block the downstream
+//! `synth --native-pointer-abi --shadow-stack-size` MCU dissolve. gale
+//! hand-patches both via WAT surgery today; this pass emits them fused so
+//! the dissolve proceeds without manual intervention.
+//!
+//! ## Part 1 — coalesce the per-provider `__stack_pointer` globals
+//!
+//! `--memory shared` merges the N linear memories into one but leaves one
+//! mutable-`i32` `__stack_pointer` global PER fused provider, all descending
+//! from the same shared shadow-stack top (`sp_init`). A shared memory has ONE
+//! shadow stack; keeping N of them is UNSOUND (two providers on a
+//! cross-component call clobber each other's frames) and blocks synth's
+//! shadow-stack rebasing ("could not uniquely identify the shadow-stack
+//! global", synth#707). We keep one survivor and remap every reference to the
+//! coalesced duplicates onto it, then drop the extras from the global section.
+//!
+//! ## Part 2 — DCE the dead lowered-import shim trampoline
+//!
+//! The pre-meld wac composite carries a lowered-import shim: an `$imports`
+//! table plus a `call_indirect` trampoline populated at instantiation. After
+//! meld flattens cross-component calls to DIRECT calls, a vestigial
+//! trampoline survives — unreachable, mis-typed, kept alive only by its
+//! numeric-named export. synth's closed-world check (synth#642/#676) declines
+//! it. Dropping the keep-alive export makes the function DCE-eligible, which
+//! is the minimal correct fix (#334); synth then DCEs the body.
+//!
+//! Both fixups are `--memory shared`-only. The non-shared / multi-memory
+//! paths never call into this module, so their output is byte-for-byte
+//! unchanged.
+
+use std::collections::{HashMap, HashSet};
+
+use wasm_encoder::{ExportKind as EncoderExportKind, Function, ValType};
+use wasmparser::{BinaryReader, CodeSectionReader, Operator};
+
+use crate::merger::MergedModule;
+use crate::parser::{ImportKind, ParsedComponent};
+use crate::rewriter::{IndexMaps, rewrite_function_body};
+use crate::segments::{ElementSegmentMode, ReindexedElementItems};
+use crate::{Error, Result};
+
+/// Outcome of an MCU-dissolve pass, for logging and test assertions.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DissolveStats {
+    /// Number of duplicate `__stack_pointer`-class globals coalesced away
+    /// (i.e. dropped from the global section; the survivor is not counted).
+    pub stack_pointers_coalesced: usize,
+    /// Number of dead lowered-import trampoline keep-alive exports dropped.
+    pub trampoline_exports_dropped: usize,
+}
+
+/// Apply both MCU-dissolve fixups in place. Caller gates this on
+/// `MemoryStrategy::SharedMemory`.
+pub fn dissolve_fixups(
+    merged: &mut MergedModule,
+    components: &[ParsedComponent],
+) -> Result<DissolveStats> {
+    let stack_pointers_coalesced = coalesce_stack_pointers(merged, components)?;
+    let trampoline_exports_dropped = drop_dead_import_trampolines(merged)?;
+    let stats = DissolveStats {
+        stack_pointers_coalesced,
+        trampoline_exports_dropped,
+    };
+    if stats != DissolveStats::default() {
+        log::info!(
+            "#334 MCU-dissolve: coalesced {} duplicate __stack_pointer global(s), \
+             dropped {} dead lowered-import trampoline export(s)",
+            stats.stack_pointers_coalesced,
+            stats.trampoline_exports_dropped,
+        );
+    }
+    Ok(stats)
+}
+
+// ---------------------------------------------------------------------------
+// Part 1 — __stack_pointer coalescing
+// ---------------------------------------------------------------------------
+
+/// A `__stack_pointer`-class defined global, resolved into the fused module's
+/// absolute global-index space.
+struct SpCandidate {
+    /// Absolute global index in the fused module.
+    merged_idx: u32,
+    /// The `i32.const` shadow-stack top the global initialises to.
+    init: i32,
+    /// Whether the `name` section's global-name subsection named this global
+    /// exactly `__stack_pointer` (the authoritative signal).
+    named: bool,
+}
+
+/// Coalesce the per-provider `__stack_pointer` globals into one survivor.
+/// Returns the number of duplicates dropped.
+fn coalesce_stack_pointers(
+    merged: &mut MergedModule,
+    components: &[ParsedComponent],
+) -> Result<usize> {
+    let import_base = merged.import_counts.global;
+
+    // Gather candidates from the ORIGINAL parsed globals — the merged
+    // `ConstExpr` init is opaque, but the source `init_expr_bytes` is
+    // readable and the `global_index_map` translates its index into the
+    // fused space. `__stack_pointer` is always a DEFINED (not imported)
+    // global, and cross-module SP sharing via a global import is already
+    // unified by the merger, so iterating defined globals visits each
+    // genuinely-separate SP exactly once.
+    let mut candidates: Vec<SpCandidate> = Vec::new();
+    let mut seen: HashSet<u32> = HashSet::new();
+    for (comp_idx, comp) in components.iter().enumerate() {
+        for (mod_idx, module) in comp.core_modules.iter().enumerate() {
+            let import_global_count = module
+                .imports
+                .iter()
+                .filter(|i| matches!(i.kind, ImportKind::Global(_)))
+                .count() as u32;
+            let names = parse_global_names(module);
+            for (old_idx, g) in module.globals.iter().enumerate() {
+                // Only mutable i32 globals with a single `i32.const` initialiser
+                // can be a shadow-stack pointer.
+                if !g.mutable || g.content_type != ValType::I32 {
+                    continue;
+                }
+                let Some(init) = read_i32_const(&g.init_expr_bytes) else {
+                    continue;
+                };
+                let abs_old = import_global_count + old_idx as u32;
+                let Some(&merged_idx) = merged.global_index_map.get(&(comp_idx, mod_idx, abs_old))
+                else {
+                    continue;
+                };
+                // Guard: only consider globals that still live in the fused
+                // global section (a defined slot), and dedup by fused index.
+                if merged_idx < import_base || !seen.insert(merged_idx) {
+                    continue;
+                }
+                let named = names
+                    .get(&abs_old)
+                    .map(|n| n == "__stack_pointer")
+                    .unwrap_or(false);
+                candidates.push(SpCandidate {
+                    merged_idx,
+                    init,
+                    named,
+                });
+            }
+        }
+    }
+
+    // Decide which sets to coalesce. Correctness over cleanup: only fuse
+    // globals we are confident share one shadow stack.
+    let groups = choose_coalesce_groups(&candidates);
+    if groups.is_empty() {
+        return Ok(0);
+    }
+
+    // Build the redirect (dropped -> survivor) and the drop set.
+    let mut redirect: HashMap<u32, u32> = HashMap::new();
+    let mut drop_set: Vec<u32> = Vec::new();
+    for group in &groups {
+        let survivor = *group.iter().min().expect("group is non-empty");
+        for &idx in group {
+            if idx != survivor {
+                redirect.insert(idx, survivor);
+                drop_set.push(idx);
+            }
+        }
+    }
+    drop_set.sort_unstable();
+    drop_set.dedup();
+    let coalesced = drop_set.len();
+
+    // New absolute index after removing everything in `drop_set` below it.
+    let shift = |old: u32| -> u32 {
+        let removed_below = drop_set.iter().filter(|&&d| d < old).count() as u32;
+        old - removed_below
+    };
+
+    // Full old -> new global-index remap: a coalesced duplicate routes to the
+    // survivor's post-shift index; every surviving global slides down past the
+    // holes left by the drops.
+    let total = import_base + merged.globals.len() as u32;
+    let mut gmap: HashMap<u32, u32> = HashMap::new();
+    for old in 0..total {
+        let new = match redirect.get(&old) {
+            Some(&survivor) => shift(survivor),
+            None => shift(old),
+        };
+        if new != old || redirect.contains_key(&old) {
+            gmap.insert(old, new);
+        }
+    }
+
+    // Rewrite every `global.get`/`global.set` in the fused code section
+    // through the same remap the merger uses for its own renumbering.
+    let maps = IndexMaps {
+        globals: gmap.clone(),
+        ..IndexMaps::new()
+    };
+    for f in merged.functions.iter_mut() {
+        f.body = reparse_and_rewrite_body(&f.body, &maps)?;
+    }
+
+    // Remap global exports (the survivor may be re-exported).
+    for e in merged.exports.iter_mut() {
+        if matches!(e.kind, EncoderExportKind::Global)
+            && let Some(&new) = gmap.get(&e.index)
+        {
+            e.index = new;
+        }
+    }
+
+    // Drop the coalesced duplicates from the global section. (Defined globals
+    // occupy `merged.globals[merged_idx - import_base]`.) Init expressions can
+    // only reference IMPORTED globals, which we never drop, so surviving
+    // initialisers need no rewrite.
+    let drop_positions: HashSet<usize> = drop_set
+        .iter()
+        .map(|&d| (d - import_base) as usize)
+        .collect();
+    let kept: Vec<_> = std::mem::take(&mut merged.globals)
+        .into_iter()
+        .enumerate()
+        .filter_map(|(j, g)| (!drop_positions.contains(&j)).then_some(g))
+        .collect();
+    merged.globals = kept;
+
+    Ok(coalesced)
+}
+
+/// Group SP candidates into coalescible sets (each set shares one shadow
+/// stack). Returns groups of fused global indices, each with ≥2 members.
+///
+/// ONLY the authoritative signal is used: a global the `name` section named
+/// exactly `__stack_pointer`. An init-value heuristic was rejected (Mythos
+/// #334 review): two unrelated mutable-i32 globals in different components that
+/// merely share an init value (an errno/TLS/counter global at the same `K`)
+/// would be fused, redirecting one component's `global.set` onto the other's
+/// storage — silent cross-component corruption. A mis-coalesce is worse than a
+/// no-op, so absent the name we do NOT guess (the fused module keeps its
+/// several SP globals; synth surfaces the multi-SP condition rather than meld
+/// corrupting it). The robust name-free signal, if ever needed, is the
+/// `linking` symbol table — not the init value.
+fn choose_coalesce_groups(candidates: &[SpCandidate]) -> Vec<Vec<u32>> {
+    // Group `__stack_pointer`-named candidates by init value (a shared memory's
+    // SP top is the common `sp_init`); coalesce equal-init groups only —
+    // differing inits would signal a pre-partitioned layout we must not merge.
+    let mut by_init: HashMap<i32, Vec<u32>> = HashMap::new();
+    for c in candidates.iter().filter(|c| c.named) {
+        by_init.entry(c.init).or_default().push(c.merged_idx);
+    }
+    finalize_groups(by_init)
+}
+
+/// Keep only multi-member groups; sort each for deterministic survivor choice.
+fn finalize_groups(by_init: HashMap<i32, Vec<u32>>) -> Vec<Vec<u32>> {
+    let mut groups: Vec<Vec<u32>> = by_init
+        .into_values()
+        .filter(|g| g.len() >= 2)
+        .map(|mut g| {
+            g.sort_unstable();
+            g.dedup();
+            g
+        })
+        .filter(|g| g.len() >= 2)
+        .collect();
+    groups.sort();
+    groups
+}
+
+/// Parse a module's `name` section global-name subsection into
+/// `absolute-global-index -> name`. Returns empty on absence or malformation
+/// (never guess).
+fn parse_global_names(module: &crate::parser::CoreModule) -> HashMap<u32, String> {
+    let mut out = HashMap::new();
+    let Some((_, data)) = module.custom_sections.iter().find(|(n, _)| n == "name") else {
+        return out;
+    };
+    let reader = wasmparser::NameSectionReader::new(BinaryReader::new(data, 0));
+    for subsection in reader {
+        let Ok(subsection) = subsection else {
+            return HashMap::new();
+        };
+        if let wasmparser::Name::Global(namemap) = subsection {
+            for naming in namemap {
+                let Ok(naming) = naming else { continue };
+                out.insert(naming.index, naming.name.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Read a lone `i32.const K` constant-expression body (init-expr bytes, with
+/// the trailing `end` already stripped by the parser). Returns `None` for any
+/// other shape — we only coalesce globals whose initialiser is exactly a
+/// shadow-stack-top constant.
+fn read_i32_const(bytes: &[u8]) -> Option<i32> {
+    // 0x41 = i32.const, followed by a signed LEB128 immediate.
+    if bytes.first() != Some(&0x41) {
+        return None;
+    }
+    let (val, consumed) = read_sleb128(&bytes[1..])?;
+    if 1 + consumed != bytes.len() {
+        return None;
+    }
+    i32::try_from(val).ok()
+}
+
+/// Minimal signed-LEB128 decoder. Returns `(value, bytes_consumed)`.
+fn read_sleb128(bytes: &[u8]) -> Option<(i64, usize)> {
+    let mut result: i64 = 0;
+    let mut shift: u32 = 0;
+    let mut i = 0;
+    loop {
+        let byte = *bytes.get(i)?;
+        i += 1;
+        result |= ((byte & 0x7f) as i64) << shift;
+        shift += 7;
+        if byte & 0x80 == 0 {
+            if shift < 64 && (byte & 0x40) != 0 {
+                result |= -1i64 << shift;
+            }
+            return Some((result, i));
+        }
+        if shift >= 64 {
+            return None;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Part 2 — dead lowered-import trampoline export drop
+// ---------------------------------------------------------------------------
+
+/// Drop the keep-alive export of any vestigial lowered-import trampoline so
+/// synth can DCE the body. Returns the number of exports dropped.
+fn drop_dead_import_trampolines(merged: &mut MergedModule) -> Result<usize> {
+    let func_base = merged.import_counts.func;
+
+    // Every function reachable by a real call (direct, tail, or ref.func) plus
+    // the start function. A trampoline reached by any of these is live —
+    // leave it alone.
+    let mut reachable: HashSet<u32> = HashSet::new();
+    if let Some(s) = merged.start_function {
+        reachable.insert(s);
+    }
+    for f in &merged.functions {
+        collect_reachable(&f.body, &mut reachable)?;
+    }
+
+    // Tables that hold at least one DEFINED function via a static element
+    // segment are ordinary indirect-call tables, NOT the host-populated
+    // lowered-import table. The `$imports` table holds only imported
+    // functions (or is filled at instantiation with no static segment).
+    let mut table_has_defined_fn: HashSet<u32> = HashSet::new();
+    for seg in &merged.elements {
+        if let ElementSegmentMode::Active { table_index, .. } = seg.mode
+            && let ReindexedElementItems::Functions(fs) = &seg.items
+            && fs.iter().any(|&fi| fi >= func_base)
+        {
+            table_has_defined_fn.insert(table_index);
+        }
+    }
+
+    // Collect the exports to drop: numeric-named function exports whose body
+    // is a bare `local.get*; i32.const K; call_indirect` over an import table
+    // and which nothing calls.
+    let mut to_drop: Vec<(String, u32)> = Vec::new();
+    for e in &merged.exports {
+        if !matches!(e.kind, EncoderExportKind::Func) {
+            continue;
+        }
+        // Keep-alive exports of the wac shim are numeric ("0", "1", …). A real
+        // WIT export never uses a pure-integer core name — a strong,
+        // conservative discriminator.
+        if e.name.is_empty() || !e.name.bytes().all(|b| b.is_ascii_digit()) {
+            continue;
+        }
+        let fidx = e.index;
+        if fidx < func_base || reachable.contains(&fidx) {
+            continue;
+        }
+        let Some(mf) = merged.defined_func(fidx) else {
+            continue;
+        };
+        let Some(table) = match_import_trampoline(&mf.body)? else {
+            continue;
+        };
+        // The dispatch table must be an import table, not a normal vtable.
+        if table_has_defined_fn.contains(&table) {
+            continue;
+        }
+        to_drop.push((e.name.clone(), fidx));
+    }
+
+    if to_drop.is_empty() {
+        return Ok(0);
+    }
+    let before = merged.exports.len();
+    merged.exports.retain(|e| {
+        !(matches!(e.kind, EncoderExportKind::Func)
+            && to_drop.iter().any(|(n, i)| *n == e.name && *i == e.index))
+    });
+    Ok(before - merged.exports.len())
+}
+
+/// Structural match for a lowered-import trampoline body:
+/// `(local.get …)* i32.const K  call_indirect <table> (type T)  end`.
+/// Returns the dispatch table index on a match, `None` otherwise.
+fn match_import_trampoline(body: &Function) -> Result<Option<u32>> {
+    let section = one_func_code_section(body);
+    let reader = CodeSectionReader::new(BinaryReader::new(&section, 0))?;
+    if let Some(b) = reader.into_iter().next() {
+        let b = b?;
+        let mut table = None;
+        let mut seen_call_indirect = false;
+        let mut seen_const = false;
+        let mut ok = true;
+        for op in b.get_operators_reader()? {
+            match op? {
+                Operator::LocalGet { .. } => {
+                    if seen_call_indirect {
+                        ok = false;
+                    }
+                }
+                Operator::I32Const { .. } => {
+                    if seen_call_indirect {
+                        ok = false;
+                    }
+                    seen_const = true;
+                }
+                Operator::CallIndirect { table_index, .. } => {
+                    if seen_call_indirect {
+                        ok = false; // more than one call_indirect — not a bare trampoline
+                    }
+                    table = Some(table_index);
+                    seen_call_indirect = true;
+                }
+                Operator::End => {}
+                _ => ok = false,
+            }
+        }
+        return Ok((ok && seen_call_indirect && seen_const)
+            .then_some(table)
+            .flatten());
+    }
+    Ok(None)
+}
+
+/// Collect direct/tail-call and `ref.func` targets from a function body.
+fn collect_reachable(body: &Function, out: &mut HashSet<u32>) -> Result<()> {
+    let section = one_func_code_section(body);
+    let reader = CodeSectionReader::new(BinaryReader::new(&section, 0))?;
+    for b in reader {
+        let b = b?;
+        for op in b.get_operators_reader()? {
+            match op? {
+                Operator::Call { function_index }
+                | Operator::ReturnCall { function_index }
+                | Operator::RefFunc { function_index } => {
+                    out.insert(function_index);
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Shared body-reparse helper
+// ---------------------------------------------------------------------------
+
+/// Wrap one already-encoded function body as a single-entry code section so
+/// `wasmparser` can re-read it. `into_raw_body` yields the body bytes
+/// (`locals + code`) WITHOUT a size prefix, so a valid single-entry code
+/// section is `[count=1][body-size][body]`.
+fn one_func_code_section(body: &Function) -> Vec<u8> {
+    let raw = body.clone().into_raw_body();
+    let mut section = vec![0x01u8]; // one function entry
+    write_uleb128(raw.len() as u64, &mut section);
+    section.extend_from_slice(&raw);
+    section
+}
+
+/// Append a u32/u64 as unsigned LEB128.
+fn write_uleb128(mut v: u64, out: &mut Vec<u8>) {
+    loop {
+        let byte = (v & 0x7f) as u8;
+        v >>= 7;
+        if v == 0 {
+            out.push(byte);
+            break;
+        }
+        out.push(byte | 0x80);
+    }
+}
+
+/// Re-parse an encoded body and rewrite its index references through `maps`
+/// (only `globals` is populated by this module; everything else is identity).
+fn reparse_and_rewrite_body(body: &Function, maps: &IndexMaps) -> Result<Function> {
+    let section = one_func_code_section(body);
+    let reader = CodeSectionReader::new(BinaryReader::new(&section, 0))?;
+    if let Some(b) = reader.into_iter().next() {
+        let b = b?;
+        // `param_count` only matters under address rebasing (off here), so 0.
+        return rewrite_function_body(&b, 0, maps);
+    }
+    Err(Error::EncodingError(
+        "mcu_dissolve: empty single-function code section".to_string(),
+    ))
+}

--- a/meld-core/tests/mcu_dissolve.rs
+++ b/meld-core/tests/mcu_dissolve.rs
@@ -1,0 +1,687 @@
+//! #334 (SR-49) — MCU-dissolve fixups on the `--memory shared` path.
+//!
+//! Exercises the two fused fixups that unblock the downstream
+//! `synth --native-pointer-abi --shadow-stack-size` dissolve:
+//!   1. coalescing the N per-provider `__stack_pointer` globals into one
+//!      shared shadow stack, and
+//!   2. dropping the vestigial lowered-import trampoline's keep-alive export.
+//!
+//! The fixtures are hand-built `MergedModule`s (mirroring how
+//! `tests/rebasing_end_to_end.rs` constructs modules with `wasm-encoder`),
+//! plus minimal `ParsedComponent`s carrying the `name`-section global-name
+//! subsection the primary detector reads. Assertions re-parse the transformed
+//! output; the runtime test additionally runs the coalesced module in
+//! wasmtime to prove the two providers' shadow stacks no longer alias.
+
+use std::collections::{BTreeMap, HashMap};
+
+use meld_core::mcu_dissolve::dissolve_fixups;
+use meld_core::merger::{
+    ImportCounts, MergedExport, MergedFuncType, MergedFunction, MergedGlobal, MergedModule,
+};
+use meld_core::parser::{self, CoreModule, ParsedComponent};
+use meld_core::segments::{ElementSegmentMode, ReindexedElementItems, ReindexedElementSegment};
+
+use wasm_encoder::{
+    ConstExpr, ExportKind, Function, GlobalType as EncGlobalType, MemArg, RefType, ValType,
+};
+
+// ---------------------------------------------------------------------------
+// Small binary-encoding helpers
+// ---------------------------------------------------------------------------
+
+fn uleb128(mut v: u64) -> Vec<u8> {
+    let mut out = Vec::new();
+    loop {
+        let byte = (v & 0x7f) as u8;
+        v >>= 7;
+        if v == 0 {
+            out.push(byte);
+            break;
+        }
+        out.push(byte | 0x80);
+    }
+    out
+}
+
+fn sleb128(mut v: i64) -> Vec<u8> {
+    let mut out = Vec::new();
+    loop {
+        let byte = (v & 0x7f) as u8;
+        v >>= 7;
+        let sign = byte & 0x40 != 0;
+        if (v == 0 && !sign) || (v == -1 && sign) {
+            out.push(byte);
+            break;
+        }
+        out.push(byte | 0x80);
+    }
+    out
+}
+
+/// `i32.const V` init-expr bytes WITHOUT the trailing `end` — the form
+/// `parser::GlobalType::init_expr_bytes` stores.
+fn i32_const_init(v: i32) -> Vec<u8> {
+    let mut b = vec![0x41u8];
+    b.extend(sleb128(v as i64));
+    b
+}
+
+/// A `name` section payload (subsection stream) with a global-name
+/// subsection (id 7) naming the given absolute global indices.
+fn global_name_section(names: &[(u32, &str)]) -> Vec<u8> {
+    let mut sub = uleb128(names.len() as u64);
+    for (idx, name) in names {
+        sub.extend(uleb128(*idx as u64));
+        sub.extend(uleb128(name.len() as u64));
+        sub.extend(name.as_bytes());
+    }
+    let mut payload = vec![0x07u8];
+    payload.extend(uleb128(sub.len() as u64));
+    payload.extend(sub);
+    payload
+}
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+fn merged_base() -> MergedModule {
+    MergedModule {
+        types: Vec::new(),
+        imports: Vec::new(),
+        functions: Vec::new(),
+        tables: Vec::new(),
+        memories: Vec::new(),
+        globals: Vec::new(),
+        exports: Vec::new(),
+        start_function: None,
+        elements: Vec::new(),
+        data_segments: Vec::new(),
+        custom_sections: Vec::new(),
+        fused_function_names: BTreeMap::new(),
+        function_index_map: HashMap::new(),
+        memory_index_map: HashMap::new(),
+        table_index_map: HashMap::new(),
+        global_index_map: HashMap::new(),
+        type_index_map: HashMap::new(),
+        realloc_map: HashMap::new(),
+        import_counts: ImportCounts {
+            func: 0,
+            table: 0,
+            memory: 0,
+            global: 0,
+        },
+        import_memory_indices: Vec::new(),
+        import_realloc_indices: Vec::new(),
+        resource_rep_by_component: HashMap::new(),
+        resource_new_by_component: HashMap::new(),
+        handle_tables: HashMap::new(),
+        task_return_shims: HashMap::new(),
+        async_result_globals: HashMap::new(),
+        segment_bases: HashMap::new(),
+    }
+}
+
+fn mut_i32_global(init: i32) -> MergedGlobal {
+    MergedGlobal {
+        ty: EncGlobalType {
+            val_type: ValType::I32,
+            mutable: true,
+            shared: false,
+        },
+        init_expr: ConstExpr::i32_const(init),
+    }
+}
+
+fn merged_func(type_idx: u32, body: Function) -> MergedFunction {
+    MergedFunction {
+        type_idx,
+        body,
+        origin: (0, 0, 0),
+        synthetic_kind: None,
+    }
+}
+
+fn parser_global(init: i32) -> parser::GlobalType {
+    parser::GlobalType {
+        content_type: ValType::I32,
+        mutable: true,
+        init_expr_bytes: i32_const_init(init),
+    }
+}
+
+/// A one-module component whose defined globals are `globals`, optionally with
+/// a `name` section naming some of them.
+fn component_with_globals(
+    globals: Vec<parser::GlobalType>,
+    names: &[(u32, &str)],
+) -> ParsedComponent {
+    let mut m = CoreModule {
+        index: 0,
+        bytes: Vec::new(),
+        types: Vec::new(),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        functions: Vec::new(),
+        memories: Vec::new(),
+        tables: Vec::new(),
+        globals,
+        start: None,
+        data_count: None,
+        element_count: 0,
+        custom_sections: Vec::new(),
+        code_section_range: None,
+        global_section_range: None,
+        element_section_range: None,
+        data_section_range: None,
+    };
+    if !names.is_empty() {
+        m.custom_sections
+            .push(("name".to_string(), global_name_section(names)));
+    }
+    let mut c = ParsedComponent::empty();
+    c.core_modules.push(m);
+    c
+}
+
+// ---------------------------------------------------------------------------
+// Re-encode a MergedModule to a runnable core module (subset the tests need).
+// ---------------------------------------------------------------------------
+
+fn encode_core(m: &MergedModule) -> Vec<u8> {
+    use wasm_encoder::{
+        CodeSection, ElementSection, ExportSection, FunctionSection, GlobalSection, MemorySection,
+        Module, TableSection, TypeSection,
+    };
+    let mut module = Module::new();
+
+    let mut types = TypeSection::new();
+    for t in &m.types {
+        types
+            .ty()
+            .function(t.params.iter().copied(), t.results.iter().copied());
+    }
+    module.section(&types);
+
+    let mut funcs = FunctionSection::new();
+    for f in &m.functions {
+        funcs.function(f.type_idx);
+    }
+    module.section(&funcs);
+
+    if !m.tables.is_empty() {
+        let mut tables = TableSection::new();
+        for t in &m.tables {
+            tables.table(*t);
+        }
+        module.section(&tables);
+    }
+
+    if !m.memories.is_empty() {
+        let mut mems = MemorySection::new();
+        for mem in &m.memories {
+            mems.memory(*mem);
+        }
+        module.section(&mems);
+    }
+
+    let mut globals = GlobalSection::new();
+    for g in &m.globals {
+        globals.global(g.ty, &g.init_expr);
+    }
+    module.section(&globals);
+
+    let mut exports = ExportSection::new();
+    for e in &m.exports {
+        exports.export(&e.name, e.kind, e.index);
+    }
+    module.section(&exports);
+
+    if !m.elements.is_empty() {
+        let mut elems = ElementSection::new();
+        for seg in &m.elements {
+            meld_core::segments::encode_element_segment(&mut elems, seg);
+        }
+        module.section(&elems);
+    }
+
+    let mut code = CodeSection::new();
+    for f in &m.functions {
+        code.function(&f.body);
+    }
+    module.section(&code);
+
+    module.finish()
+}
+
+/// Read `(mutable, i32, init_value)` triples for a module's globals.
+fn parse_globals(bytes: &[u8]) -> Vec<(bool, bool, Option<i32>)> {
+    let mut out = Vec::new();
+    let parser = wasmparser::Parser::new(0);
+    for payload in parser.parse_all(bytes) {
+        if let wasmparser::Payload::GlobalSection(reader) = payload.unwrap() {
+            for g in reader {
+                let g = g.unwrap();
+                let is_i32 = matches!(g.ty.content_type, wasmparser::ValType::I32);
+                let mut init = None;
+                for op in g.init_expr.get_operators_reader() {
+                    if let Ok(wasmparser::Operator::I32Const { value }) = op {
+                        init = Some(value);
+                    }
+                }
+                out.push((g.ty.mutable, is_i32, init));
+            }
+        }
+    }
+    out
+}
+
+/// Read the operator stream of function body `func_idx` (defined-function
+/// order) from an encoded module.
+fn parse_body_ops(bytes: &[u8], func_idx: usize) -> Vec<String> {
+    let mut idx = 0usize;
+    let mut ops = Vec::new();
+    let parser = wasmparser::Parser::new(0);
+    for payload in parser.parse_all(bytes) {
+        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
+            if idx == func_idx {
+                for op in body.get_operators_reader().unwrap() {
+                    ops.push(format!("{:?}", op.unwrap()));
+                }
+            }
+            idx += 1;
+        }
+    }
+    ops
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Part 1 structural: a fused 2-provider shared module ends with exactly one
+/// SP-class global, coalesced duplicate refs point at the survivor, and a
+/// surviving global above the dropped slot renumbers down.
+#[test]
+fn stack_pointer_globals_coalesced() {
+    const SP_INIT: i32 = 1024;
+
+    // Merged layout: [0]=SP(A), [1]=SP(B, dup), [2]=plain(42).
+    let mut m = merged_base();
+    m.globals = vec![
+        mut_i32_global(SP_INIT),
+        mut_i32_global(SP_INIT),
+        mut_i32_global(42),
+    ];
+
+    // A single function touching global 1 (dup SP → survivor 0) and global 2
+    // (plain → renumbers 2→1). Type () -> ().
+    m.types = vec![MergedFuncType {
+        params: vec![],
+        results: vec![],
+    }];
+    let mut body = Function::new([]);
+    body.instructions()
+        .i32_const(5)
+        .global_set(1) // set dup SP  -> expect global_set 0
+        .global_get(2) // get plain   -> expect global_get 1
+        .drop()
+        .global_get(0) // get survivor SP -> stays 0
+        .drop()
+        .end();
+    m.functions = vec![merged_func(0, body)];
+
+    // global_index_map: comp0.g0 -> 0 (SP A), comp0.g1 -> 2 (plain),
+    // comp1.g0 -> 1 (SP B).
+    m.global_index_map.insert((0, 0, 0), 0);
+    m.global_index_map.insert((0, 0, 1), 2);
+    m.global_index_map.insert((1, 0, 0), 1);
+
+    let comps = vec![
+        component_with_globals(
+            vec![parser_global(SP_INIT), parser_global(42)],
+            &[(0, "__stack_pointer")],
+        ),
+        component_with_globals(vec![parser_global(SP_INIT)], &[(0, "__stack_pointer")]),
+    ];
+
+    let stats = dissolve_fixups(&mut m, &comps).unwrap();
+    assert_eq!(
+        stats.stack_pointers_coalesced, 1,
+        "exactly one duplicate SP coalesced away"
+    );
+
+    // Re-encode and re-parse the output globals.
+    let bytes = encode_core(&m);
+    wasmparser::validate(&bytes).expect("coalesced module must validate");
+    let globals = parse_globals(&bytes);
+    assert_eq!(globals.len(), 2, "one SP duplicate dropped: 3 -> 2 globals");
+    let sp_class = globals
+        .iter()
+        .filter(|(mutable, is_i32, init)| *mutable && *is_i32 && *init == Some(SP_INIT))
+        .count();
+    assert_eq!(sp_class, 1, "exactly one SP-class (init==sp_init) global");
+
+    // Redirected + renumbered instructions.
+    let ops = parse_body_ops(&bytes, 0);
+    assert_eq!(
+        ops,
+        vec![
+            "I32Const { value: 5 }",
+            "GlobalSet { global_index: 0 }", // dup SP 1 -> survivor 0
+            "GlobalGet { global_index: 1 }", // plain 2 -> renumbered 1
+            "Drop",
+            "GlobalGet { global_index: 0 }", // survivor unchanged
+            "Drop",
+            "End",
+        ],
+        "coalesced refs point at survivor and surviving global renumbers down",
+    );
+}
+
+/// Part 1 behavioural: after coalescing, the two providers descend one shared
+/// shadow stack, so a nested cross-provider call no longer clobbers the
+/// caller's frame. The pre-transform module (two independent SPs) clobbers;
+/// the coalesced module does not.
+#[test]
+fn shared_stack_pointer_runtime_non_clobber() {
+    use wasmtime::{Engine, Instance, Module, Store};
+
+    const SP_INIT: i32 = 1024;
+    const MARK_A: i32 = 0xAA;
+    const MARK_B: i32 = 0xBB;
+    let memarg = MemArg {
+        offset: 0,
+        align: 2,
+        memory_index: 0,
+    };
+
+    let mut m = merged_base();
+    m.import_counts.memory = 0;
+    m.memories = vec![wasm_encoder::MemoryType {
+        minimum: 1,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    }];
+    m.globals = vec![mut_i32_global(SP_INIT), mut_i32_global(SP_INIT)];
+    m.types = vec![
+        MergedFuncType {
+            params: vec![],
+            results: vec![ValType::I32],
+        },
+        MergedFuncType {
+            params: vec![],
+            results: vec![],
+        },
+    ];
+
+    // Provider A (uses SP global 0): alloc a frame, stamp MARK_A, call B,
+    // reload the stamp, free the frame, return the reloaded value.
+    let mut a = Function::new([]);
+    a.instructions()
+        .global_get(0)
+        .i32_const(16)
+        .i32_sub()
+        .global_set(0)
+        .global_get(0)
+        .i32_const(MARK_A)
+        .i32_store(memarg)
+        .call(1)
+        .global_get(0)
+        .i32_load(memarg)
+        .global_get(0)
+        .i32_const(16)
+        .i32_add()
+        .global_set(0)
+        .end();
+
+    // Provider B (uses SP global 1): alloc a frame, stamp MARK_B, free.
+    let mut b = Function::new([]);
+    b.instructions()
+        .global_get(1)
+        .i32_const(16)
+        .i32_sub()
+        .global_set(1)
+        .global_get(1)
+        .i32_const(MARK_B)
+        .i32_store(memarg)
+        .global_get(1)
+        .i32_const(16)
+        .i32_add()
+        .global_set(1)
+        .end();
+
+    m.functions = vec![merged_func(0, a), merged_func(1, b)];
+    m.exports.push(MergedExport {
+        name: "run".to_string(),
+        kind: ExportKind::Func,
+        index: 0,
+    });
+
+    m.global_index_map.insert((0, 0, 0), 0);
+    m.global_index_map.insert((1, 0, 0), 1);
+    let comps = vec![
+        component_with_globals(vec![parser_global(SP_INIT)], &[(0, "__stack_pointer")]),
+        component_with_globals(vec![parser_global(SP_INIT)], &[(0, "__stack_pointer")]),
+    ];
+
+    // Pre-transform: two independent SPs both start at the top, so B clobbers
+    // A's frame — A observes MARK_B (the hazard #334 fixes).
+    let pre = encode_core(&m);
+    wasmparser::validate(&pre).expect("pre module validates");
+    let run = |bytes: &[u8]| -> i32 {
+        let engine = Engine::default();
+        let module = Module::new(&engine, bytes).unwrap();
+        let mut store = Store::new(&engine, ());
+        let inst = Instance::new(&mut store, &module, &[]).unwrap();
+        let f = inst.get_typed_func::<(), i32>(&mut store, "run").unwrap();
+        f.call(&mut store, ()).unwrap()
+    };
+    assert_eq!(
+        run(&pre),
+        MARK_B,
+        "pre-fix: independent SPs alias, B clobbers A's frame"
+    );
+
+    // Coalesce and re-check: one shared SP, B allocates below A's frame, so
+    // A's stamp survives.
+    let stats = dissolve_fixups(&mut m, &comps).unwrap();
+    assert_eq!(stats.stack_pointers_coalesced, 1);
+    assert_eq!(m.globals.len(), 1, "single shared shadow-stack global");
+
+    let post = encode_core(&m);
+    wasmparser::validate(&post).expect("post module validates");
+    assert_eq!(
+        run(&post),
+        MARK_A,
+        "post-fix: shared SP, nested provider call no longer clobbers"
+    );
+}
+
+/// Part 2: a dead lowered-import trampoline's numeric keep-alive export is
+/// dropped, while real exports, vtable-backed trampolines, and non-trampoline
+/// numeric exports are left alone.
+#[test]
+fn dead_import_trampoline_export_dropped() {
+    let mut m = merged_base();
+    m.import_counts.func = 1; // one imported function at index 0
+
+    // Types: t0 = () -> () (import + normal), t1 = (i32) -> () (mis-typed).
+    m.types = vec![
+        MergedFuncType {
+            params: vec![],
+            results: vec![],
+        },
+        MergedFuncType {
+            params: vec![ValType::I32],
+            results: vec![],
+        },
+    ];
+
+    // Two funcref tables: table 0 = import table (holds imported func 0),
+    // table 1 = ordinary vtable (holds defined func 2).
+    m.tables = vec![
+        wasm_encoder::TableType {
+            element_type: RefType::FUNCREF,
+            minimum: 1,
+            maximum: Some(1),
+            table64: false,
+            shared: false,
+        },
+        wasm_encoder::TableType {
+            element_type: RefType::FUNCREF,
+            minimum: 1,
+            maximum: Some(1),
+            table64: false,
+            shared: false,
+        },
+    ];
+    m.elements = vec![
+        ReindexedElementSegment {
+            mode: ElementSegmentMode::Active {
+                table_index: 0,
+                offset: ConstExpr::i32_const(0),
+            },
+            element_type: RefType::FUNCREF,
+            items: ReindexedElementItems::Functions(vec![0]), // imported func
+        },
+        ReindexedElementSegment {
+            mode: ElementSegmentMode::Active {
+                table_index: 1,
+                offset: ConstExpr::i32_const(0),
+            },
+            element_type: RefType::FUNCREF,
+            items: ReindexedElementItems::Functions(vec![2]), // defined func
+        },
+    ];
+
+    // Defined function 1: the dead lowered-import trampoline over table 0.
+    let mut tramp = Function::new([]);
+    tramp
+        .instructions()
+        .i32_const(0)
+        .call_indirect(0, 1) // table 0 (import table), type 1 (mis-typed)
+        .end();
+    // Defined function 2: a normal exported function.
+    let mut normal = Function::new([]);
+    normal.instructions().end();
+    // Defined function 3: a trampoline, but over the vtable (table 1) — live.
+    let mut vtramp = Function::new([]);
+    vtramp
+        .instructions()
+        .i32_const(0)
+        .call_indirect(1, 1) // table 1 (vtable), type 1
+        .end();
+    // Defined function 4: numeric-exported but NOT a bare trampoline.
+    let mut not_tramp = Function::new([]);
+    not_tramp
+        .instructions()
+        .i32_const(1)
+        .i32_const(2)
+        .i32_add()
+        .drop()
+        .end();
+
+    m.functions = vec![
+        merged_func(0, tramp),     // merged idx 1
+        merged_func(0, normal),    // merged idx 2
+        merged_func(1, vtramp),    // merged idx 3
+        merged_func(0, not_tramp), // merged idx 4
+    ];
+
+    m.exports = vec![
+        MergedExport {
+            name: "0".to_string(), // dead trampoline keep-alive — DROP
+            kind: ExportKind::Func,
+            index: 1,
+        },
+        MergedExport {
+            name: "greet".to_string(), // real export — keep
+            kind: ExportKind::Func,
+            index: 2,
+        },
+        MergedExport {
+            name: "9".to_string(), // vtable trampoline — keep (live table)
+            kind: ExportKind::Func,
+            index: 3,
+        },
+        MergedExport {
+            name: "7".to_string(), // numeric but not a trampoline — keep
+            kind: ExportKind::Func,
+            index: 4,
+        },
+    ];
+
+    let stats = dissolve_fixups(&mut m, &[]).unwrap();
+    assert_eq!(
+        stats.trampoline_exports_dropped, 1,
+        "only the dead one drops"
+    );
+
+    let names: Vec<&str> = m.exports.iter().map(|e| e.name.as_str()).collect();
+    assert!(!names.contains(&"0"), "dead trampoline export dropped");
+    assert!(names.contains(&"greet"), "real export preserved");
+    assert!(names.contains(&"9"), "vtable-backed trampoline preserved");
+    assert!(
+        names.contains(&"7"),
+        "non-trampoline numeric export preserved"
+    );
+}
+
+/// Guard: a single-SP shared module (nothing to coalesce) and a two-SP module
+/// with DIFFERING inits (conservative equal-init rule) are both left
+/// completely unchanged.
+#[test]
+fn conservative_no_coalesce_when_unsure() {
+    // (a) single SP + one plain global: nothing to coalesce.
+    let mut m = merged_base();
+    m.globals = vec![mut_i32_global(1024), mut_i32_global(42)];
+    m.global_index_map.insert((0, 0, 0), 0);
+    m.global_index_map.insert((0, 0, 1), 1);
+    let comps = vec![component_with_globals(
+        vec![parser_global(1024), parser_global(42)],
+        &[(0, "__stack_pointer")],
+    )];
+    let stats = dissolve_fixups(&mut m, &comps).unwrap();
+    assert_eq!(stats.stack_pointers_coalesced, 0);
+    assert_eq!(m.globals.len(), 2, "single SP: globals untouched");
+    assert_eq!(stats.trampoline_exports_dropped, 0);
+
+    // (b) two named SPs but DIFFERENT inits: must not fuse across partitions.
+    let mut m = merged_base();
+    m.globals = vec![mut_i32_global(1024), mut_i32_global(2048)];
+    m.global_index_map.insert((0, 0, 0), 0);
+    m.global_index_map.insert((1, 0, 0), 1);
+    let comps = vec![
+        component_with_globals(vec![parser_global(1024)], &[(0, "__stack_pointer")]),
+        component_with_globals(vec![parser_global(2048)], &[(0, "__stack_pointer")]),
+    ];
+    let stats = dissolve_fixups(&mut m, &comps).unwrap();
+    assert_eq!(
+        stats.stack_pointers_coalesced, 0,
+        "differing SP inits are not coalesced"
+    );
+    assert_eq!(m.globals.len(), 2);
+
+    // (c) two UNNAMED mutable-i32 globals sharing an init (no `name` section
+    // marking either `__stack_pointer`): must NOT coalesce (Mythos #334 review —
+    // an init-value guess would fuse two unrelated globals and clobber one
+    // component's writes). Absent the authoritative name, we never guess.
+    let mut m = merged_base();
+    m.globals = vec![mut_i32_global(1024), mut_i32_global(1024)];
+    m.global_index_map.insert((0, 0, 0), 0);
+    m.global_index_map.insert((1, 0, 0), 1);
+    let comps = vec![
+        component_with_globals(vec![parser_global(1024)], &[]),
+        component_with_globals(vec![parser_global(1024)], &[]),
+    ];
+    let stats = dissolve_fixups(&mut m, &comps).unwrap();
+    assert_eq!(
+        stats.stack_pointers_coalesced, 0,
+        "unnamed same-init globals are not coalesced (no init-value guessing)"
+    );
+    assert_eq!(m.globals.len(), 2, "unnamed globals untouched");
+}

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1707,3 +1707,61 @@ artifacts:
         absolute address purely as a value (no load/store) still slips the
         hard-error gate; does not affect the supported `--emit-relocs` path.
 
+  - id: SR-49
+    type: sw-req
+    title: Fused shared-memory output is directly MCU-dissolvable
+    description: >
+      When `meld fuse --memory shared` flattens a wac-composed multi-provider
+      node for the single-address-space (MCU) dissolve path, the fused core
+      module shall not leave artifacts that block a downstream
+      `synth --native-pointer-abi --shadow-stack-size` lowering (#334). Two are
+      required:
+      (1) SHADOW-STACK COALESCING — the fused module shall carry a SINGLE
+      `__stack_pointer` global, not one per input component. A shared linear
+      memory has one shadow stack; leaving N mutable `i32` globals all
+      initialised to the same `sp_init` is UNSOUND (two components descending
+      from the shared-memory top clobber each other's frames on a
+      cross-component call) and defeats synth's shadow-stack rebasing (it cannot
+      uniquely identify the stack global, synth#707). meld shall keep one
+      survivor and redirect every `global.get`/`global.set` of the coalesced
+      duplicates to it, dropping the extras.
+      (2) DEAD-SHIM DCE — the vestigial wac lowered-import trampoline (a
+      `call_indirect` through an `$imports` table, exported as `"0"`, that
+      becomes unreachable and mis-typed once meld flattens the real
+      cross-component calls to direct calls) shall not survive in the fused
+      output: meld shall drop its keep-alive export (or not materialise it once
+      imports are internalised) so it is DCE-eligible. A surviving mis-typed
+      trampoline is loud-declined by synth's closed-world check (synth#642/#676),
+      skipping the function.
+      Result: the fused node dissolves cleanly (zero warnings) to a
+      budget-fitting relocatable object — gale's gust:os v0.4.0 buffer node fits
+      the STM32F100 8 KiB SRAM budget without the hand WAT surgery gale currently
+      applies.
+    status: proposed
+    tags: [memory-strategy, shared-memory, mcu, dissolve, dce, v0.41.0]
+    links:
+      - type: derives-from
+        target: SYS-2
+      - type: derives-from
+        target: SYS-8
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/334"
+        kind: github
+        last-checked: 2026-07-11
+    release: v0.41.0
+    fields:
+      implementation:
+        - meld-core/src/merger.rs
+        - meld-core/src/rewriter.rs
+      verification-method: test
+      verification-description: >
+        PLANNED. (1) A fused two-provider shared-memory module exposes exactly
+        one mutable `i32` `__stack_pointer`-class global (init == sp_init), and
+        every use of a coalesced duplicate is redirected to the survivor
+        (global-index remap verified; a runtime check that two providers' frames
+        do not alias). (2) The fused output contains no exported `call_indirect`
+        trampoline over an import table — the dead shim's keep-alive export is
+        dropped so it DCEs. End-to-end oracle on the gale app-tl repro: the fused
+        module lowers under `synth ... --native-pointer-abi --shadow-stack-size`
+        with zero closed-world/shadow-stack warnings and fits the 8 KiB budget.
+


### PR DESCRIPTION
Makes a `meld fuse --memory shared` wac-composed multi-provider node dissolve cleanly on an MCU (SR-49) — the "ergonomics gate" gale currently hand-works-around with WAT surgery, and the companion to #326.

A post-merge pass (`mcu_dissolve.rs`, gated on `SharedMemory`, run before encoding so DWARF/attestation stay consistent) does two fixups:

1. **Coalesce the N per-component `__stack_pointer` globals into one** shared shadow stack. Leaving them separate is **unsound** (providers descending from the shared-memory top clobber each other's frames on a cross-component call) and blocks synth's shadow-stack rebasing (synth#707). Keep one survivor, redirect `global.get`/`global.set` of the duplicates via the existing rewriter machinery, renumber survivors down, drop extras.
2. **Drop the dead lowered-import shim trampoline's keep-alive export** (the numeric `"0"` export over an unreachable, import-dispatched `call_indirect`) so synth DCEs it instead of loud-declining (synth#642/#676).

## Conservative detection (the risk area)
SP coalescing uses **only** the authoritative `name`-section signal (`__stack_pointer`). An init-value fallback heuristic was **rejected during this branch's Mythos pass** — it could fuse two unrelated mutable-i32 globals in different components that merely share an init value, silently clobbering one component's writes. Absent the name, meld does not guess. Trampoline drop requires numeric name + strict body shape + unreachable + import dispatch table.

## Tests (457 lib + 4 integration green; clippy + fmt clean)
- `stack_pointer_globals_coalesced` — 3→2 globals, exactly one SP remains, redirect + renumber verified.
- `shared_stack_pointer_runtime_non_clobber` — **wasmtime**: pre-coalesce the nested provider call clobbers the caller's frame; post-coalesce it doesn't.
- `dead_import_trampoline_export_dropped` — dead `"0"` dropped; real/vtable/non-trampoline exports kept.
- `conservative_no_coalesce_when_unsure` — single-SP, differing-init, AND unnamed same-init all → 0 coalesced.

## Falsification
If SP coalescing regressed, `shared_stack_pointer_runtime_non_clobber` (frames alias) fails. If detection became unsafe, `conservative_no_coalesce_when_unsure` (unnamed same-init coalesced) fails. If the trampoline drop hit a live export, `dead_import_trampoline_export_dropped` (kept exports) fails.

Refs #334, SR-49, SYS-2, SYS-8, synth#707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)