### PR TITLE
refactor(adr7): extract the address-strategy seam from the merger (path-H inc 1)

### DIFF
--- a/meld-core/src/address_strategy.rs
+++ b/meld-core/src/address_strategy.rs
@@ -1,0 +1,209 @@
+//! Address / memory strategy seam (ADR-7 path-H, increment 1).
+//!
+//! meld places each fused module's linear memory somewhere in the output's
+//! address space, and how a module's *absolute addresses* are handled depends
+//! on the memory strategy in force:
+//!
+//! - **multi-memory** — each component keeps its own memory; nothing to rebase.
+//! - **shared-rebase** (ADR-6 path-D) — the module is placed at a shared-memory
+//!   base and its `reloc.CODE`/`reloc.DATA` memory-address sites are shifted by
+//!   that base (the #326→#340 reloc consumer, with the #351 stale-reloc backstop).
+//! - **static-base PIC** (ADR-7 / #353, future) — PIC inputs compute addresses
+//!   from `__memory_base`; meld folds a disjoint constant base per module. No
+//!   absolute-address relocation sites exist, so this strategy will short-circuit
+//!   the reloc machinery entirely.
+//!
+//! This module is the single home for that decision. Increment 1 extracts the
+//! existing shared-rebase resolution here **behavior-preservingly** — same
+//! validation (`MissingRelocMetadata`, memory64 reject, `MisalignedReloc`), same
+//! short-circuits — so the pluggable variants above can be added later without
+//! touching the merger's hot path. The canonical/multi path is unchanged (it
+//! resolves to an empty plan).
+
+use crate::{Error, Result};
+
+/// What the address strategy resolved for one module: which relocation sites the
+/// rewriter must rebase. An empty plan (`code_addr_relocs: None`, no data
+/// entries) means "no address rebasing for this module" (multi-memory, or shared
+/// memory with a zero base / no reloc metadata).
+#[derive(Debug, Default)]
+pub struct AddressPlan {
+    /// Code-section byte offsets of `R_WASM_MEMORY_ADDR_*` sites to rebase
+    /// ([`crate::reloc::RelocInfo::code_memory_addr_offsets`]). `None` = the
+    /// legacy blanket path (a no-op when the base is 0); `Some` = reloc-driven.
+    pub code_addr_relocs: Option<std::collections::HashSet<u32>>,
+    /// `reloc.DATA` `R_WASM_MEMORY_ADDR_I32` inline pointers to rebase in the
+    /// data segments' payloads.
+    pub data_addr_relocs: Vec<crate::reloc::RelocEntry>,
+}
+
+/// Resolve the address plan for one module placed at `memory_base_offset`.
+///
+/// `has_direct_memory_access` is evaluated **lazily** (only when a non-zero base
+/// carries no reloc metadata) so a component that never needs the check pays
+/// nothing and cannot fail on it — preserving the merger's original
+/// short-circuit exactly.
+///
+/// Behaviour (shared-rebase strategy; unchanged from the pre-extraction merger):
+/// - `address_rebasing == false` → empty plan.
+/// - non-zero base, no reloc metadata, direct memory access → `MissingRelocMetadata`
+///   (ADR-6 path-F: cannot rebase baked-in absolute addresses → don't silently
+///   corrupt).
+/// - reloc metadata with non-32-bit inline data pointers (memory64) →
+///   `UnsupportedFeature` (#326 Finding B).
+/// - reloc metadata whose `reloc.CODE` sites no longer land on rebasable
+///   immediates → `MisalignedReloc` (#351 backstop; stale/relaxed relocs).
+/// - reloc metadata otherwise → the code/data reloc sites to rebase.
+/// - no reloc metadata (and base 0 or bulk-only access) → empty plan.
+#[allow(clippy::too_many_arguments)]
+pub fn resolve_address_plan(
+    custom_sections: &[(String, Vec<u8>)],
+    code_section_range: Option<(usize, usize)>,
+    module_bytes: &[u8],
+    memory_base_offset: u64,
+    address_rebasing: bool,
+    component_name: &str,
+    module_idx: usize,
+    has_direct_memory_access: impl FnOnce() -> Result<bool>,
+) -> Result<AddressPlan> {
+    if !address_rebasing {
+        return Ok(AddressPlan::default());
+    }
+
+    let has_reloc = crate::reloc::has_reloc_metadata(custom_sections);
+
+    // Path-F (ADR-6): a non-zero-base module with no reloc metadata that does
+    // *direct* (non-bulk) memory access has absolute addresses we cannot find —
+    // emitting it unchanged would collide it with a prior module. Hard-fail.
+    if memory_base_offset != 0 && !has_reloc && has_direct_memory_access()? {
+        return Err(Error::MissingRelocMetadata {
+            component: component_name.to_string(),
+            module: module_idx.to_string(),
+        });
+    }
+
+    if !has_reloc {
+        return Ok(AddressPlan::default());
+    }
+
+    let info = crate::reloc::parse_reloc_info(custom_sections)?;
+
+    // #326 Finding B: memory64 emits 8-byte inline data pointers we cannot
+    // rebase; the segment moves while the pointers stay stale. Reject.
+    if info.has_unhandled_data_addr_relocs() {
+        return Err(Error::UnsupportedFeature(format!(
+            "component '{component_name}' module {module_idx}: shared-memory \
+             rebasing of non-32-bit inline data pointers (memory64 reloc.DATA) \
+             is not supported (#326)",
+        )));
+    }
+
+    let data_addr_relocs = info.data_memory_addr_entries();
+    let code_offsets = info.code_memory_addr_offsets();
+
+    // #351 backstop: every reloc.CODE memory-address site must still land on a
+    // rebasable immediate; a producer that relaxed LEB immediates without
+    // rewriting reloc offsets (pulseengine/wasm-tools#3) leaves them drifted.
+    if let Some((start, end)) = code_section_range {
+        let code_content = &module_bytes[start..end];
+        if let Some(offset) =
+            crate::reloc::first_misaligned_code_reloc(code_content, &code_offsets)?
+        {
+            return Err(Error::MisalignedReloc {
+                component: component_name.to_string(),
+                module: module_idx.to_string(),
+                offset,
+            });
+        }
+    }
+
+    Ok(AddressPlan {
+        code_addr_relocs: Some(code_offsets),
+        data_addr_relocs,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    // A module with no reloc custom sections.
+    fn no_reloc() -> Vec<(String, Vec<u8>)> {
+        vec![("name".to_string(), vec![0])]
+    }
+
+    #[test]
+    fn rebasing_off_is_empty_plan_and_never_probes_memory_access() {
+        let probed = Cell::new(false);
+        let plan = resolve_address_plan(
+            &no_reloc(),
+            None,
+            &[],
+            0x1_0000,
+            false, // address_rebasing off
+            "c",
+            0,
+            || {
+                probed.set(true);
+                Ok(true)
+            },
+        )
+        .unwrap();
+        assert!(plan.code_addr_relocs.is_none());
+        assert!(plan.data_addr_relocs.is_empty());
+        assert!(
+            !probed.get(),
+            "must not probe memory access when rebasing is off"
+        );
+    }
+
+    #[test]
+    fn base_zero_no_reloc_is_empty_plan_without_probe() {
+        // At base 0 there is nothing to collide with, so the path-F check (and
+        // its memory-access probe) must be skipped even without reloc metadata.
+        let probed = Cell::new(false);
+        let plan = resolve_address_plan(
+            &no_reloc(),
+            None,
+            &[],
+            0, // base 0
+            true,
+            "c",
+            0,
+            || {
+                probed.set(true);
+                Ok(true)
+            },
+        )
+        .unwrap();
+        assert!(plan.code_addr_relocs.is_none());
+        assert!(
+            !probed.get(),
+            "base 0 must not trigger the direct-access probe"
+        );
+    }
+
+    #[test]
+    fn nonzero_base_no_reloc_direct_access_hard_fails() {
+        let err = resolve_address_plan(&no_reloc(), None, &[], 0x1_0000, true, "comp", 3, || {
+            Ok(true)
+        })
+        .unwrap_err();
+        assert!(
+            matches!(err, Error::MissingRelocMetadata { .. }),
+            "expected MissingRelocMetadata, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn nonzero_base_no_reloc_bulk_only_is_empty_plan() {
+        // No reloc but only bulk-memory access (probe returns false): safe — the
+        // rewriter rebases bulk ops' runtime operands, so no baked address hides.
+        let plan =
+            resolve_address_plan(&no_reloc(), None, &[], 0x1_0000, true, "c", 0, || Ok(false))
+                .unwrap();
+        assert!(plan.code_addr_relocs.is_none());
+        assert!(plan.data_addr_relocs.is_empty());
+    }
+}

--- a/meld-core/src/address_strategy.rs
+++ b/meld-core/src/address_strategy.rs
@@ -17,8 +17,17 @@
 //! existing shared-rebase resolution here **behavior-preservingly** — same
 //! validation (`MissingRelocMetadata`, memory64 reject, `MisalignedReloc`), same
 //! short-circuits — so the pluggable variants above can be added later without
-//! touching the merger's hot path. The canonical/multi path is unchanged (it
-//! resolves to an empty plan).
+//! touching the merger's hot path.
+//!
+//! **Scope — this is *only* the absolute-address rebasing decision.** An
+//! [`AddressPlan`] carries *which relocation sites to shift* for a non-zero
+//! shared-memory base, and nothing else. Under **multi-memory** each component
+//! keeps its own linear memory at its own base, so there are no sites to shift
+//! and the plan is **empty** — an empty plan means "no address rebasing needed
+//! here", **not** that fusion is disabled. It does **not** touch cross-component
+//! adapter (FACT) generation, transcoding, or any other part of the merge: those
+//! run identically regardless of what this resolves. Multi-memory + FACT remains
+//! the generic, first-class fusion path (ADR-7's canonical / `open` profile).
 
 use crate::{Error, Result};
 

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -48,6 +48,7 @@
 
 pub mod abi_proofs;
 pub mod adapter;
+pub mod address_strategy;
 pub mod attestation;
 pub mod component_wrap;
 pub mod custom_merge;

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -1915,69 +1915,25 @@ impl Merger {
             .and_then(|plan| plan.bases.get(&(comp_idx, mod_idx)).copied())
             .unwrap_or(0);
 
-        // #326: relocation-driven address rebasing. A module placed at a
-        // non-zero shared-memory base has its absolute addresses shifted by
-        // that base; the `reloc.CODE` MEMORY_ADDR sites name exactly which
-        // `i32.const`/`memarg` immediates encode those addresses.
-        //
-        // Path-F (ADR-6): if such a module carries NO reloc metadata we cannot
-        // find its absolute addresses, so emitting it unchanged would collide
-        // it with a prior module and silently corrupt memory. Hard-fail —
-        // BUT only when the module actually performs *direct* (non-bulk)
-        // memory access. A module whose every memory touch is a bulk-memory op
-        // (`memory.copy/fill/init`) is safe without relocs: the rewriter
-        // rebases those ops' runtime address operands dynamically
-        // (`append_rebased_address`), so no baked-in absolute address can hide.
-        let mut data_addr_relocs: Vec<crate::reloc::RelocEntry> = Vec::new();
-        let code_addr_relocs = if self.address_rebasing {
-            let has_reloc = crate::reloc::has_reloc_metadata(&module.custom_sections);
-            if memory_base_offset != 0 && !has_reloc && module_has_direct_memory_access(module)? {
-                return Err(Error::MissingRelocMetadata {
-                    component: component_display_name(components, comp_idx),
-                    module: mod_idx.to_string(),
-                });
-            }
-            if has_reloc {
-                let info = crate::reloc::parse_reloc_info(&module.custom_sections)?;
-                // #326 Finding B: a memory64 module emits 8-byte inline data
-                // pointers (`R_WASM_MEMORY_ADDR_I64`) we cannot rebase; the
-                // segment placement would move while the pointers stay stale —
-                // silent corruption. Reject rather than emit a wrong module.
-                if info.has_unhandled_data_addr_relocs() {
-                    return Err(Error::UnsupportedFeature(format!(
-                        "component '{}' module {mod_idx}: shared-memory rebasing of \
-                         non-32-bit inline data pointers (memory64 reloc.DATA) is not \
-                         supported (#326)",
-                        component_display_name(components, comp_idx),
-                    )));
-                }
-                data_addr_relocs = info.data_memory_addr_entries();
-                let code_offsets = info.code_memory_addr_offsets();
-                // #351 backstop: verify every reloc.CODE memory-address site
-                // still lands on a rebasable immediate. A producer that relaxed
-                // LEB immediates without rewriting reloc offsets
-                // (pulseengine/wasm-tools#3) leaves them drifted; a drifted site
-                // is applied to the wrong operator or silently skipped, so
-                // hard-fail rather than corrupt the shared address space.
-                if let Some((start, end)) = module.code_section_range {
-                    let code_content = &module.bytes[start..end];
-                    if let Some(offset) =
-                        crate::reloc::first_misaligned_code_reloc(code_content, &code_offsets)?
-                    {
-                        return Err(Error::MisalignedReloc {
-                            component: component_display_name(components, comp_idx),
-                            module: mod_idx.to_string(),
-                            offset,
-                        });
-                    }
-                }
-                Some(code_offsets)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        // Address / memory strategy (ADR-7 path-H): resolve which relocation
+        // sites this module needs rebased for its shared-memory placement. The
+        // full decision + validation (path-F MissingRelocMetadata, memory64
+        // reject, the #351 MisalignedReloc backstop) lives in
+        // `address_strategy`; `has_direct_memory_access` is passed as a closure
+        // so it stays lazily evaluated (only a non-zero-base, no-reloc module
+        // pays the check — the original short-circuit).
+        let address_plan = crate::address_strategy::resolve_address_plan(
+            &module.custom_sections,
+            module.code_section_range,
+            &module.bytes,
+            memory_base_offset,
+            self.address_rebasing,
+            &component_display_name(components, comp_idx),
+            mod_idx,
+            || module_has_direct_memory_access(module),
+        )?;
+        let data_addr_relocs = address_plan.data_addr_relocs;
+        let code_addr_relocs = address_plan.code_addr_relocs;
 
         let module_memory = if self.address_rebasing {
             module_memory_type(module)?


### PR DESCRIPTION
Executes **ADR-7 path-H, increment 1** (#354): extract the per-module
address/memory strategy resolution out of `Merger::merge` into a dedicated
`address_strategy` module — **behavior-preservingly**. This is the pluggable seam
the decided architecture hangs off.

## What

- `address_strategy.rs` — `AddressPlan` + `resolve_address_plan`, holding the full
  decision + validation (ADR-6 path-F `MissingRelocMetadata`, memory64 reject,
  the #351 `MisalignedReloc` backstop). `has_direct_memory_access` is passed as a
  **closure** so the original lazy short-circuit (only a non-zero-base, no-reloc
  module pays the probe) is preserved exactly.
- `merger.rs` — the ~50-line reloc-consumption block replaced with one call.
- 4 focused unit tests (rebasing-off / base-0 / no-reloc-direct → hard-fail /
  bulk-only → empty, plus closure-laziness).

## Scope of `AddressPlan` (does *not* affect multi-memory + FACT fusion)

An `AddressPlan` carries **only** which relocation sites to shift for a non-zero
shared-memory base — nothing else. Under **multi-memory**, each component keeps
its own linear memory at its own base, so there are no sites to shift and the
plan is **empty**. An empty plan means *"no address rebasing needed here"* — it
is **not** a disablement of fusion, and it does **not** touch cross-component
adapter (**FACT**) generation, transcoding, or any other part of the merge. Those
run identically regardless of what this seam resolves. Multi-memory + FACT stays
the generic, first-class fusion path (ADR-7's canonical / `open` profile);
`multi_memory` fixtures remain green (6/6).

The shared-rebase strategy now lives here. **Static-base PIC (#353)** and the
**per-boundary call-lowering seam** are the next increments — they plug in here
without touching the merger's hot path.

## No behavior change

Canonical gating fixtures (`test_326_reloc_const_rebasing_end_to_end`,
`test_address_rebasing_end_to_end`) + `drop_realloc` + full `meld-core` suite all
green; fmt + clippy clean. Pure structural extraction.

Tier-5 (merger.rs + new fusion-critical module) → Mythos discover pass to follow.

Refs #354 (ADR-7)
