### PR TITLE
feat(adr7): multiply-instantiated module support — RFC-46 Q1 (path-H inc 3)

### DIFF
--- a/meld-core/src/core_instance_topology.rs
+++ b/meld-core/src/core_instance_topology.rs
@@ -1,0 +1,257 @@
+//! Core-instance topology normalization (ADR-7 path-H, increment 3 — RFC-46 Q1).
+//!
+//! RFC-46 open question Q1 is *multiply-instantiated modules*: what does a fuser
+//! do when a component instantiates the same core module more than once? The RFC
+//! options are **reject**, **duplicate**, or **multi-module output**. meld
+//! shipped "reject" first (SR-31, `DuplicateModuleInstantiation`); this module is
+//! the **"duplicate"** resolution.
+//!
+//! ## The idea: turn N instances into N distinct modules
+//!
+//! The merger's index-space machinery is already proven correct for **N distinct
+//! modules** — it allocates each module its own functions / memories / tables /
+//! globals and rebases every index, keying its merge maps by
+//! `(component_idx, module_idx, local_idx)`. "The same module instantiated N
+//! times" is just a special case: give each instantiation its **own** module
+//! identity and the existing machinery does the rest.
+//!
+//! [`expand_multiply_instantiated_modules`] does exactly that — for each 2nd..Nth
+//! instantiation of a core module it appends a deep clone of that module (a fresh
+//! `module_idx`) and rewrites the instantiation to reference the clone. After the
+//! pass **no core module is instantiated more than once**, so:
+//!
+//! - each instance gets **independent** functions/memory/tables/globals — two
+//!   instances cannot share mutable state (the STPA **H-1** hazard the "duplicate"
+//!   option must avoid); and
+//! - every `(component, module)`-keyed merge map (`segment_bases`, `realloc_map`,
+//!   the resource maps, the five index maps) gets a **distinct key per instance**,
+//!   so the second instance can never overwrite the first (the silent-corruption
+//!   failure mode of naïve duplication).
+//!
+//! A component that instantiates each module at most once is returned unchanged.
+//!
+//! ## Status — mechanism only (activation gated)
+//!
+//! This pass is the *mechanism*. Wiring it into the fuse pipeline (and dropping
+//! the [`crate::Error::DuplicateModuleInstantiation`] reject) flips a **verified
+//! safety requirement** (SR-31) and must be gated on a differential
+//! *execution* oracle proving two instances of one module keep **independent
+//! mutable state** end-to-end — identical-content module duplication can stress
+//! export-name and segment handling that a structural test cannot see. Until that
+//! oracle lands, meld still rejects multiply-instantiated modules at fuse time;
+//! this module is exercised only by its own structural unit tests.
+
+use crate::parser::{InstanceKind, ParsedComponent};
+use std::collections::HashSet;
+
+/// Expand each 2nd..Nth instantiation of a core module into its own distinct
+/// [`CoreModule`](crate::parser::CoreModule), rewriting that instantiation to
+/// reference the fresh module index. Returns the number of duplicate modules
+/// synthesized (0 = the component was left unchanged).
+///
+/// See the module docs for why this reuses the merger's proven per-module
+/// machinery and cannot share mutable state or overwrite merge-map entries.
+pub fn expand_multiply_instantiated_modules(component: &mut ParsedComponent) -> usize {
+    let mut seen: HashSet<u32> = HashSet::new();
+    let mut duplicates = 0usize;
+
+    for i in 0..component.instances.len() {
+        // Copy the instantiated module index out so the borrow is released
+        // before we mutate `core_modules` / `instances` below.
+        let module_idx = match &component.instances[i].kind {
+            InstanceKind::Instantiate { module_idx, .. } => *module_idx,
+            InstanceKind::FromExports(_) => continue,
+        };
+
+        // First instantiation of this module — nothing to do.
+        if seen.insert(module_idx) {
+            continue;
+        }
+
+        // Nth instantiation (N >= 2): clone the source module under a fresh
+        // index. Locate the source by its recorded `.index` rather than by
+        // position, so this is robust even if `core_modules` is ever non-dense.
+        let Some(src_pos) = component
+            .core_modules
+            .iter()
+            .position(|m| m.index == module_idx)
+        else {
+            // No matching module (malformed input) — leave it for the merger's
+            // own validation to reject; don't paper over it here.
+            continue;
+        };
+
+        let new_index = component.core_modules.len() as u32;
+        let mut dup = component.core_modules[src_pos].clone();
+        dup.index = new_index;
+        component.core_modules.push(dup);
+        seen.insert(new_index);
+
+        // Point this instantiation at the fresh module so the merger sees a
+        // distinct module identity for it.
+        if let InstanceKind::Instantiate { module_idx, .. } = &mut component.instances[i].kind {
+            *module_idx = new_index;
+        }
+        duplicates += 1;
+    }
+
+    duplicates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::{ComponentInstance, CoreModule, InstanceKind};
+
+    fn mk_module(index: u32) -> CoreModule {
+        CoreModule {
+            index,
+            bytes: vec![index as u8], // distinct marker so clones are traceable
+            types: vec![],
+            imports: vec![],
+            exports: vec![],
+            functions: vec![],
+            memories: vec![],
+            tables: vec![],
+            globals: vec![],
+            start: None,
+            data_count: None,
+            element_count: 0,
+            custom_sections: vec![],
+            code_section_range: None,
+            global_section_range: None,
+            element_section_range: None,
+            data_section_range: None,
+        }
+    }
+
+    fn instantiate(index: u32, module_idx: u32) -> ComponentInstance {
+        ComponentInstance {
+            index,
+            kind: InstanceKind::Instantiate {
+                module_idx,
+                args: vec![],
+            },
+        }
+    }
+
+    fn mk_component(
+        modules: Vec<CoreModule>,
+        instances: Vec<ComponentInstance>,
+    ) -> ParsedComponent {
+        ParsedComponent {
+            name: None,
+            core_modules: modules,
+            imports: vec![],
+            exports: vec![],
+            types: vec![],
+            instances,
+            canonical_functions: vec![],
+            sub_components: vec![],
+            component_aliases: vec![],
+            component_instances: vec![],
+            core_entity_order: vec![],
+            component_func_defs: vec![],
+            component_instance_defs: vec![],
+            component_type_defs: vec![],
+            original_size: 0,
+            original_hash: String::new(),
+            depth_0_sections: vec![],
+            p3_async_features: vec![],
+        }
+    }
+
+    fn module_idxs(c: &ParsedComponent) -> Vec<u32> {
+        c.instances
+            .iter()
+            .filter_map(|i| match &i.kind {
+                InstanceKind::Instantiate { module_idx, .. } => Some(*module_idx),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn single_instantiation_unchanged() {
+        let mut c = mk_component(vec![mk_module(0)], vec![instantiate(0, 0)]);
+        assert_eq!(expand_multiply_instantiated_modules(&mut c), 0);
+        assert_eq!(c.core_modules.len(), 1);
+        assert_eq!(module_idxs(&c), vec![0]);
+    }
+
+    #[test]
+    fn distinct_modules_unchanged() {
+        // Two different modules, each instantiated once — no duplication.
+        let mut c = mk_component(
+            vec![mk_module(0), mk_module(1)],
+            vec![instantiate(0, 0), instantiate(1, 1)],
+        );
+        assert_eq!(expand_multiply_instantiated_modules(&mut c), 0);
+        assert_eq!(c.core_modules.len(), 2);
+        assert_eq!(module_idxs(&c), vec![0, 1]);
+    }
+
+    #[test]
+    fn double_instantiation_creates_one_distinct_module() {
+        let mut c = mk_component(
+            vec![mk_module(0)],
+            vec![instantiate(0, 0), instantiate(1, 0)],
+        );
+        assert_eq!(expand_multiply_instantiated_modules(&mut c), 1);
+        // A fresh module was appended; the two instances now point at distinct
+        // module identities.
+        assert_eq!(c.core_modules.len(), 2);
+        assert_eq!(module_idxs(&c), vec![0, 1]);
+        // The clone is an independent deep copy of the source (same content).
+        assert_eq!(c.core_modules[1].bytes, c.core_modules[0].bytes);
+        assert_eq!(c.core_modules[1].index, 1);
+    }
+
+    #[test]
+    fn triple_instantiation_creates_two_distinct_modules() {
+        let mut c = mk_component(
+            vec![mk_module(0)],
+            vec![instantiate(0, 0), instantiate(1, 0), instantiate(2, 0)],
+        );
+        assert_eq!(expand_multiply_instantiated_modules(&mut c), 2);
+        assert_eq!(c.core_modules.len(), 3);
+        assert_eq!(module_idxs(&c), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn interleaved_duplicate_gets_fresh_index() {
+        // modules 0 and 1; instantiate 0, then 1, then 0 again.
+        let mut c = mk_component(
+            vec![mk_module(0), mk_module(1)],
+            vec![
+                instantiate(0, 0),
+                instantiate(1, 1),
+                instantiate(2, 0), // second instantiation of module 0
+            ],
+        );
+        assert_eq!(expand_multiply_instantiated_modules(&mut c), 1);
+        assert_eq!(c.core_modules.len(), 3);
+        // Only the repeated instantiation is rewritten; it points at the clone
+        // (new index 2), which is a copy of module 0.
+        assert_eq!(module_idxs(&c), vec![0, 1, 2]);
+        assert_eq!(c.core_modules[2].bytes, c.core_modules[0].bytes);
+    }
+
+    #[test]
+    fn from_exports_instances_are_ignored() {
+        // A FromExports instance is not an instantiation and must not count.
+        let mut c = mk_component(
+            vec![mk_module(0)],
+            vec![
+                instantiate(0, 0),
+                ComponentInstance {
+                    index: 1,
+                    kind: InstanceKind::FromExports(vec![]),
+                },
+                instantiate(2, 0), // the real second instantiation of module 0
+            ],
+        );
+        assert_eq!(expand_multiply_instantiated_modules(&mut c), 1);
+        assert_eq!(c.core_modules.len(), 2);
+    }
+}

--- a/meld-core/src/core_instance_topology.rs
+++ b/meld-core/src/core_instance_topology.rs
@@ -30,16 +30,19 @@
 //!
 //! A component that instantiates each module at most once is returned unchanged.
 //!
-//! ## Status — mechanism only (activation gated)
+//! ## Status — wired, execution-oracle-gated (SR-55)
 //!
-//! This pass is the *mechanism*. Wiring it into the fuse pipeline (and dropping
-//! the [`crate::Error::DuplicateModuleInstantiation`] reject) flips a **verified
-//! safety requirement** (SR-31) and must be gated on a differential
-//! *execution* oracle proving two instances of one module keep **independent
-//! mutable state** end-to-end — identical-content module duplication can stress
-//! export-name and segment handling that a structural test cannot see. Until that
-//! oracle lands, meld still rejects multiply-instantiated modules at fuse time;
-//! this module is exercised only by its own structural unit tests.
+//! This pass is wired into [`crate::Fuser::fuse_with_stats`] *before*
+//! resolve/merge, so multiply-instantiated modules now fuse. Because activating
+//! it supersedes the [`crate::Error::DuplicateModuleInstantiation`] reject (a
+//! safety-relevant behavior, SR-31), it is gated on a differential **execution**
+//! oracle — `tests/multiply_instantiated_runtime.rs`
+//! (`two_instances_keep_independent_counter_state`) fuses a component that
+//! instantiates one core module twice, executes it on wasmtime, and asserts the
+//! two instances keep **independent** mutable counter state (a shared-state H-1
+//! corruption would fail it). The SR-31 reject is retained as an unreachable
+//! backstop. See this module's own structural unit tests for the expansion
+//! invariants.
 
 use crate::parser::{InstanceKind, ParsedComponent};
 use std::collections::HashSet;

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -409,6 +409,28 @@ impl Fuser {
         if self.components.is_empty() {
             return Err(Error::NoComponents);
         }
+
+        // RFC-46 Q1 (ADR-7 path-H inc 3): normalize multiply-instantiated core
+        // modules into distinct module identities *before* resolve/merge, so each
+        // instantiation is allocated independent functions/memory/tables/globals
+        // via the merger's per-module machinery (already proven correct for N
+        // distinct modules) — no shared mutable state (H-1), no (component,
+        // module)-keyed map overwrites. After this pass no module is instantiated
+        // more than once, so the `DuplicateModuleInstantiation` reject in the
+        // resolver/merger becomes an unreachable backstop. Idempotent, so a
+        // repeated fuse (after another `add_component`) is safe.
+        let mut duplicated_modules = 0usize;
+        for component in &mut self.components {
+            duplicated_modules +=
+                crate::core_instance_topology::expand_multiply_instantiated_modules(component);
+        }
+        if duplicated_modules > 0 {
+            log::info!(
+                "core-instance topology: duplicated {duplicated_modules} multiply-instantiated \
+                 core module(s) into distinct identities (RFC-46 Q1)"
+            );
+        }
+
         // Restore the originally-requested strategy before resolving, so a
         // repeated fuse (e.g. after another `add_component`) re-derives the
         // resolution from the CURRENT component set instead of reusing a

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod adapter;
 pub mod address_strategy;
 pub mod attestation;
 pub mod component_wrap;
+pub mod core_instance_topology;
 pub mod custom_merge;
 pub mod dwarf;
 mod error;

--- a/meld-core/tests/multiply_instantiated_runtime.rs
+++ b/meld-core/tests/multiply_instantiated_runtime.rs
@@ -1,0 +1,111 @@
+//! RFC-46 Q1 "duplicate" — differential EXECUTION oracle (ADR-7 path-H inc 3).
+//!
+//! The gating oracle for enabling multiply-instantiated-module support: fuse a
+//! component that instantiates ONE core module TWICE, each holding a mutable
+//! counter global, then execute the fused core module on wasmtime and assert the
+//! two instances keep **independent** mutable state (STPA H-1). If duplication
+//! silently shared state, `inc2()` would observe `inc1()`'s increments.
+//!
+//! Until the `core_instance_topology` normalization is wired into the fuse
+//! pipeline, meld REJECTS this component (SR-31, `DuplicateModuleInstantiation`);
+//! `baseline_currently_rejects` pins that pre-wiring behavior and doubles as a
+//! check that the fixture is a genuine multiply-instantiated component.
+
+use meld_core::{Fuser, FuserConfig, MemoryStrategy};
+
+/// A component with a single core module (a mutable counter + `inc`), instantiated
+/// twice, whose two instances' `inc` are lifted as component exports `inc1`/`inc2`.
+fn multiply_instantiated_component() -> Vec<u8> {
+    let wat = r#"
+    (component
+      (core module $m
+        (global $ctr (mut i32) (i32.const 0))
+        (func $inc (result i32)
+          global.get $ctr
+          i32.const 1
+          i32.add
+          global.set $ctr
+          global.get $ctr)
+        (export "inc" (func $inc)))
+      (core instance $i1 (instantiate $m))
+      (core instance $i2 (instantiate $m))
+      (alias core export $i1 "inc" (core func $f1))
+      (alias core export $i2 "inc" (core func $f2))
+      (func $lift1 (result u32) (canon lift (core func $f1)))
+      (func $lift2 (result u32) (canon lift (core func $f2)))
+      (export "inc1" (func $lift1))
+      (export "inc2" (func $lift2)))
+    "#;
+    wat::parse_str(wat).expect("multiply-instantiated component WAT must assemble")
+}
+
+fn base_config() -> FuserConfig {
+    FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        reproducible: false,
+        component_provenance: false,
+        address_rebasing: false,
+        preserve_names: false,
+        custom_sections: meld_core::CustomSectionHandling::Drop,
+        dwarf_handling: meld_core::DwarfHandling::Strip,
+        output_format: meld_core::OutputFormat::CoreModule,
+        opaque_resources: Vec::new(),
+    }
+}
+
+/// The differential execution oracle: fuse the multiply-instantiated component
+/// and prove the two instances keep INDEPENDENT mutable counter state.
+///
+/// Each `inc()` returns the post-increment counter. Interleaving the two exports:
+///   inc1 → 1, inc1 → 2, inc2 → 1, inc1 → 3, inc2 → 2
+/// Independent state gives 1,2,1,3,2. **Shared** state (the H-1 corruption this
+/// feature must avoid) would give 1,2,3,4,5 — so the load-bearing assertion is
+/// that `inc2`'s FIRST call returns 1, not 3.
+#[test]
+fn two_instances_keep_independent_counter_state() {
+    use wasmtime::{Config, Engine, Instance, Module as RuntimeModule, Store};
+
+    let component = multiply_instantiated_component();
+    let mut fuser = Fuser::new(base_config());
+    fuser
+        .add_component_named(&component, Some("multiply-instantiated"))
+        .unwrap();
+    let (fused, _stats) = fuser
+        .fuse_with_stats()
+        .expect("multiply-instantiated module must now fuse (RFC-46 Q1 duplicate support)");
+
+    // Fused output must be a valid core module.
+    let mut validator = wasmparser::Validator::new();
+    validator
+        .validate_all(&fused)
+        .expect("fused multiply-instantiated output should validate");
+
+    let mut engine_config = Config::new();
+    engine_config.wasm_multi_memory(true);
+    let engine = Engine::new(&engine_config).unwrap();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    // The two instances both export the core name `inc`; meld disambiguates the
+    // second instance's export with a `$0` suffix (identical-name dedup). These
+    // are two DISTINCT merged functions over two DISTINCT counter globals.
+    let inc1 = instance
+        .get_typed_func::<(), i32>(&mut store, "inc")
+        .expect("fused module should export inc (instance 1)");
+    let inc2 = instance
+        .get_typed_func::<(), i32>(&mut store, "inc$0")
+        .expect("fused module should export inc$0 (instance 2)");
+
+    assert_eq!(inc1.call(&mut store, ()).unwrap(), 1, "inc1 #1");
+    assert_eq!(inc1.call(&mut store, ()).unwrap(), 2, "inc1 #2");
+    assert_eq!(
+        inc2.call(&mut store, ()).unwrap(),
+        1,
+        "inc2's FIRST call must be 1 — independent state; a 3 here means the two \
+         instances share the counter global (H-1 corruption)"
+    );
+    assert_eq!(inc1.call(&mut store, ()).unwrap(), 3, "inc1 #3");
+    assert_eq!(inc2.call(&mut store, ()).unwrap(), 2, "inc2 #2");
+}

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -840,10 +840,12 @@ artifacts:
     description: >
       The merger shall detect when the same core module is instantiated
       more than once within a component and return a diagnostic error.
-      Silent production of corrupt output shall not occur. Future work
-      may support multi-module component output (per cfallin's "simple
-      component" proposal), but until then, fail-fast rejection is
-      required.
+      Silent production of corrupt output shall not occur. NOTE: SR-55
+      (ADR-7 path-H inc 3) now SUPPORTS multiply-instantiated modules via
+      core-instance duplication, superseding the reject for handleable
+      cases; this detect-and-reject is retained as an unreachable backstop
+      (its ls_m_5 unit test still passes) for any residual meld cannot
+      duplicate soundly.
     status: verified
     tags: [stpa-derived]
     links:
@@ -2044,8 +2046,8 @@ artifacts:
       distinct modules. When active, this SUPERSEDES the SR-31 reject for the
       supported cases; SR-31's fail-fast remains for any residual meld cannot
       duplicate soundly.
-    status: draft
-    tags: [rfc46, adr7, merger, topology, in-progress]
+    status: implemented
+    tags: [rfc46, adr7, merger, topology]
     links:
       - type: derives-from
         target: SYS-2
@@ -2054,24 +2056,32 @@ artifacts:
       - type: mitigates
         target: LS-M-5
     cited-source:
-      - uri: "https://github.com/pulseengine/meld/pull/360"
+      - uri: "https://github.com/pulseengine/meld/pull/362"
         kind: github
         last-checked: 2026-07-21
     fields:
       implementation:
         - meld-core/src/core_instance_topology.rs
+        - meld-core/src/lib.rs
       verification-method: test
       verification-description: >
-        DRAFT — mechanism only. The normalization pass is implemented and
-        structurally unit-tested (core_instance_topology::tests: single/distinct
-        unchanged; double/triple/interleaved expansion to N distinct module
-        identities; FromExports ignored). NOT YET ACTIVE: wiring the pass into
-        the fuse pipeline and dropping the DuplicateModuleInstantiation reject is
-        gated on a differential EXECUTION oracle proving two instances of one
-        module keep independent mutable state end-to-end (a real
-        multiply-instantiated component fixture, fused and executed on wasmtime).
-        Until that oracle is green + a Tier-5 Mythos pass on the wiring, SR-31
-        (reject) remains the shipped, verified behavior.
+        IMPLEMENTED — mechanism + wiring + differential EXECUTION oracle, green
+        locally (CI + merge pending → not yet `verified`). The normalization pass
+        (core_instance_topology) is wired into `Fuser::fuse_with_stats` before
+        resolve/merge, so multiply-instantiated modules now fuse. Verified by:
+        (1) structural unit tests (core_instance_topology::tests — single/distinct
+        unchanged; double/triple/interleaved → N distinct module identities;
+        FromExports ignored); (2) the differential execution oracle
+        multiply_instantiated_runtime::two_instances_keep_independent_counter_state
+        — a component instantiating ONE core module (mutable counter) TWICE is
+        fused (MultiMemory, CoreModule), VALIDATED, and executed on wasmtime; the
+        two instances' counters advance independently (inc→1,2; inc$0→1; inc→3;
+        inc$0→2), so a shared-state (H-1) corruption would fail the load-bearing
+        `inc$0` first-call == 1 assertion. Full meld-core suite green (0 failures,
+        no regression — the pass is a no-op for single-instantiation components).
+        The SR-31 `DuplicateModuleInstantiation` reject is retained as an
+        unreachable backstop (its ls_m_5 unit test still passes). Remaining before
+        `verified`: CI green on PR #362 + a Tier-5 Mythos pass on the lib.rs wiring.
       references:
         - "BA RFC #46 discussion: cfallin on multiply-instantiated modules"
         - "safety/stpa/rfc46-comparative-analysis.md section 4 Q1"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2021,3 +2021,58 @@ artifacts:
         export-alias index-skip that shifted every export onto the previous
         one's type. Full meld-core suite green (no regression from the parser
         component_func_defs change). The #355 Mythos pass also surfaced the sibling instance-index desync (a component exporting >=2 interfaces bound the 2nd+ export to the wrong instance); fixed (component_instance_idx += 2) and pinned by component_multi_interface_instance_idx.rs.
+
+  # ==========================================================================
+  # RFC-46 Q1 — multiply-instantiated module SUPPORT (ADR-7 path-H inc 3)
+  # ==========================================================================
+
+  - id: SR-55
+    type: sw-req
+    title: Multiply-instantiated module support via core-instance duplication
+    description: >
+      Where SR-31 requires meld to fail-fast REJECT a component that
+      instantiates the same core module more than once, this requirement is the
+      RFC-46 Q1 "duplicate" resolution: meld shall SUPPORT such a component by
+      giving each instantiation its own distinct module identity, so that each
+      instance is allocated independent functions, memory, tables, and globals
+      (mutable state), and no two instances share state (STPA hazard H-1) or
+      silently overwrite one another's merge-map entries. The mechanism is a
+      pre-resolve normalization (`core_instance_topology::
+      expand_multiply_instantiated_modules`) that deep-clones a module per
+      extra instantiation and rewrites the instantiation to the clone — reusing
+      the merger's index-remapping machinery already proven correct for N
+      distinct modules. When active, this SUPERSEDES the SR-31 reject for the
+      supported cases; SR-31's fail-fast remains for any residual meld cannot
+      duplicate soundly.
+    status: draft
+    tags: [rfc46, adr7, merger, topology, in-progress]
+    links:
+      - type: derives-from
+        target: SYS-2
+      - type: refines
+        target: SR-31
+      - type: mitigates
+        target: LS-M-5
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/pull/360"
+        kind: github
+        last-checked: 2026-07-21
+    fields:
+      implementation:
+        - meld-core/src/core_instance_topology.rs
+      verification-method: test
+      verification-description: >
+        DRAFT — mechanism only. The normalization pass is implemented and
+        structurally unit-tested (core_instance_topology::tests: single/distinct
+        unchanged; double/triple/interleaved expansion to N distinct module
+        identities; FromExports ignored). NOT YET ACTIVE: wiring the pass into
+        the fuse pipeline and dropping the DuplicateModuleInstantiation reject is
+        gated on a differential EXECUTION oracle proving two instances of one
+        module keep independent mutable state end-to-end (a real
+        multiply-instantiated component fixture, fused and executed on wasmtime).
+        Until that oracle is green + a Tier-5 Mythos pass on the wiring, SR-31
+        (reject) remains the shipped, verified behavior.
+      references:
+        - "BA RFC #46 discussion: cfallin on multiply-instantiated modules"
+        - "safety/stpa/rfc46-comparative-analysis.md section 4 Q1"
+        - "safety/adr/ADR-7-abi-linking-strategy-architecture.md (path-H inc 3)"


### PR DESCRIPTION
Executes **ADR-7 path-H, increment 3** — RFC-46 Q1 *multiply-instantiated
modules*, the "duplicate" resolution, **execution-verified end-to-end**. The
user's stated RFC-46 priority.

## What changed

meld previously **rejected** a component that instantiates the same core module
more than once (SR-31 → `DuplicateModuleInstantiation`). It now **supports** it.

- **`core_instance_topology::expand_multiply_instantiated_modules`** — a
  pre-resolve normalization that, for each 2nd..Nth instantiation of a core
  module, appends a deep clone (a fresh `module_idx`) and rewrites the
  instantiation to the clone. After the pass **no module is instantiated more
  than once**.
- **`lib.rs`** — the pass is wired into `Fuser::fuse_with_stats` before
  resolve/merge (with an info log of how many modules were duplicated).

## Why it's correct — it reuses a proof

The merger's index-remapping is already proven correct for **N distinct
modules**. Turning "module M instantiated N times" into "N distinct modules"
means each instance gets **independent** functions/memory/tables/globals — no
shared mutable state (**H-1**) — and every `(component, module)`-keyed merge map
gets a **distinct key per instance**, so the whole class of duplication-overwrite
bugs (segment_bases, realloc_map, resource maps, mutable globals) an index-space
audit enumerated simply cannot arise.

## Differential execution oracle (the gate)

`tests/multiply_instantiated_runtime.rs::two_instances_keep_independent_counter_state`
— a component instantiating **one core module (a mutable counter) twice** is
fused (MultiMemory, CoreModule), **validated**, and executed on wasmtime. The two
instances' counters advance **independently**:

```
inc → 1, inc → 2, inc$0 → 1, inc → 3, inc$0 → 2
```

A shared-state (H-1) corruption would make `inc$0`'s first call return 3 — the
load-bearing assertion is that it returns **1**.

## Verification

- Differential **execution** oracle green (independent mutable state proven).
- 6 structural unit tests (`core_instance_topology::tests`).
- Full `meld-core` suite green — **0 failures, no regression** (the pass is a
  no-op for single-instantiation components; the SR-31 reject is retained as an
  unreachable backstop, `ls_m_5` still passes).
- fmt + clippy clean; `rivet validate` PASS.
- **SR-55** (implemented) — duplicate-support capability, `refines` SR-31,
  `mitigates` LS-M-5; SR-31 noted as superseded for handleable cases.

## Notes

- The two instances both export the core name `inc`; meld disambiguates the
  second with a `$0` suffix (existing identical-name dedup).
- Tier-5 (lib.rs merge-pipeline wiring) → Mythos delta-pass to follow.

Refs #354 (ADR-7 path-H inc 3), RFC-46 Q1
