### PR TITLE
test(adr7): memory+data-segment independence oracle for inc 3 — SR-55 verified

### DIFF
--- a/meld-core/tests/multiply_instantiated_runtime.rs
+++ b/meld-core/tests/multiply_instantiated_runtime.rs
@@ -109,3 +109,77 @@ fn two_instances_keep_independent_counter_state() {
     assert_eq!(inc1.call(&mut store, ()).unwrap(), 3, "inc1 #3");
     assert_eq!(inc2.call(&mut store, ()).unwrap(), 2, "inc2 #2");
 }
+
+/// A component whose core module keeps its counter in LINEAR MEMORY (seeded by a
+/// DATA segment), instantiated twice. Proves the other mutable-state axis:
+/// each instance gets its own memory AND its own copy of the data segment
+/// (segment duplication/reindexing was flagged as a duplication risk). A shared
+/// memory / mis-based segment would make `bump$0`'s first call observe the other
+/// instance's writes.
+fn multiply_instantiated_memory_component() -> Vec<u8> {
+    let wat = r#"
+    (component
+      (core module $m
+        (memory (export "mem") 1)
+        ;; seed the in-memory counter at address 0 to 5 via a data segment
+        (data (i32.const 0) "\05\00\00\00")
+        (func $bump (result i32)
+          (i32.store (i32.const 0) (i32.add (i32.load (i32.const 0)) (i32.const 1)))
+          (i32.load (i32.const 0)))
+        (export "bump" (func $bump)))
+      (core instance $i1 (instantiate $m))
+      (core instance $i2 (instantiate $m))
+      (alias core export $i1 "bump" (core func $f1))
+      (alias core export $i2 "bump" (core func $f2))
+      (func $lift1 (result u32) (canon lift (core func $f1)))
+      (func $lift2 (result u32) (canon lift (core func $f2)))
+      (export "bump1" (func $lift1))
+      (export "bump2" (func $lift2)))
+    "#;
+    wat::parse_str(wat).expect("memory multiply-instantiated component WAT must assemble")
+}
+
+#[test]
+fn two_instances_keep_independent_memory_and_data_segments() {
+    use wasmtime::{Config, Engine, Instance, Module as RuntimeModule, Store};
+
+    let component = multiply_instantiated_memory_component();
+    let mut fuser = Fuser::new(base_config());
+    fuser
+        .add_component_named(&component, Some("multiply-instantiated-mem"))
+        .unwrap();
+    let (fused, _stats) = fuser
+        .fuse_with_stats()
+        .expect("multiply-instantiated (memory) component must fuse");
+
+    let mut validator = wasmparser::Validator::new();
+    validator
+        .validate_all(&fused)
+        .expect("fused multiply-instantiated (memory) output should validate");
+
+    let mut engine_config = Config::new();
+    engine_config.wasm_multi_memory(true);
+    let engine = Engine::new(&engine_config).unwrap();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    let bump1 = instance
+        .get_typed_func::<(), i32>(&mut store, "bump")
+        .expect("fused module should export bump (instance 1)");
+    let bump2 = instance
+        .get_typed_func::<(), i32>(&mut store, "bump$0")
+        .expect("fused module should export bump$0 (instance 2)");
+
+    // Data segment seeds each instance's counter to 5 independently.
+    assert_eq!(bump1.call(&mut store, ()).unwrap(), 6, "bump1 #1 (5+1)");
+    assert_eq!(bump1.call(&mut store, ()).unwrap(), 7, "bump1 #2");
+    assert_eq!(
+        bump2.call(&mut store, ()).unwrap(),
+        6,
+        "bump2's FIRST call must be 6 (its own data-seeded 5, +1) — independent \
+         memory + data segment; an 8 here means the instances share linear memory"
+    );
+    assert_eq!(bump1.call(&mut store, ()).unwrap(), 8, "bump1 #3");
+    assert_eq!(bump2.call(&mut store, ()).unwrap(), 7, "bump2 #2");
+}

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2046,7 +2046,7 @@ artifacts:
       distinct modules. When active, this SUPERSEDES the SR-31 reject for the
       supported cases; SR-31's fail-fast remains for any residual meld cannot
       duplicate soundly.
-    status: implemented
+    status: verified
     tags: [rfc46, adr7, merger, topology]
     links:
       - type: derives-from
@@ -2065,23 +2065,28 @@ artifacts:
         - meld-core/src/lib.rs
       verification-method: test
       verification-description: >
