### PR TITLE
chore(release): v0.41.2 — stale reloc.CODE backstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.41.2] - 2026-07-16
+
+Soundness patch: stale relocation metadata can no longer silently miscompile
+shared-memory fusion.
+
+**Falsification:** if a producer's drifted `reloc.CODE` site slipped through
+un-rebased again, `test_351_stale_reloc_offsets_hard_error` fails — it fuses the
+exact reproducing components and asserts the hard `MisalignedReloc` at code
+offset 42, while the consistent-reloc oracle still rebases correctly.
+
 ### Fixed
 
 - **Stale `reloc.CODE` offsets no longer silently miscompile shared-memory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.41.1"
+version = "0.41.2"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts **v0.41.2**, shipping the #351 soundness backstop (#352, SR-53 verified).

- meld now hard-fails with `MisalignedReloc` when a `reloc.CODE` memory-address
  site does not land on a rebasable immediate (stale/drifted relocs from
  LEB-relaxation; upstream pulseengine/wasm-tools#3), instead of silently
  miscompiling `--memory shared --address-rebase` output.
- avrabe confirmed the fix on a fresh build (#351).
- `rivet release status v0.41.2` → ✓ cuttable (1 artifact, verified).

**Falsification:** `test_351_stale_reloc_offsets_hard_error`.

Version bump 0.41.1 → 0.41.2; CHANGELOG rolled. Tag `v0.41.2` cut on merge.