### PR TITLE
chore(release): v0.41.3 — --component output correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.41.3] - 2026-07-17
+
+Correctness patch for the `--component` output path.
+
+**Falsification:** if a bare world export lifted with the wrong (or empty)
+signature again, `component_bare_export_355.rs` fails (invalid component /
+wrong arity); if a component exporting ≥2 interfaces mis-bound an export,
+`component_multi_interface_instance_idx.rs` fails.
+
 ### Fixed
 - **`fuse --component` emitted an invalid component for non-empty export
   signatures (#355).** Bare *world* exports (e.g. `world root { export get-b:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.41.2"
+version = "0.41.3"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts **v0.41.3**, shipping the #355 fixes (merged in #357).

- `fuse --component` now lifts bare *world* exports with their real signatures
  (was an empty `(func)` → **invalid** component for any non-empty signature).
- A component exporting ≥2 interfaces now binds each export to its own instance
  (sibling index-desync surfaced by the #355 Mythos pass).

SR-54 (verified). Falsification: `component_bare_export_355.rs` +
`component_multi_interface_instance_idx.rs`. Version bump 0.41.2 → 0.41.3;
CHANGELOG rolled. Tag `v0.41.3` on merge.