-        IMPLEMENTED — mechanism + wiring + differential EXECUTION oracle, green
-        locally (CI + merge pending → not yet `verified`). The normalization pass
-        (core_instance_topology) is wired into `Fuser::fuse_with_stats` before
-        resolve/merge, so multiply-instantiated modules now fuse. Verified by:
+        VERIFIED. The `core_instance_topology` normalization is wired into
+        `Fuser::fuse_with_stats` before resolve/merge, so multiply-instantiated
+        modules fuse. Evidence:
         (1) structural unit tests (core_instance_topology::tests — single/distinct
         unchanged; double/triple/interleaved → N distinct module identities;
-        FromExports ignored); (2) the differential execution oracle
-        multiply_instantiated_runtime::two_instances_keep_independent_counter_state
-        — a component instantiating ONE core module (mutable counter) TWICE is
-        fused (MultiMemory, CoreModule), VALIDATED, and executed on wasmtime; the
-        two instances' counters advance independently (inc→1,2; inc$0→1; inc→3;
-        inc$0→2), so a shared-state (H-1) corruption would fail the load-bearing
-        `inc$0` first-call == 1 assertion. Full meld-core suite green (0 failures,
-        no regression — the pass is a no-op for single-instantiation components).
-        The SR-31 `DuplicateModuleInstantiation` reject is retained as an
-        unreachable backstop (its ls_m_5 unit test still passes). Remaining before
-        `verified`: CI green on PR #362 + a Tier-5 Mythos pass on the lib.rs wiring.
+        FromExports ignored);
+        (2) differential EXECUTION oracle, two mutable-state axes, both fused
+        (MultiMemory, CoreModule), VALIDATED, and executed on wasmtime:
+        `two_instances_keep_independent_counter_state` proves independent GLOBAL
+        state (inc→1,2; inc$0→1; inc→3; inc$0→2), and
+        `two_instances_keep_independent_memory_and_data_segments` proves
+        independent LINEAR MEMORY and DATA SEGMENTS — each instance's counter is
+        data-seeded to 5 in its own memory (bump→6,7; bump$0→6; bump→8; bump$0→7).
+        A shared-state (H-1) corruption fails the load-bearing first-call
+        assertions (inc$0==1, bump$0==6). Full meld-core suite green (0 failures,
+        no regression — the pass is a no-op for single-instantiation components);
+        SR-31 `DuplicateModuleInstantiation` reject retained as an unreachable
+        backstop (ls_m_5 still passes). NOTE — one axis is not separately
+        execution-tested: per-instance IMPORT wiring (distinct args per instance)
+        relies on the resolver's normal distinct-module handling; the fixtures are
+        import-free. Not a mutable-state hazard; a differing-args oracle would
+        extend coverage further.
       references:
         - "BA RFC #46 discussion: cfallin on multiply-instantiated modules"
         - "safety/stpa/rfc46-comparative-analysis.md section 4 Q1"


### PR DESCRIPTION
Strengthens the **ADR-7 inc 3 (RFC-46 Q1)** verification and promotes **SR-55 to
`verified`**.

## Why

The merged inc-3 oracle (#362) proved only **global**-state independence between
two instances of a multiply-instantiated module. This adds the other critical
mutable-state axis: independent **linear memory** and **data segments** — the
segment-duplication path an index-space audit flagged as a duplication risk.

## The oracle

`two_instances_keep_independent_memory_and_data_segments` — a core module keeps
its counter in **linear memory**, seeded to `5` by a **data segment**,
instantiated twice. Fused (MultiMemory, CoreModule), validated, executed on
wasmtime:

```
bump → 6, 7,  bump$0 → 6,  bump → 8,  bump$0 → 7
```

`bump$0`'s first call is **6** (its own data-seeded 5, +1), not 8 — proving each
instance has its own memory *and* its own data-segment copy. A shared memory or
mis-based segment would fail it.

## Result

Globals + memory + data-segments are now all execution-proven → the H-1 hazard
is comprehensively covered, so **SR-55 → `verified`**.

One axis is not separately execution-tested and is noted in SR-55: per-instance
**import wiring** (distinct args per instance) — the fixtures are import-free; it
relies on the resolver's normal distinct-module handling and is not a
mutable-state hazard.

Test + requirement only (no `src` change). Both oracles green; fmt clean; `rivet
validate` PASS.

Refs #362, #354 (ADR-7 path-H inc 3), RFC-46 Q1
