### PR TITLE
chore(release): v0.41.1 — reproducible output no longer path-dependent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.41.1] - 2026-07-15
+
+Reproducibility patch: `--reproducible` output no longer depends on the input
+file path.
+
+**Falsification:** if the input path leaked into the output again,
+`test_reproducible_attestation_is_byte_stable` fails — it now asserts that
+byte-identical input under two different paths fuses to the same sha, while the
+non-reproducible control still differs.
+
+### Fixed
+
+- **`--reproducible` was still path-dependent (#341).** #325 removed the
+  random-UUID/wall-clock nondeterminism, but the caller-supplied component name
+  (the CLI passes the input file *path*) still leaked into the output via the
+  attestation input descriptor and the provenance `component_id`, so
+  byte-identical components at different paths fused to different sha256s. Under
+  `--reproducible`, the input identifier is now the positional `component-{index}`
+  (path/filename-independent); the input's content stays pinned by its sha256.
+  Two CI checkouts / temp dirs fusing the same component now agree — restoring
+  the re-verifiable, sigil-signable attestation the jess/Pixhawk first-flash
+  image set needs.
+
 ## [0.41.0] - 2026-07-15
 
 MCU-dissolve completion + a const-expr correctness fix. v0.40.0 made

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.41.0"
+version = "0.41.1"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1868,3 +1868,52 @@ artifacts:
         const-first pure fold are unchanged. Two Mythos passes (the second caught
         the operand-swapped sibling + the imported-global index-map ordering bug).
 
+  - id: SR-52
+    type: sw-req
+    title: Reproducible output depends only on input content
+    description: >
+      With `--reproducible`, the fused artifact shall be byte-identical for
+      byte-identical INPUT CONTENT, independent of anything not derived from that
+      content: no random state, no wall-clock, and no caller-supplied path/name.
+      (#325) The attestation id shall be derived from the output content and the
+      timestamp from `SOURCE_DATE_EPOCH` (default epoch 0) rather than a random
+      UUID + wall clock. (#341) The caller-supplied component name — which the
+      CLI populates from the input FILE PATH — shall NOT leak into the output:
+      under `--reproducible` the input identifier in the attestation input
+      descriptor and the provenance `component_id` shall be the positional
+      `component-{index}`, with the input's content still pinned by its sha256
+      (`original_hash`). Rationale: two parties, CI checkouts, or temp dirs
+      fusing the same component must obtain the same sha for a re-verifiable,
+      sigil-signable attestation (jess/Pixhawk first-flash image set). Off the
+      `--reproducible` path the human-friendly name is retained.
+    status: verified
+    tags: [attestation, reproducibility, supply-chain, v0.41.1]
+    links:
+      - type: derives-from
+        target: SYS-10
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/325"
+        kind: github
+        last-checked: 2026-07-15
+      - uri: "https://github.com/pulseengine/meld/issues/341"
+        kind: github
+        last-checked: 2026-07-15
+    release: v0.41.1
+    fields:
+      implementation:
+        - meld-core/src/attestation.rs
+        - meld-core/src/provenance.rs
+        - meld-core/src/lib.rs
+      verification-method: test
+      verification-description: >
+        VERIFIED (#341 merged 2026-07-15; #325 v0.38.0).
+        `test_reproducible_attestation_is_byte_stable` (meld-core/src/lib.rs,
+        default features): reproducible fusion is byte-identical across
+        independent runs (#325); byte-identical input under two DIFFERENT paths
+        (`/tmp/pa/falcon.wasm` vs `/tmp/pb/falcon.wasm`) fuses to the SAME output
+        under `--reproducible` (#341, was different pre-fix); the
+        non-reproducible control differs (random attestation id + retained name),
+        so the flag is not a no-op. Path leak closed at all three output sites
+        (default attestation descriptor, wsc `InputArtifact`, provenance
+        `component_id`).
+


### PR DESCRIPTION
Cut **v0.41.1** (0.41.0 → 0.41.1). Scope: **#341** — `--reproducible` output no longer depends on the input file path.

## Gate
- `rivet release status v0.41.1` → **Cuttable** (SR-52 `verified`)
- `rivet validate` → **PASS**
- CHANGELOG `[0.41.1]` with falsification

## What ships
Under `--reproducible`, the caller-supplied component name (CLI passes the input path) no longer leaks into the output — the input identifier is positional `component-{index}` at all three sites (attestation descriptor, wsc `InputArtifact`, provenance `component_id`), content pinned by sha256. Byte-identical inputs at different paths now fuse identically.

## Note
**#339** (the Finding-A value-pointer gate) was investigated but **not shipped** — the fix is undecidable without reloc metadata and would over-reject real components + un-do #298. Documented on the issue as a by-design residual (`--emit-relocs` is the sound path).

Refs #341, #325, SR-52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)