### PR TITLE
chore(release): v0.42.0 — ADR-7 path-H + multiply-instantiated + static-PIC + same-memory transcoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-07-23
+
+ADR-7 path-H — the ABI/linking-strategy architecture — landed in full, plus two
+new fusion capabilities and safety hardening.
+
+### Added
+- **Multiply-instantiated module support (RFC-46 Q1)** — a component that
+  instantiates the same core module more than once now fuses (under explicit
+  `--memory multi`) with each instance allocated independent
+  functions/memory/tables/globals, instead of being rejected. A pre-resolve
+  core-instance topology normalization turns N instantiations into N distinct
+  modules, reusing the merger's proven per-module index-remapping (SR-55).
+- **Static-PIC data/element offset folding** — meld consumes PIC /
+  shared-everything inputs and statically folds a `__memory_base`-relative
+  segment offset (`global.get $base` and the extended-const `base + N` shape)
+  to a concrete `i32.const` once the base becomes a defined constant after
+  fusion, so the output is valid for wasmtime, not just wasm-tools (#353).
+- **Same-memory string transcoding** — a mixed-encoding call under
+  `--memory shared` now transcodes correctly within the one shared memory,
+  instead of hard-failing (#361).
+
+### Changed
+- **ADR-7 path-H architecture** — the merger's per-boundary decisions are now
+  pluggable seams: the address strategy (`address_strategy`, inc 1) and the
+  call lowering + inline decision (`adapter::call_lowering`, inc 2), each
+  extracted behavior-preservingly and unit-tested as a truth table (#354).
+
+### Fixed
+- **Multiply-instantiated safety-claim gap (#364)** — support is gated to the
+  execution-verified `MultiMemory` case; `SharedMemory`/`Auto` reject (their
+  independence is unverified), so shipped behavior matches SR-31/SR-55.
+- **Silent same-memory cross-encoding miscompile (#360/#361)** — the sync twin
+  of the async cross-encoding guard: mixed-encoding same-memory calls no longer
+  deliver bytes in the wrong encoding.
+
+**Falsification:** if a multiply-instantiated module fused under `--memory multi`
+shared mutable state between instances, `multiply_instantiated_runtime` fails
+(the second instance's counter would observe the first's writes); if a static-PIC
+`base + N` data offset were left un-folded, `pic_extended_const_353` fails
+(wasmtime rejects the fused module); if a same-memory UTF-8→UTF-16 call skipped
+transcoding, `adapter_safety::test_361_same_memory_utf8_to_utf16_transcoding`
+returns the wrong sum.
+
 ## [0.41.3] - 2026-07-17
 
 Correctness patch for the `--component` output path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.41.3"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.41.3"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.41.3"
+version = "0.42.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2066,6 +2066,7 @@ artifacts:
       reject fires instead.
     status: verified
     tags: [rfc46, adr7, merger, topology]
+    release: v0.42.0
     links:
       - type: derives-from
         target: SYS-2


### PR DESCRIPTION
Cuts **v0.42.0** — the full ADR-7 path-H arc plus two new fusion capabilities and
safety hardening. Everything below is already merged to `main`; this is the
version bump + CHANGELOG + SR release fields.

## Highlights (since v0.41.3)

**New capabilities**
- Multiply-instantiated module support (RFC-46 Q1, `--memory multi`, SR-55) — #362/#363
- Static-PIC data/element offset folding (bare + extended-const `base + N`) — #365/#368
- Same-memory string transcoding — #367

**ADR-7 path-H architecture** (pluggable per-boundary seams)
- Address-strategy seam (inc 1) — #359
- Call-lowering + inline seam (inc 2) — #360
- ADR-7 decision record — #354

**Safety hardening**
- Multiply-instantiated gated to the execution-verified MultiMemory case; SharedMemory/Auto reject (#364) — #366
- Sync same-memory cross-encoding silent miscompile closed (#360/#361)

## Falsification

- Multiply-instantiated sharing state between instances → `multiply_instantiated_runtime` fails.
- Un-folded static-PIC `base + N` offset → `pic_extended_const_353` fails (wasmtime rejects).
- Same-memory UTF-8→UTF-16 skipping transcoding → `adapter_safety::test_361_same_memory_utf8_to_utf16_transcoding` returns the wrong sum.

`rivet validate` PASS; `meld-core` builds clean at 0.42.0.

After merge, tag `v0.42.0` on the merge commit to trigger the release pipeline.
