### PR TITLE
feat(v0.44.0): fix #371 params-area all-zeros + #339 static-PIC global-init fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-08-12
+
+Two silent-corruption fixes in the cross-component adapter and the shared-memory
+rebase path, both closing demonstrated divergences with hard runtime oracles.
+
+### Fixed
+- **Fixed-size / large-params calls returned all-zeros (SR-58, #371)** — a
+  cross-component call with flat params > 16 AND flat results > 1 uses the
+  combined `(params_ptr, retptr)` convention; it matched the retptr heuristic and
+  was routed to an adapter that never copied the params buffer across memories,
+  so the callee read its parameters from its own memory at the caller's address →
+  all-zeros. The output validated (silent). The retptr adapter now performs the
+  cross-memory params-area copy (with pointer-pair, inner-resource, and borrow
+  fixups) in the combined convention. Shapes it cannot bridge (3-component borrow
+  chains; nested `list<string>`/`list<list<_>>` inside a >16-param buffer) now
+  **fail loud** instead of emitting silently-wrong code.
+- **Static-PIC global initializers were emitted un-folded (SR-59, #339)** — a
+  global initialized `__memory_base + N` (the real PIC toolchain shape) was not
+  folded to the module's placed address after fusion, producing a module wasmtime
+  rejects (`constant expression required: global.get of locally defined global`).
+  `convert_init_expr` now applies the #353 base-fold to global initializers.
+
+### Changed
+- **Loud acceptance under `--memory shared --address-rebase` (SR-59, #339)** —
+  when meld accepts a no-reloc, non-zero-base module with a code section (the
+  path-F carve-out), it now warns that an absolute address used only as a value
+  will not be rebased, and names `--emit-relocs`. This is observability, not a
+  detector — a precise "is this const an address" test is undecidable without
+  relocations. Corrects SR-48's overstated "shall HARD-ERROR" wording to match
+  the shipped carve-out.
+- **Clearer `memory.grow` rejection (#299)** — the diagnostic now names the
+  remedies (grow-free embedder-arena build, or `--memory multi`).
+
+### Known / residual (documented, not fixed)
+- Bare no-reloc absolute-const globals, address-as-value under no relocs, and the
+  operand-swapped `i32.add(N, global.get $defined_base)` PIC form remain
+  undecidable-or-unobserved residuals (#339 stays open). The last fails loud at
+  instantiation, never silently.
+
 ## [0.43.0] - 2026-08-12
 
 Single-address-space (MCU) memory hardening for `--memory shared` (#370):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.43.0"
+version = "0.44.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -6063,6 +6063,7 @@ impl FactStyleGenerator {
                 caller_type_idx,
                 caller_param_count,
                 callee_param_count,
+                resource_rep_imports,
             );
         }
 
@@ -6663,27 +6664,51 @@ impl FactStyleGenerator {
         Ok((adapter_type_idx, func))
     }
 
-    /// Generate an adapter for the params-ptr calling convention.
+    /// Number of i32 scratch locals [`Self::emit_params_area_copy`] requires.
     ///
-    /// When flat param count > MAX_FLAT_PARAMS (16), the canonical ABI stores all
-    /// params in a buffer in linear memory. Both caller and callee use:
-    ///   (params_ptr: i32) → result...
+    /// Layout of the scratch block (starting at the caller-chosen `scratch_base`):
+    ///   +0                : callee_ptr        (allocated buffer in callee memory)
+    ///   +1 ..+1+N         : dest_ptr per (ptr,len) pair
+    ///   +1+N              : loop_counter       (only if a pair has inner resources)
+    ///   last              : pair_len scratch   (only if there is ≥1 pair)
+    fn params_area_copy_scratch_count(site: &AdapterSite) -> u32 {
+        let ptr_pair_offsets = &site.requirements.params_area_pointer_pair_offsets;
+        let copy_layouts = &site.requirements.params_area_copy_layouts;
+        let num_ptr_pairs = ptr_pair_offsets.len() as u32;
+        let has_inner_resources = copy_layouts.iter().any(|cl| {
+            matches!(cl,
+                crate::resolver::CopyLayout::Elements { inner_resources, .. }
+                if !inner_resources.is_empty()
+            )
+        });
+        let loop_counter_count = if has_inner_resources { 1u32 } else { 0 };
+        let pair_len_scratch_count = if num_ptr_pairs > 0 { 1u32 } else { 0 };
+        1 + num_ptr_pairs + loop_counter_count + pair_len_scratch_count
+    }
+
+    /// Emit Phases 1–3.5 of the params-area cross-memory copy: allocate a buffer
+    /// of `params_area_byte_size`/`params_area_max_align` in the callee's memory,
+    /// bulk-copy the caller's params buffer into it, then walk every
+    /// `params_area_pointer_pair_offsets` / `params_area_copy_layouts` entry
+    /// (encoding-aware string/list copy + inner-resource fixups) and every
+    /// `params_area_borrow_fixups` entry (borrow handle → rep). Returns the local
+    /// index holding the pointer to the freshly-allocated callee buffer.
     ///
-    /// The adapter bridges different memories:
-    /// 1. Allocate buffer in callee's memory via cabi_realloc
-    /// 2. Bulk copy the params buffer from caller to callee memory
-    /// 3. Fix up any (ptr, len) pairs inside the buffer — copy pointed-to data
-    ///    from caller memory to callee memory and update the pointers
-    /// 4. Call callee with new pointer
-    /// 5. Return the result(s)
-    fn generate_params_ptr_adapter(
+    /// `params_ptr_local` is the local holding the caller's params buffer pointer.
+    /// `scratch_base` is the first index of a contiguous i32 scratch block of size
+    /// [`Self::params_area_copy_scratch_count`] that the caller has reserved.
+    ///
+    /// Shared by [`Self::generate_params_ptr_adapter`] (pure params-ptr) and
+    /// [`Self::generate_retptr_adapter`] (combined params-ptr + retptr, #371).
+    fn emit_params_area_copy(
         &self,
+        func: &mut Function,
         site: &AdapterSite,
         options: &AdapterOptions,
-        target_func: u32,
-        caller_type_idx: u32,
         resource_rep_imports: &std::collections::HashMap<(String, String), u32>,
-    ) -> Result<(u32, Function)> {
+        params_ptr_local: u32,
+        scratch_base: u32,
+    ) -> Result<u32> {
         let params_area_size = site.requirements.params_area_byte_size.unwrap_or(0);
         let params_area_align = site.requirements.params_area_max_align.max(1);
         let ptr_pair_offsets = &site.requirements.params_area_pointer_pair_offsets;
@@ -6694,7 +6719,6 @@ impl FactStyleGenerator {
             0
         });
 
-        // Check if any list copy layouts contain inner resources (borrow handles)
         let has_inner_resources = copy_layouts.iter().any(|cl| {
             matches!(cl,
                 crate::resolver::CopyLayout::Elements { inner_resources, .. }
@@ -6702,43 +6726,40 @@ impl FactStyleGenerator {
             )
         });
 
-        // Local layout:
-        //   0: params_ptr (the function parameter — pointer to caller's memory)
-        //   1: callee_ptr (allocated pointer in callee's memory)
-        //   2..2+N: dest_ptr for each pointer pair copy
-        //   2+N: loop_counter (if inner resources need fixup)
-        //   last: pair_len_local (scratch for per-pair overflow guard)
+        // #371 / SR-58 fail-loud (surfaced by the Mythos delta-pass): Phase 3
+        // relocates a pointer pair's payload and its `inner_resources`, but NOT
+        // its `inner_pointers` — the per-element nested pointer pairs of a
+        // `list<string>` / `list<list<_>>` / `list<record{string}>` inside the
+        // params buffer. Those nested pointers would stay pointing into CALLER
+        // memory after the bulk copy, so the callee would dereference dangling
+        // addresses (silent cross-memory corruption). This gap pre-dates #371
+        // (it exists in the pure params-ptr path too — this helper is shared),
+        // but rather than leave it silent, refuse to emit. Loud-not-silent
+        // (SR-56/SR-59 philosophy); tracked for real inner_pointers handling.
+        if let Some(bad) = copy_layouts.iter().find(|cl| {
+            matches!(cl,
+                crate::resolver::CopyLayout::Elements { inner_pointers, .. }
+                if !inner_pointers.is_empty()
+            )
+        }) {
+            return Err(crate::Error::AdapterGeneration(format!(
+                "params-area copy for import '{}': a pointer pair carries nested inner pointers \
+                 ({bad:?}) — list<string>/list<list<_>>/list<record{{string}}> inside a \
+                 >16-flat-param buffer is not yet bridged across memories; refusing to emit code \
+                 that would leave the nested pointers dangling in caller memory",
+                site.import_name,
+            )));
+        }
+
         let num_ptr_pairs = ptr_pair_offsets.len() as u32;
         let loop_counter_count = if has_inner_resources { 1u32 } else { 0 };
-        let pair_len_scratch_count = if num_ptr_pairs > 0 { 1u32 } else { 0 };
-        let scratch_count = 1 + num_ptr_pairs + loop_counter_count + pair_len_scratch_count; // callee_ptr + per-pair dest ptrs + loop counter + pair_len
 
-        // Post-return needs result save locals
-        let has_post_return = options.callee_post_return.is_some();
-        // For params-ptr, the results come from the callee directly.
-
-        let mut local_decls: Vec<(u32, wasm_encoder::ValType)> = Vec::new();
-        if scratch_count > 0 {
-            local_decls.push((scratch_count, wasm_encoder::ValType::I32));
-        }
-
-        // We don't know result count from here, so we handle post-return simply:
-        // if there's a post-return, we'll save and restore results.
-        // But for params-ptr functions with resource results, result count should be 1 (i32).
-        // For simplicity: if has_post_return, add 1 i32 result save local.
-        let result_save_base = 1 + scratch_count; // after params_ptr(0) + scratch
-        if has_post_return {
-            local_decls.push((1, wasm_encoder::ValType::I32));
-        }
-
-        let mut func = Function::new(local_decls);
-
-        let params_ptr_local: u32 = 0;
-        let callee_ptr_local: u32 = 1;
-        let pair_dest_base: u32 = 2;
+        // Scratch layout (see params_area_copy_scratch_count):
+        let callee_ptr_local: u32 = scratch_base;
+        let pair_dest_base: u32 = scratch_base + 1;
         // Scratch local holding the length of the current (ptr, len) pair,
-        // used by emit_overflow_guard. Only present when there is at least
-        // one pointer pair.
+        // used by emit_overflow_guard. Only referenced when there is at
+        // least one pointer pair.
         let pair_len_local: u32 = pair_dest_base + num_ptr_pairs + loop_counter_count;
 
         // --- Phase 1: Allocate buffer in callee's memory ---
@@ -6747,7 +6768,7 @@ impl FactStyleGenerator {
         func.instruction(&Instruction::I32Const(0)); // original_size
         func.instruction(&Instruction::I32Const(params_area_align as i32)); // alignment
         func.instruction(&Instruction::I32Const(params_area_size as i32)); // new_size
-        emit_checked_realloc(&mut func, callee_realloc, callee_ptr_local);
+        emit_checked_realloc(func, callee_realloc, callee_ptr_local);
 
         // --- Phase 2: Bulk copy the entire params buffer ---
         // memory.copy $callee_mem $caller_mem (callee_ptr, params_ptr, size)
@@ -6798,12 +6819,12 @@ impl FactStyleGenerator {
             let realloc_align = if is_compact_utf16 { 2 } else { 1 };
 
             // Allocate: new_ptr = cabi_realloc(0, 0, align, <byte count>)
-            emit_overflow_guard(&mut func, pair_len_local, byte_mult);
+            emit_overflow_guard(func, pair_len_local, byte_mult);
             func.instruction(&Instruction::I32Const(0));
             func.instruction(&Instruction::I32Const(0));
             func.instruction(&Instruction::I32Const(realloc_align));
-            emit_copy_byte_count(&mut func, pair_len_local, byte_mult, is_compact_utf16);
-            emit_checked_realloc(&mut func, callee_realloc, dest_local);
+            emit_copy_byte_count(func, pair_len_local, byte_mult, is_compact_utf16);
+            emit_checked_realloc(func, callee_realloc, dest_local);
 
             // Copy data: memory.copy callee caller (new_ptr, old_ptr, <byte count>)
             func.instruction(&Instruction::LocalGet(dest_local)); // dst (in callee mem)
@@ -6816,7 +6837,7 @@ impl FactStyleGenerator {
                 memory_index: options.callee_memory,
             })); // src (in caller mem)
             // Byte count from the stashed (still-tagged) length operand.
-            emit_copy_byte_count(&mut func, pair_len_local, byte_mult, is_compact_utf16);
+            emit_copy_byte_count(func, pair_len_local, byte_mult, is_compact_utf16);
             func.instruction(&Instruction::MemoryCopy {
                 src_mem: options.caller_memory,
                 dst_mem: options.callee_memory,
@@ -6943,6 +6964,55 @@ impl FactStyleGenerator {
             }));
         }
 
+        Ok(callee_ptr_local)
+    }
+
+    /// Generate an adapter for the params-ptr calling convention.
+    ///
+    /// When flat param count > MAX_FLAT_PARAMS (16), the canonical ABI stores all
+    /// params in a buffer in linear memory. Both caller and callee use:
+    ///   (params_ptr: i32) → result...
+    ///
+    /// The adapter bridges different memories:
+    /// 1. Allocate buffer in callee's memory via cabi_realloc
+    /// 2. Bulk copy the params buffer from caller to callee memory
+    /// 3. Fix up any (ptr, len) pairs inside the buffer — copy pointed-to data
+    ///    from caller memory to callee memory and update the pointers
+    /// 4. Call callee with new pointer
+    /// 5. Return the result(s)
+    fn generate_params_ptr_adapter(
+        &self,
+        site: &AdapterSite,
+        options: &AdapterOptions,
+        target_func: u32,
+        caller_type_idx: u32,
+        resource_rep_imports: &std::collections::HashMap<(String, String), u32>,
+    ) -> Result<(u32, Function)> {
+        // Scratch block for the params-area copy helper lives immediately after
+        // the single function parameter (params_ptr = local 0), i.e. base 1.
+        let scratch_count = Self::params_area_copy_scratch_count(site);
+
+        // Post-return needs a result-save local (after params_ptr(0) + scratch).
+        let has_post_return = options.callee_post_return.is_some();
+        let result_save_base = 1 + scratch_count;
+
+        let mut local_decls: Vec<(u32, wasm_encoder::ValType)> = Vec::new();
+        if scratch_count > 0 {
+            local_decls.push((scratch_count, wasm_encoder::ValType::I32));
+        }
+        // We don't know result count from here, so we handle post-return simply:
+        // if there's a post-return, we'll save and restore the (i32) result.
+        if has_post_return {
+            local_decls.push((1, wasm_encoder::ValType::I32));
+        }
+
+        let mut func = Function::new(local_decls);
+
+        // Phases 1–3.5: allocate callee buffer, bulk-copy, fix up pointer pairs
+        // and borrow handles. params_ptr is local 0; scratch starts at index 1.
+        let callee_ptr_local =
+            self.emit_params_area_copy(&mut func, site, options, resource_rep_imports, 0, 1)?;
+
         // --- Phase 4: Call callee with the new pointer ---
         func.instruction(&Instruction::LocalGet(callee_ptr_local));
         func.instruction(&Instruction::Call(target_func));
@@ -6987,6 +7057,7 @@ impl FactStyleGenerator {
         caller_type_idx: u32,
         caller_param_count: usize,
         callee_param_count: usize,
+        resource_rep_imports: &std::collections::HashMap<(String, String), u32>,
     ) -> Result<(u32, Function)> {
         let retptr_local = (caller_param_count - 1) as u32;
         let return_area_size = site.requirements.return_area_byte_size.unwrap_or(8);
@@ -7007,12 +7078,70 @@ impl FactStyleGenerator {
             .conditional_result_pointer_pairs
             .is_empty();
 
+        // #371 / SR-58: COMBINED convention — flat params > 16 AND flat results > 1.
+        //   caller (lowered):  (params_ptr, retptr) → ()
+        //   callee (lifted):   (params_ptr)        → i32 (return area ptr)
+        // The params satisfy the params-ptr convention (all params live behind a
+        // single pointer into caller memory), while the results still satisfy the
+        // retptr convention. When memories differ, the caller's params_ptr cannot
+        // be passed raw to the callee — the whole params buffer (with its inner
+        // string/list/resource pointers) must be copied into callee memory first,
+        // exactly like the pure params-ptr adapter does. The flat
+        // `pointer_pair_positions` describe FLAT param slots that do NOT exist in
+        // this convention (params are behind the pointer), so the outbound flat
+        // copy (Phase 0/1/1b) is meaningless here and MUST be skipped — indexing
+        // those flat positions as locals would corrupt scratch/retptr locals.
+        let uses_params_area = site.requirements.params_area_byte_size.is_some()
+            && options.caller_memory != options.callee_memory;
+
+        if uses_params_area {
+            // Fail LOUD rather than emit silently-wrong code for shapes the
+            // params-area copy cannot bridge.
+            if callee_param_count != 1 {
+                return Err(crate::Error::AdapterGeneration(format!(
+                    "#371 combined params-ptr+retptr adapter for import '{}': expected callee to \
+                     take exactly 1 params_ptr param, found {} — cannot bridge safely",
+                    site.import_name, callee_param_count,
+                )));
+            }
+            if options.callee_realloc.is_none() {
+                return Err(crate::Error::AdapterGeneration(format!(
+                    "#371 combined params-ptr+retptr adapter for import '{}': no callee realloc — \
+                     cannot allocate the cross-memory params buffer",
+                    site.import_name,
+                )));
+            }
+            // emit_params_area_copy only bridges borrow handles inside the buffer
+            // for the 2-component case (callee defines the resource), via
+            // params_area_borrow_fixups. A borrow<T> where the callee does NOT
+            // define T (3-component chain) has no in-buffer fixup emitted (see
+            // the `// 3-component chains ... could be added here` note where
+            // params_area_borrow_fixups is populated), so the handle would reach
+            // the callee UNCONVERTED. Refuse rather than emit a silently-wrong
+            // handle. (Mirrors the same unhandled shape in the pure params-ptr
+            // adapter; own<T> is fine — the callee converts it internally.)
+            if let Some(op) = site
+                .requirements
+                .params_area_resource_positions
+                .iter()
+                .find(|op| !op.is_owned && !op.callee_defines_resource)
+            {
+                return Err(crate::Error::AdapterGeneration(format!(
+                    "#371 combined params-ptr+retptr adapter for import '{}': borrow<{}> inside a \
+                     >16-flat-param buffer needs a 3-component resource-rep chain, which the \
+                     params-area copy does not yet bridge — refusing to emit an unconverted handle",
+                    site.import_name, op.import_field,
+                )));
+            }
+        }
+
         // Scratch locals layout (all i32, after caller params):
         //   [dest_ptr_0..dest_ptr_N]  (one per param pointer pair)
         //   [cond_dest_ptr]           (reused for conditional param/result copies)
         //   [result_ptr]              (return area pointer from callee)
         //   [data_ptr] [data_len] [caller_new_ptr]  (reused for each result pair)
         //   [loop_idx, inner_ptr, inner_len, new_ptr] × depth  (for nested fixup loops)
+        //   [params-area copy scratch block]  (#371, only when uses_params_area)
         let mut scratch_count: u32 = 0;
         let dest_ptr_base = caller_param_count as u32;
         if num_param_pairs > 0 && options.callee_realloc.is_some() {
@@ -7035,17 +7164,55 @@ impl FactStyleGenerator {
         if !options.inner_resource_fixups.is_empty() {
             scratch_count += 1; // resource loop counter
         }
+        // #371: reserve the params-area copy scratch block AT THE END so no
+        // existing scratch/local index shifts. Passed to emit_params_area_copy.
+        let params_area_scratch_base = caller_param_count as u32 + scratch_count;
+        if uses_params_area {
+            scratch_count += Self::params_area_copy_scratch_count(site);
+        }
 
         let local_decls = vec![(scratch_count, wasm_encoder::ValType::I32)];
         let mut func = Function::new(local_decls);
 
-        // Phase 0: Convert borrow resource handles
-        emit_resource_borrow_phase0(&mut func, &options.resource_rep_calls);
+        // Phase 0: Convert borrow resource handles.
+        // #371: resource_rep_calls carry FLAT param indices; in params-area mode
+        // those flat slots don't exist (borrow handles live inside the buffer and
+        // are fixed up by emit_params_area_copy via params_area_borrow_fixups), so
+        // skip the flat Phase 0 to avoid clobbering the retptr / scratch locals.
+        if !uses_params_area {
+            emit_resource_borrow_phase0(&mut func, &options.resource_rep_calls);
+        }
+
+        // #371: emit the cross-memory params-area copy (Phases 1–3.5 of the
+        // params-ptr adapter). params_ptr is caller local 0; the copied callee
+        // buffer pointer is captured for the callee call below.
+        let params_area_callee_ptr = if uses_params_area {
+            log::debug!(
+                "#371 combined params-ptr+retptr adapter: import={} params_buf={}B ({} inner ptr \
+                 pairs, {} borrow fixups) — copying params area across memories",
+                site.import_name,
+                site.requirements.params_area_byte_size.unwrap_or(0),
+                site.requirements.params_area_pointer_pair_offsets.len(),
+                options.params_area_borrow_fixups.len(),
+            );
+            Some(self.emit_params_area_copy(
+                &mut func,
+                site,
+                options,
+                resource_rep_imports,
+                0, // caller params_ptr is local 0
+                params_area_scratch_base,
+            )?)
+        } else {
+            None
+        };
 
         // --- Phase 1: Outbound copy of ALL pointer pairs (caller → callee) ---
+        // Skipped in params-area mode (params live behind the pointer, not in
+        // flat slots — see uses_params_area rationale above).
         if let Some(callee_realloc) = options
             .callee_realloc
-            .filter(|_| !param_ptr_positions.is_empty())
+            .filter(|_| !param_ptr_positions.is_empty() && !uses_params_area)
         {
             let param_layouts = &site.requirements.param_copy_layouts;
             for (pair_idx, &ptr_pos) in param_ptr_positions.iter().enumerate() {
@@ -7180,7 +7347,12 @@ impl FactStyleGenerator {
         }
 
         // --- Phase 1b: Conditional param copy (option/result/variant params) ---
-        if let Some(callee_realloc) = options.callee_realloc.filter(|_| has_cond_param_pairs) {
+        // Skipped in params-area mode (flat conditional params don't exist —
+        // see uses_params_area rationale above).
+        if let Some(callee_realloc) = options
+            .callee_realloc
+            .filter(|_| has_cond_param_pairs && !uses_params_area)
+        {
             for cond in &site.requirements.conditional_pointer_pairs {
                 let ptr_local = cond.ptr_position;
                 let len_local = cond.ptr_position + 1;
@@ -7223,7 +7395,12 @@ impl FactStyleGenerator {
         }
 
         // Push callee params (after all pointer remapping)
-        if !param_ptr_positions.is_empty() && options.callee_realloc.is_some() {
+        if let Some(callee_ptr_local) = params_area_callee_ptr {
+            // #371 combined convention: the callee takes a single params_ptr;
+            // pass the freshly-copied callee-memory buffer, NOT the caller's raw
+            // params_ptr (local 0). callee_param_count == 1 is enforced above.
+            func.instruction(&Instruction::LocalGet(callee_ptr_local));
+        } else if !param_ptr_positions.is_empty() && options.callee_realloc.is_some() {
             for i in 0..callee_param_count as u32 {
                 if let Some(pair_idx) = param_ptr_positions.iter().position(|&pos| pos == i) {
                     func.instruction(&Instruction::LocalGet(dest_ptr_base + pair_idx as u32));

--- a/meld-core/src/address_strategy.rs
+++ b/meld-core/src/address_strategy.rs
@@ -92,6 +92,27 @@ pub fn resolve_address_plan(
     }
 
     if !has_reloc {
+        // Part 2 (#339 Finding A): we reach here for a non-zero-base module with
+        // no reloc metadata that passed the path-F check above (it does no direct
+        // load/store). It is ACCEPTED with an empty plan — but an absolute address
+        // used purely as a VALUE (`i32.const <abs>; call $import`, a returned or
+        // stored pointer) is emitted verbatim and will NOT be rebased, so it can
+        // silently alias a neighbouring module's window. A sound "is this const an
+        // address" detector is undecidable without relocs (a broadened gate was
+        // built, reviewed, and reverted), so this is observability only — warn
+        // loudly and name the remedy rather than corrupt or over-reject.
+        if memory_base_offset != 0 && code_section_range.is_some() {
+            log::warn!(
+                "component '{component_name}' module {module_idx}: placed at \
+                 non-zero shared-memory base {memory_base_offset:#x} with a code \
+                 section but NO relocation metadata. Direct load/store is absent \
+                 (fusion proceeds), but any absolute address used as a VALUE \
+                 (e.g. `i32.const <addr>` passed to a call or returned/stored as \
+                 a pointer) will be emitted UN-REBASED and may alias another \
+                 component's memory. Rebuild with `--emit-relocs` so meld can \
+                 rebase these addresses exactly (#339)."
+            );
+        }
         return Ok(AddressPlan::default());
     }
 

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -3364,6 +3364,38 @@ fn create_global_init(val_type: &ValType) -> ConstExpr {
     }
 }
 
+/// #339: fold a **defined-base** extended-const global initializer to a concrete
+/// `i32.const`.
+///
+/// After fusion an imported `__memory_base`-style base becomes a DEFINED global.
+/// A global INITIALIZER const-expr may only `global.get` an *imported* global, so
+/// re-emitting a `global.get` of the now-defined base is rejected by wasmtime
+/// ("constant expression required: global.get of locally defined global"). When
+/// the (already index-remapped) sequence begins with a `global.get` of a global
+/// whose init folds to a constant i32 (recorded in `defined_global_i32_const`),
+/// evaluate `base ± N` and emit a single `i32.const`. This mirrors the #353
+/// data/element-offset fold in `segments::ParsedConstExpr::reindex`, and it is
+/// exactly the address rebase #339 asks for: the initializer holds `base + N`,
+/// the module's own placed address, not a stale un-rebased value.
+///
+/// Returns `None` (leave the sequence verbatim) unless the LEADING op is a
+/// `global.get` of a defined constant — an imported base (absent from the map)
+/// stays a runtime-dependent `global.get` (#338), preserving the multi-memory
+/// contract where the base is bound at instantiation.
+fn fold_defined_base_init(
+    seq: &[crate::segments::ExtConstOp],
+    merged: &MergedModule,
+) -> Option<ConstExpr> {
+    if let Some(crate::segments::ExtConstOp::GlobalGet(g)) = seq.first()
+        && let Some(&base) = merged.defined_global_i32_const.get(g)
+        && let Some(folded) = crate::segments::eval_ext_const_i32_with_base(seq, base)
+    {
+        Some(ConstExpr::i32_const(folded))
+    } else {
+        None
+    }
+}
+
 /// Convert stored init expression bytes into a `wasm_encoder::ConstExpr`,
 /// remapping any global or function indices through the merged module maps.
 ///
@@ -3418,7 +3450,25 @@ fn convert_init_expr(
                 // genuine multi-module fusion (#338).
                 Ok(crate::segments::ExtConstFold::Extended(seq)) => {
                     let remapped: Vec<_> = seq.iter().map(|o| o.remap_global(remap)).collect();
-                    crate::segments::ext_const_to_expr(&remapped)
+                    // #339: as in the `global.get`-first arm, fold a leading
+                    // defined-base `base ± N` to a constant. A const-first
+                    // embedded `global.get` (`N + base`) does NOT lead with the
+                    // base, so `fold_defined_base_init` declines and it stays
+                    // verbatim — CORRECT for an IMPORTED base (the #338
+                    // multi-memory `N + __memory_base` contract, where the base
+                    // is a live import). RESIDUAL (pre-existing, #339): if that
+                    // embedded `global.get` is a now-DEFINED constant base
+                    // (operand-swapped PIC form), emitting it verbatim yields
+                    // `i32.const N; global.get <defined>; i32.add`, which
+                    // wasm-tools accepts but wasmtime REJECTS ("constant
+                    // expression required: global.get of locally defined
+                    // global"). The leading-only fold does not cover it; not
+                    // observed from wasm-ld (which emits base-first), so tracked
+                    // as a residual rather than fixed here (would require
+                    // generalising the fold to a non-leading single defined
+                    // base). Fails loud at instantiation, never silent.
+                    fold_defined_base_init(&remapped, merged)
+                        .unwrap_or_else(|| crate::segments::ext_const_to_expr(&remapped))
                 }
                 Err(_) => ConstExpr::raw(bytes.iter().copied()),
             }
@@ -3465,9 +3515,24 @@ fn convert_init_expr(
             match crate::segments::read_extended_const_global_get(&mut ops, global_index) {
                 Ok(Some(seq)) => {
                     let remapped: Vec<_> = seq.iter().map(|o| o.remap_global(remap)).collect();
-                    crate::segments::ext_const_to_expr(&remapped)
+                    // #339: fold `base ± N` to `i32.const` when the base is a
+                    // now-DEFINED constant (a fused `__memory_base`); rebases the
+                    // global's address and avoids an invalid `global.get` of a
+                    // defined global in a const-expr. Imported bases fold to None
+                    // → preserved verbatim (#338).
+                    fold_defined_base_init(&remapped, merged)
+                        .unwrap_or_else(|| crate::segments::ext_const_to_expr(&remapped))
                 }
-                Ok(None) => ConstExpr::global_get(remap(global_index)),
+                Ok(None) => {
+                    // Bare `global.get`: if it names a now-DEFINED constant base,
+                    // fold to that constant (a const-expr cannot `global.get` a
+                    // defined global). Imported globals stay verbatim (#338).
+                    let new_idx = remap(global_index);
+                    match merged.defined_global_i32_const.get(&new_idx) {
+                        Some(&value) => ConstExpr::i32_const(value),
+                        None => ConstExpr::global_get(new_idx),
+                    }
+                }
                 Err(_) => ConstExpr::raw(bytes.iter().copied()),
             }
         }

--- a/meld-core/src/rewriter.rs
+++ b/meld-core/src/rewriter.rs
@@ -511,7 +511,15 @@ fn rewrite_operator(
                     return Ok(vec![Instruction::Unreachable]);
                 }
                 return Err(Error::UnsupportedFeature(
-                    "memory.grow not supported with address rebasing".to_string(),
+                    "memory.grow not supported with address rebasing: each module \
+                     is placed at a fixed base in one shared linear memory, so a \
+                     module cannot grow memory out from under its neighbours. \
+                     Remedies: build grow-free by backing allocation with the \
+                     embedder arena (pulseengine/wit-bindgen#4) so the vestigial \
+                     `cabi_realloc`/`sbrk` grow is eliminated, or fuse with \
+                     `--memory multi` so each component keeps its own growable \
+                     memory (#299)."
+                        .to_string(),
                 ));
             }
             Instruction::MemoryGrow(maps.remap_memory(mem))

--- a/meld-core/src/segments.rs
+++ b/meld-core/src/segments.rs
@@ -86,7 +86,7 @@ pub(crate) fn ext_const_to_expr(ops: &[ExtConstOp]) -> ConstExpr {
 /// all decline the fold. Used by [`ParsedConstExpr::reindex`] to fold a data /
 /// element offset `global.get $__memory_base + N` once the base is a defined
 /// constant (#353).
-fn eval_ext_const_i32_with_base(ops: &[ExtConstOp], base: i32) -> Option<i32> {
+pub(crate) fn eval_ext_const_i32_with_base(ops: &[ExtConstOp], base: i32) -> Option<i32> {
     let mut stack: Vec<i32> = Vec::new();
     for (i, op) in ops.iter().enumerate() {
         match op {

--- a/meld-core/tests/pic_extended_const_353.rs
+++ b/meld-core/tests/pic_extended_const_353.rs
@@ -84,3 +84,76 @@ fn pic_extended_const_data_offset_valid_for_wasmtime_353() {
          `global.get` of a now-defined global (#353)",
     );
 }
+
+// ─── #339 / SR-59: the same base-fold gap in GLOBAL INITIALIZERS ────────────
+
+/// `$main` defines+exports `__memory_base` = 0x10000 and owns the memory;
+/// `$lib` imports it and defines a wasm GLOBAL initialized to the base-relative
+/// address `__memory_base + 8` and a getter that returns it. This is the
+/// `global.get`-first extended-const shape a data-address-valued global takes
+/// after `wasm-tools component link`.
+fn pic_globinit_component() -> Vec<u8> {
+    let wat = r#"
+    (component
+      (core module $main
+        (global (export "__memory_base") i32 (i32.const 65536))
+        (memory (export "memory") 2))
+      (core module $lib
+        (import "env" "memory" (memory 1))
+        (import "env" "__memory_base" (global $base i32))
+        (global $g (mut i32) (i32.add (global.get $base) (i32.const 8)))
+        (func (export "get_g") (result i32) (global.get $g)))
+      (core instance $mi (instantiate $main))
+      (core instance $li (instantiate $lib (with "env" (instance $mi)))))
+    "#;
+    wat::parse_str(wat).expect("PIC global-init component WAT must assemble")
+}
+
+/// #339 Part 1 oracle. A global INITIALIZER holding the base-relative address
+/// `__memory_base + N` is NOT rebased by `merger::convert_init_expr`, which
+/// remaps the global index but (pre-fix) never folds the now-DEFINED base. The
+/// re-emitted `global.get <defined>; i32.const 8; i32.add` is:
+///   * INVALID for wasmtime ("constant expression required: global.get of
+///     locally defined global") — the fused module fails to instantiate; and
+///   * semantically the #339 corruption — the initializer must resolve to the
+///     module's own placed address `base + 8`, not a stale value.
+///
+/// RED before the fix: `RuntimeModule::new` fails to parse. After the fix the
+/// initializer folds to `i32.const (base+8)` and `get_g` returns 65544.
+#[test]
+fn pic_extended_const_global_init_valid_and_rebased_339() {
+    let component = pic_globinit_component();
+    let mut fuser = Fuser::new(base_config());
+    fuser
+        .add_component_named(&component, Some("pic-globinit"))
+        .unwrap();
+    let (fused, _) = fuser
+        .fuse_with_stats()
+        .expect("PIC global-init component must fuse");
+
+    assert!(
+        wasmparser::Validator::new().validate_all(&fused).is_ok(),
+        "fused output must validate under wasm-tools"
+    );
+
+    use wasmtime::{Config, Engine, Instance, Module as RuntimeModule, Store};
+    let mut cfg = Config::new();
+    cfg.wasm_multi_memory(true);
+    let engine = Engine::new(&cfg).unwrap();
+    let module = RuntimeModule::new(&engine, &fused).expect(
+        "fused PIC output must be valid for wasmtime: a global initializer of \
+         `__memory_base + N` must be folded to `i32.const (base+N)`, not left as \
+         a `global.get` of a now-defined global (#339)",
+    );
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).expect("instantiate");
+    let get_g = instance
+        .get_typed_func::<(), i32>(&mut store, "get_g")
+        .expect("get_g export");
+    assert_eq!(
+        get_g.call(&mut store, ()).unwrap(),
+        65536 + 8,
+        "the global must hold its own REBASED address base+8=65544, not a stale \
+         un-rebased value (#339)"
+    );
+}

--- a/meld-core/tests/value_address_warn_339.rs
+++ b/meld-core/tests/value_address_warn_339.rs
@@ -1,0 +1,154 @@
+//! #339 Part 2 (SR-59) — loud-not-silent acceptance of a no-reloc value-address
+//! module under `--memory shared --address-rebase`.
+//!
+//! The path-F gate hard-fails a non-zero-base, no-reloc module only when it does
+//! a direct load/store. A module that uses an absolute address purely as a VALUE
+//! (`i32.const <abs>; return` / passed to a call) has no load/store, so it is
+//! ACCEPTED with an empty rebase plan — and its address const is emitted
+//! un-rebased. A sound "is this const an address" detector is undecidable without
+//! relocs (a broadened gate was built, reviewed, and REVERTED), so meld does not
+//! reject; it must instead WARN loudly and name the remedy (`--emit-relocs`).
+//!
+//! This test pins the observability contract: the acceptance warning fires and
+//! names the module, AND the output still validates (non-regression for the
+//! accepted-no-reloc class, #298 / #304).
+
+use std::sync::{Mutex, Once};
+
+use meld_core::{Fuser, FuserConfig, MemoryStrategy};
+use wasm_encoder::{
+    CodeSection, Component, ExportKind, ExportSection, Function, FunctionSection, Instruction,
+    MemorySection, MemoryType, Module, ModuleSection, TypeSection, ValType,
+};
+
+// ── minimal log capture (this test file is its own test binary, so it owns the
+//    process-global logger here without contending with other test files) ──────
+
+static CAPTURED: Mutex<Vec<String>> = Mutex::new(Vec::new());
+static INIT: Once = Once::new();
+
+static LOGGER: CaptureLogger = CaptureLogger;
+
+struct CaptureLogger;
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record<'_>) {
+        if record.level() == log::Level::Warn {
+            CAPTURED.lock().unwrap().push(format!("{}", record.args()));
+        }
+    }
+    fn flush(&self) {}
+}
+
+fn install_capture() {
+    INIT.call_once(|| {
+        log::set_logger(&LOGGER).expect("install capture logger");
+        log::set_max_level(log::LevelFilter::Warn);
+    });
+}
+
+fn shared_memory_section() -> MemorySection {
+    let mut memory = MemorySection::new();
+    memory.memory(MemoryType {
+        minimum: 1,
+        maximum: Some(2),
+        memory64: false,
+        shared: true,
+        page_size_log2: None,
+    });
+    memory
+}
+
+fn build_component(module: Module) -> Vec<u8> {
+    let mut component = Component::new();
+    component.section(&ModuleSection(&module));
+    component.finish()
+}
+
+/// component-a: a 1-page shared memory occupying window `[0, 64KiB)`. No code, so
+/// the value-address module below is placed at a non-zero base.
+fn build_base_module() -> Module {
+    let mut exports = ExportSection::new();
+    exports.export("memory", ExportKind::Memory, 0);
+    let mut module = Module::new();
+    module.section(&shared_memory_section()).section(&exports);
+    module
+}
+
+/// component-b: a shared memory + a function that RETURNS an absolute address
+/// literal as a value (`i32.const 0x1234; end`). No load/store ⟹ path-F accepts
+/// it; no reloc metadata ⟹ the const cannot be rebased. This is exactly the
+/// accepted-but-un-rebased class the warning must announce.
+fn build_value_address_module() -> Module {
+    let mut types = TypeSection::new();
+    types.ty().function([], [ValType::I32]);
+
+    let mut functions = FunctionSection::new();
+    functions.function(0);
+
+    let mut exports = ExportSection::new();
+    exports.export("get_addr", ExportKind::Func, 0);
+
+    let mut code = CodeSection::new();
+    let mut f = Function::new([]);
+    f.instruction(&Instruction::I32Const(0x1234)); // absolute address used as a VALUE
+    f.instruction(&Instruction::End);
+    code.function(&f);
+
+    let mut module = Module::new();
+    module
+        .section(&types)
+        .section(&functions)
+        .section(&shared_memory_section())
+        .section(&exports)
+        .section(&code);
+    module
+}
+
+#[test]
+fn value_address_no_reloc_accept_warns_and_validates_339() {
+    install_capture();
+    CAPTURED.lock().unwrap().clear();
+
+    let component_a = build_component(build_base_module());
+    let component_b = build_component(build_value_address_module());
+
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::SharedMemory,
+        address_rebasing: true,
+        pack_rebase: false,
+        ..Default::default()
+    };
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(&component_a, Some("component-a"))
+        .unwrap();
+    fuser
+        .add_component_named(&component_b, Some("value-addr-mod"))
+        .unwrap();
+
+    // Non-regression (#298/#304): the accepted-no-reloc class must still fuse and
+    // the output must validate — the warning is observability, not a reject.
+    let fused = fuser
+        .fuse()
+        .expect("a no-reloc value-address module must be ACCEPTED (warn, not fail)");
+    assert!(
+        wasmparser::Validator::new().validate_all(&fused).is_ok(),
+        "fused output must still validate"
+    );
+
+    // The acceptance warning must fire, naming the module and the remedy.
+    let warnings = CAPTURED.lock().unwrap().clone();
+    let hit = warnings.iter().find(|w| w.contains("value-addr-mod"));
+    let hit = hit.unwrap_or_else(|| {
+        panic!("expected an acceptance warning naming the module; captured: {warnings:?}")
+    });
+    assert!(
+        hit.contains("UN-REBASED") && hit.contains("--emit-relocs"),
+        "warning must name the risk (un-rebased value) and the remedy \
+         (--emit-relocs); got: {hit}"
+    );
+}

--- a/meld-core/tests/wit_bindgen_runtime.rs
+++ b/meld-core/tests/wit_bindgen_runtime.rs
@@ -586,23 +586,13 @@ fn test_runtime_wit_bindgen_fixed_length_lists() {
     }
     let fused = fuse_fixture("fixed-length-lists", OutputFormat::Component)
         .expect("fixed-length-lists: component fusion should succeed");
-    // Fixed-size list adapter support is new; runtime execution may fail
-    // due to adapter-level issues with inline array data copying.
-    match run_wasi_component(&fused) {
-        Ok(()) => {}
-        Err(e) => {
-            let msg = format!("{e:?}");
-            if msg.contains("unreachable") || msg.contains("wasm trap") || msg.contains("assertion")
-            {
-                eprintln!(
-                    "fixed-length-lists: runtime execution failed \
-                     (adapter limitation for fixed-size lists): {e}"
-                );
-            } else {
-                panic!("fixed-length-lists: unexpected runtime error: {e:?}");
-            }
-        }
-    }
+    // SR-58 (#371): the guest round-trips fixed-size lists and asserts the
+    // values (runner.rs). Before the params-area copy fix the callee read its
+    // params from its own memory at the caller's address → all-zeros → the
+    // guest assertion trapped; the test used to tolerate that. Now it is a real
+    // differential oracle: run() must SUCCEED.
+    run_wasi_component(&fused)
+        .expect("fixed-length-lists: runtime round-trip should succeed (SR-58 / #371)");
 }
 
 #[test]

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2316,7 +2316,7 @@ artifacts:
 
   - id: SR-59
     type: sw-req
-    title: Loud no-reloc acceptance + rebased global-initializer addresses
+    title: Loud no-reloc acceptance + static-PIC global-initializer fold
     description: >
       Two residual gaps in the shared-memory rebase path left by SR-48's path-F
       carve-out (#339, #326 Finding A). (1) LOUD-NOT-SILENT: when
@@ -2326,15 +2326,32 @@ artifacts:
       the remedy (`--emit-relocs`); it shall never SILENTLY accept one. This is a
       policy/observability guarantee, NOT a detector — a sound-and-precise
       "is this const an address" test is undecidable without relocation metadata
-      (see SR-48). (2) GLOBAL-INIT REBASE: a global initializer that bakes an
-      absolute address (`(global (mut i32) (i32.const <abs>))`, or an extended-
-      const `base + N`) is currently emitted un-rebased by
-      `merger.rs::convert_init_expr` — a demonstrated end-to-end corruption (the
-      global reads the neighbor component's data under shared memory). meld shall
-      rebase a global initializer's absolute address by the module's
-      `memory_base` when it is reloc-covered, and hard-fail-or-warn otherwise;
-      `__stack_pointer`-class globals stay exempt (coalesced separately).
-    status: proposed
+      (see SR-48). (2) STATIC-PIC GLOBAL-INIT FOLD: real PIC toolchains emit a
+      global initialized to `__memory_base + N` (a leading `global.get` of the
+      base + extended-const), NOT a bare absolute const — and global initializers
+      are NEVER reloc-covered (clang/wasm-ld emit no `reloc.GLOBAL`; a data-address
+      global lowers to a `reloc.DATA` DATA symbol instead). `merger.rs::convert_init_expr`
+      previously applied the #353 `__memory_base`-fold ONLY to data/element
+      offsets, so after fusion such a global became `global.get <defined-base>;
+      i32.const N; i32.add`, which wasmtime REJECTS ("constant expression
+      required: global.get of locally defined global") — and where accepted held
+      an un-rebased address. meld shall fold a global initializer whose leading op
+      is a now-DEFINED constant base (`base + N`) to a concrete `i32.const
+      (base + N)` — the module's own placed address — mirroring the #353
+      leading-only offset fold; `__stack_pointer`-class globals stay exempt.
+      RESIDUAL (documented; #339 stays OPEN, NOT claimed fixed): a BARE no-reloc
+      absolute-const global (`(global (i32.const <abs>))`, avrabe's synthetic
+      repro) is byte-identical to an integer and carries no metadata naming the
+      site, so it is neither folded nor rebased — the same undecidability as the
+      value-address carve-out (part 1 / SR-48). Part 2's warn does not cover it
+      either (those modules carry relocs, so path-F never reaches the warn).
+      A second residual (pre-existing, Mythos-surfaced): the OPERAND-SWAPPED PIC
+      form `i32.add(i32.const N, global.get <defined-base>)` is not folded (the
+      fold is leading-base-only) → emitted verbatim → wasm-tools-valid but
+      wasmtime-invalid ("constant expression required"). Not observed from wasm-ld
+      (which emits base-first, which IS folded); fails loud at instantiation, not
+      silent; tracked, not fixed here.
+    status: verified
     tags: [memory-strategy, shared-memory, relocation, loud-not-silent, silent-corruption]
     release: v0.44.0
     links:
@@ -2352,18 +2369,24 @@ artifacts:
       implementation:
         - meld-core/src/merger.rs
         - meld-core/src/address_strategy.rs
+        - meld-core/src/segments.rs
       verification-method: test
       verification-description: >
-        PROPOSED. Global-init rebase verified by a wasmtime differential oracle:
-        fuse two reloc-bearing components under `--memory shared --address-rebase`
-        where one reads a pointer from a global initializer; assert the global
-        reads the component's OWN data (base + N), not the neighbor's (the #326
-        Finding A repro is a ready-made oracle — pre-fix the global returns the
-        raw un-rebased address). The loud-acceptance behavior is verified by a
-        log-assertion test on a no-reloc value-address module (the acceptance
-        warning fires; the output still validates — non-regression for #298/#304).
-        Explicitly NOT verified: that the gate detects address-as-value in
-        general (undecidable; documented in SR-48).
+        Part 2 (global-init fold) verified by
+        `meld-core/tests/pic_extended_const_353.rs::pic_extended_const_global_init_valid_and_rebased_339`:
+        a component whose global is initialized `__memory_base + 8` is fused and
+        run on wasmtime — RED before the fix (wasmtime rejects the unfolded
+        `global.get <defined>` init), GREEN after (accepts, and `get_g()` returns
+        the rebased `base + 8 = 65544`). Part 1 (loud acceptance) verified by
+        `meld-core/tests/value_address_warn_339.rs`: a no-reloc value-address
+        module fused under shared+rebase fires the acceptance warning and still
+        validates (non-regression for #298/#304); RED verified via negative
+        control. Explicitly NOT verified / NOT fixed: (a) the gate detecting
+        address-as-value in general, and (b) the bare no-reloc absolute-const
+        global (#339 residual) — both undecidable without relocs (see SR-48).
+        Implementation reuses `segments::eval_ext_const_i32_with_base` (visibility
+        widened to pub(crate)). The #299 memory.grow diagnostic (remedies named)
+        rides in the same change under SR-50.
       references:
         - "https://github.com/pulseengine/meld/issues/339"
         - "https://github.com/pulseengine/meld/issues/326"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -1676,8 +1676,20 @@ artifacts:
       shared-memory `memory_base` to every `R_WASM_MEMORY_ADDR_SLEB`/`_LEB`/`_I32`
       operand (code literals AND data-section pointers), and strip the consumed
       relocations from the output. When a `--memory shared` input lacks this
-      metadata (non-relocatable / PIC-stripped), meld shall HARD-ERROR rather
-      than emit an un-rebased colliding module. PIC/dylink inputs are out of
+      metadata (non-relocatable / PIC-stripped) AND performs a direct
+      `load`/`store` at a non-zero base, meld shall HARD-ERROR (path-F,
+      `module_has_direct_memory_access`) rather than emit an un-rebased colliding
+      module. RESIDUAL CARVE-OUT (corrected 2026-08-12, was overstated as an
+      unconditional hard-error): a no-reloc module that references an absolute
+      address only as a VALUE (`i32.const <abs>; call`, a returned/stored
+      pointer, or a global initializer), or that accesses memory only via
+      bulk-memory ops, is NOT caught by path-F and is currently accepted — a
+      sound-and-precise "is this const an address" detector is undecidable
+      without relocation metadata (a broadened gate was built, Mythos-reviewed,
+      and reverted for simultaneous over- and under-rejection). SR-59 governs
+      making that acceptance LOUD and closing the one tractable, execution-
+      demonstrated sub-case (global-initializer addresses in `convert_init_expr`).
+      PIC/dylink inputs are out of
       scope: a Component-Model core may import only functions, so
       `wasm-tools component new` rejects a core importing `memory`/`__memory_base`
       globals (ADR-6, path-E rejected). This supersedes, for the shared path,
@@ -2255,3 +2267,271 @@ artifacts:
         - "https://github.com/pulseengine/meld/issues/370"
         - "gale#266"
         - "meld-core/tests/pack_rebase_370.rs"
+
+  - id: SR-58
+    type: sw-req
+    title: Cross-memory params-area copy under the combined params-ptr + retptr convention
+    description: >
+      When a cross-component call flattens to MORE than the ABI flat-param limit
+      (16) AND returns MORE than the flat-result limit (1) — the combined
+      convention where the caller passes `(params_ptr, retptr)` and the callee
+      is `(params_ptr) -> i32` — the generated adapter shall copy the caller's
+      params buffer into CALLEE memory (with pointer-pair and borrow fixups)
+      before the call, in addition to the return-area copy-back. Today the
+      retptr detection wins the dispatch and returns early into
+      `generate_retptr_adapter`, which never consults `params_area_byte_size`,
+      so the callee reads its parameters from its OWN memory at the caller's
+      address → all-zeros (or, for a params area containing strings, cross-memory
+      pointer corruption). The output validates, so this is a silent
+      "validates-but-wrong" divergence (#371). The retptr-only and
+      params-ptr-only paths are unchanged.
+    status: proposed
+    tags: [adapter, canonical-abi, cross-memory, correctness, silent-divergence]
+    release: v0.44.0
+    links:
+      - type: derives-from
+        target: SYS-3
+      - type: refines
+        target: SR-12
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/371"
+        kind: github
+        last-checked: 2026-08-12
+    fields:
+      implementation:
+        - meld-core/src/adapter/fact.rs
+      verification-method: test
+      verification-description: >
+        PROPOSED. Verified by flipping the existing runtime differential test
+        `meld-core/tests/wit_bindgen_runtime.rs::test_runtime_wit_bindgen_fixed_length_lists`
+        from tolerating the guest-side trap to asserting `run()` SUCCEEDS — the
+        guest `assert_eq`s on the round-tripped fixed-size-list values then form
+        the oracle (the test is red today, green only with the params-area copy
+        in the retptr path). A same-PR case shall also cover / fail-loud-guard
+        the >16-flat-params-with-strings + retptr shape (pointer_pair_positions
+        indexing) so it does not silently corrupt.
+      references:
+        - "https://github.com/pulseengine/meld/issues/371"
+        - "meld-core/tests/wit_bindgen_runtime.rs"
+
+  - id: SR-59
+    type: sw-req
+    title: Loud no-reloc acceptance + rebased global-initializer addresses
+    description: >
+      Two residual gaps in the shared-memory rebase path left by SR-48's path-F
+      carve-out (#339, #326 Finding A). (1) LOUD-NOT-SILENT: when
+      `--memory shared --address-rebase` ACCEPTS a no-reloc, non-zero-base module
+      with a code section (the path-F carve-out — no direct load/store), meld
+      shall emit a diagnostic naming the module and the un-rebased-value risk and
+      the remedy (`--emit-relocs`); it shall never SILENTLY accept one. This is a
+      policy/observability guarantee, NOT a detector — a sound-and-precise
+      "is this const an address" test is undecidable without relocation metadata
+      (see SR-48). (2) GLOBAL-INIT REBASE: a global initializer that bakes an
+      absolute address (`(global (mut i32) (i32.const <abs>))`, or an extended-
+      const `base + N`) is currently emitted un-rebased by
+      `merger.rs::convert_init_expr` — a demonstrated end-to-end corruption (the
+      global reads the neighbor component's data under shared memory). meld shall
+      rebase a global initializer's absolute address by the module's
+      `memory_base` when it is reloc-covered, and hard-fail-or-warn otherwise;
+      `__stack_pointer`-class globals stay exempt (coalesced separately).
+    status: proposed
+    tags: [memory-strategy, shared-memory, relocation, loud-not-silent, silent-corruption]
+    release: v0.44.0
+    links:
+      - type: derives-from
+        target: SYS-6
+      - type: mitigates
+        target: LS-M-11
+      - type: refines
+        target: SR-48
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/339"
+        kind: github
+        last-checked: 2026-08-12
+    fields:
+      implementation:
+        - meld-core/src/merger.rs
+        - meld-core/src/address_strategy.rs
+      verification-method: test
+      verification-description: >
+        PROPOSED. Global-init rebase verified by a wasmtime differential oracle:
+        fuse two reloc-bearing components under `--memory shared --address-rebase`
+        where one reads a pointer from a global initializer; assert the global
+        reads the component's OWN data (base + N), not the neighbor's (the #326
+        Finding A repro is a ready-made oracle — pre-fix the global returns the
+        raw un-rebased address). The loud-acceptance behavior is verified by a
+        log-assertion test on a no-reloc value-address module (the acceptance
+        warning fires; the output still validates — non-regression for #298/#304).
+        Explicitly NOT verified: that the gate detects address-as-value in
+        general (undecidable; documented in SR-48).
+      references:
+        - "https://github.com/pulseengine/meld/issues/339"
+        - "https://github.com/pulseengine/meld/issues/326"
+
+  - id: SR-60
+    type: sw-req
+    title: Const-expr offset folding is equivalence-checked against certificate-checked QF_BV semantics
+    description: >
+      Every extended-const fold surface — `segments.rs::fold_extended_const_i32`
+      / `_i64`, `segments.rs::eval_ext_const_i32_with_base` (the #353/#368
+      static-PIC fold), and `merger.rs::convert_init_expr` — shall be validated by
+      a property harness whose reference is `ordeal` (a certificate-checked
+      QF_BV SMT solver, crates.io): for randomly generated well-formed
+      extended-const operator sequences over {i32/i64.const, add, sub, mul,
+      global.get} and base values, the folded value shall equal the wasm
+      stack-machine evaluation (modular bitvector arithmetic) — asserted via
+      `Solver::prove_equiv` returning UNSAT with a re-checkable certificate
+      (`Unknown` is a hard test failure, not a pass). Negative controls shall
+      symbolically refute the #338 truncation (`prove_equiv(base + N, base)` →
+      SAT with witness) and a mutated fold. Closes the #338 silent-miscompile
+      class with proof rather than examples (#344).
+    status: proposed
+    tags: [const-expr, verification-hardening, smt, ordeal, correctness]
+    release: v0.45.0
+    links:
+      - type: derives-from
+        target: SYS-1
+      - type: refines
+        target: SR-51
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/344"
+        kind: github
+        last-checked: 2026-08-12
+    fields:
+      implementation:
+        - meld-core/src/segments.rs
+      verification-method: test
+      verification-description: >
+        PROPOSED. A proptest generator drives the SHIPPED fold entry points
+        (`parse_const_expr_with_value` via encoded bytes, `eval_ext_const_i32_with_base`)
+        over random valid sequences; `ordeal::Solver::prove_equiv` is the
+        reference (UNSAT + `cert.recheck()`; Unknown = fail). Negative controls:
+        the #338 `base + 16` truncation refuted symbolically over free base, and
+        a deliberately-wrong fold caught. Plus 2-3 wasmtime wrap-boundary
+        ground-truth checks. Test-only change + one dev-dependency; no production
+        code touched. First requirement coverage of `eval_ext_const_i32_with_base`.
+      references:
+        - "https://github.com/pulseengine/meld/issues/344"
+        - "https://github.com/pulseengine/meld/issues/338"
+        - "ordeal 0.18 (crates.io) Solver::prove_equiv"
+
+  - id: SR-61
+    type: sw-req
+    title: Fused output passes sound abstract interpretation (scry gate)
+    description: >
+      The fused core module shall pass a `scry` abstract-interpretation
+      well-formedness check as a CI gate: a representative fused output
+      (`meld fuse` of a checked-in fixture) shall have well-formed program points
+      and call edges (`scry-viz check` exit 0), catching structural corruption
+      the wasm validator does not. scry is explicitly designed to run post-meld on
+      fused core modules (#302 Track C). This is a wasm-level verification gate on
+      the actual product (meld fuses wasm in/out but currently runs no wasm-level
+      verification).
+    status: proposed
+    tags: [ci-gate, wasm-verification, scry, abstract-interpretation, do-333]
+    release: v0.45.0
+    links:
+      - type: derives-from
+        target: SYS-11
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/302"
+        kind: github
+        last-checked: 2026-08-12
+    fields:
+      implementation:
+        - .github/workflows/scry-gate.yml
+      verification-method: automated-test
+      verification-description: >
+        PROPOSED. `scry-gate.yml` (mirrors wohl's scry-gate) clones the pinned
+        scry ref, builds `scry-viz`, fuses `tests/wit_bindgen/fixtures/strings-simple.wasm`,
+        and runs `scry-viz check` — red on crash/malformed. Verified GREEN today
+        in scoping (586 functions, 7070 program points, 464 call edges, exit 0).
+      references:
+        - "https://github.com/pulseengine/meld/issues/302"
+
+  - id: SR-62
+    type: sw-req
+    title: Fused output is witness-instrumentable with a zero-gap MC/DC gate fixture
+    description: >
+      The fused core module shall be `witness`-instrumentable, and a dedicated
+      MC/DC gate fixture (an import-free seam fused with `--preserve-names`) shall
+      report ZERO unresolved gap rows in the witness MC/DC truth table as a CI
+      gate (#302 Track C). Day-one scope is a pipeline + no-regression gate
+      (instrument → run --invoke-all → report gap==0); rich per-decision MC/DC
+      rows require a rustc-lowered fixture with DWARF (tracked as a follow-up,
+      since hand-written WAT yields zero recoverable decisions, and the fused
+      real wit-bindgen output retains wasi imports the core runner cannot stub —
+      witness#180).
+    status: proposed
+    tags: [ci-gate, wasm-verification, witness, mcdc, do-178c]
+    release: v0.45.0
+    links:
+      - type: derives-from
+        target: SYS-11
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/302"
+        kind: github
+        last-checked: 2026-08-12
+    fields:
+      implementation:
+        - .github/workflows/witness-gate.yml
+      verification-method: automated-test
+      verification-description: >
+        PROPOSED. `witness-gate.yml` (mirrors wohl's run-witness.sh) checks in a
+        small import-free WAT seam fixture, fuses it with `--preserve-names`,
+        instruments, runs `--invoke-all`, and gates `grep -oE '[0-9]+ gap' == 0`.
+        Honest limitation recorded in the SR: pipeline/no-regression until a
+        rustc-built fixture lands; the flat-decision reconstruction on WAT is
+        the same as wohl's documented finding.
+      references:
+        - "https://github.com/pulseengine/meld/issues/302"
+
+  - id: SR-63
+    type: sw-req
+    title: Embedder-provided allocator seam survives fusion (pulseengine:embedder)
+    description: >
+      The fuser shall preserve embedder-namespace imports (the
+      `pulseengine:embedder` arena-realloc seam) unresolved through
+      `fuse --memory shared --address-rebase` core-module output — never binding
+      them to a fusion-set provider nor rejecting them — so the embedder
+      (synth / native link) binds them at dissolve. This is the grow-free MCU
+      path for the jess/gale Pixhawk pipeline: components route `cabi_realloc` to
+      an embedder import (`env::__cabi_arena_realloc`) instead of growing memory
+      (#301; complements the already-shipped #298 defer-grow/export-drop, SR-50).
+      SCOPE HONESTY: the differential oracle uses a SYNTHETIC-WAT arena component
+      (proves meld's pass-through plumbing); the REAL forked-toolchain artifact
+      path (forked wit-bindgen#4 `cabi-realloc-extern` + wasm-tools#2
+      `--import-passthrough`) is NOT covered in-repo and is tracked as a
+      follow-up. `--output component` re-exposure (component_wrap arm, Gap B) is
+      out of scope here.
+    status: proposed
+    tags: [resolver, embedder-passthrough, mcu, shared-memory, grow-free]
+    release: v0.45.0
+    links:
+      - type: derives-from
+        target: SYS-8
+      - type: mitigates
+        target: LS-R-17
+      - type: refines
+        target: SR-50
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/301"
+        kind: github
+        last-checked: 2026-08-12
+    fields:
+      implementation:
+        - meld-core/src/resolver.rs
+      verification-method: test
+      verification-description: >
+        PROPOSED. Differential-execution oracle (new test in
+        `meld-core/tests/rebasing_end_to_end.rs`): fuse two SYNTHETIC arena
+        components under `--memory shared --address-rebase`; assert the fused
+        core validates, RETAINS the `env::__cabi_arena_realloc` import (nm-symbol
+        oracle), and — instantiated with a host-provided arena via `Linker` —
+        the export returns the same result as the unfused composition. Verifies
+        meld's plumbing ONLY; the forked-toolchain real-artifact path is a
+        documented follow-up (see SCOPE HONESTY in the description).
+      references:
+        - "https://github.com/pulseengine/meld/issues/301"
+        - "https://github.com/pulseengine/meld/issues/298"
+        - "https://github.com/pulseengine/meld/issues/299"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2285,7 +2285,7 @@ artifacts:
       pointer corruption). The output validates, so this is a silent
       "validates-but-wrong" divergence (#371). The retptr-only and
       params-ptr-only paths are unchanged.
-    status: proposed
+    status: verified
     tags: [adapter, canonical-abi, cross-memory, correctness, silent-divergence]
     release: v0.44.0
     links:

--- a/safety/requirements/sw-verifications.yaml
+++ b/safety/requirements/sw-verifications.yaml
@@ -647,3 +647,30 @@ artifacts:
     links:
       - type: verifies
         target: SR-58
+  - id: SWV-49
+    type: sw-verification
+    title: "Verification of SR-59: Loud no-reloc acceptance + static-PIC global-init fold"
+    description: >
+      Verifies SR-59 via two wasmtime-backed oracles (both confirmed red→green
+      by stash). Global-init fold:
+      meld-core/tests/pic_extended_const_353.rs::pic_extended_const_global_init_valid_and_rebased_339
+      — a global initialized `__memory_base + 8` fused under shared+rebase; RED
+      before (wasmtime rejects the unfolded `global.get <defined>` init), GREEN
+      after (accepts; get_g() == base+8 == 65544). merger.rs::fold_defined_base_init
+      folds a leading defined-const-base extended-const to a concrete i32.const,
+      extending the #353 offset fold to global initializers (reusing
+      segments::eval_ext_const_i32_with_base). Loud acceptance:
+      meld-core/tests/value_address_warn_339.rs — a no-reloc value-address module
+      fires the address_strategy path-F accept warning and still validates
+      (non-regression for #298/#304). Mythos delta-pass: NO DELTA-INTRODUCED
+      FINDING (immutable-only + i32-only base map rules out mutable-drift/type
+      misfire; value-preserving). Documented residuals NOT claimed fixed: the
+      bare no-reloc absolute-const global and the operand-swapped defined-base
+      form (both undecidable / pre-existing; the latter fails loud at wasmtime
+      instantiation). #299 memory.grow diagnostic rides under SR-50.
+    status: implemented
+    fields:
+      method: automated-test
+    links:
+      - type: verifies
+        target: SR-59

--- a/safety/requirements/sw-verifications.yaml
+++ b/safety/requirements/sw-verifications.yaml
@@ -620,3 +620,30 @@ artifacts:
     links:
       - type: verifies
         target: SR-57
+  - id: SWV-48
+    type: sw-verification
+    title: "Verification of SR-58: Cross-memory params-area copy (combined params-ptr + retptr)"
+    description: >
+      Verifies SR-58 by flipping the runtime differential test
+      meld-core/tests/wit_bindgen_runtime.rs::test_runtime_wit_bindgen_fixed_length_lists
+      from tolerating the guest trap to asserting run() SUCCEEDS; the guest
+      assert_eq on the round-tripped fixed-size-list values is the oracle (red
+      before the fix — callee read params from its own memory at the caller's
+      address → all-zeros → trap; green after). Fix in adapter/fact.rs: extracted
+      emit_params_area_copy (Phases 1-3.5 of the params-ptr adapter) and a
+      uses_params_area branch in generate_retptr_adapter that reserves scratch
+      AT THE END (no existing local index shifts), gates the flat-coordinate
+      Phase 0/1/1b behind !uses_params_area, and pushes the copied callee buffer
+      pointer instead of the caller's raw params_ptr. Mythos delta-pass returned
+      NO VALIDATED FINDING (worst-case local map reconstructed, no overlap;
+      refactor byte-identical; full 74-test runtime suite green). It surfaced a
+      pre-existing latent gap — nested inner_pointers (list<string>/list<list>)
+      inside a >16-param buffer were not relocated on either path — now made
+      LOUD (fail-loud Err) in the shared helper rather than left silently
+      dangling. Full suite 804 passed / 44 binaries / 0 failed.
+    status: implemented
+    fields:
+      method: automated-test
+    links:
+      - type: verifies
+        target: SR-58


### PR DESCRIPTION
Two silent-corruption fixes, each closing a demonstrated divergence with a hard runtime oracle. Part of the A+B+C tracker sweep (correctness half → v0.44.0; verification-hardening half → v0.45.0, already planned in rivet).

## SR-58 — cross-memory params-area copy (#371)
A cross-component call with flat params > 16 **and** flat results > 1 uses the combined `(params_ptr, retptr)` convention. It matched the retptr heuristic and was routed to `generate_retptr_adapter`, which never copied the params buffer across memories — so the callee read its parameters from **its own** memory at the caller's address → **all-zeros**. The output validated (silent). Fix: extract `emit_params_area_copy` and call it from a `uses_params_area` branch in the retptr adapter (scratch reserved at the end so no local index shifts; flat-coordinate phases gated off; copied buffer pointer pushed). Un-bridgeable shapes (3-component borrow chains; nested `list<string>`/`list<list<_>>` in a >16-param buffer) now **fail loud**.

**Oracle:** `test_runtime_wit_bindgen_fixed_length_lists` flipped from tolerating the guest trap to asserting `run()` succeeds (red→green). **Mythos:** NO VALIDATED FINDING (worst-case local map reconstructed, no overlap; refactor byte-identical) — it surfaced a pre-existing nested-pointer gap, now made loud.

## SR-59 — static-PIC global-init fold + loud no-reloc acceptance (#339)
Real PIC toolchains emit a global initialized `__memory_base + N`; global initializers are never reloc-covered. `convert_init_expr` applied the #353 base-fold only to data/element offsets, so such a global became `global.get <defined-base>; i32.const N; i32.add` — which **wasmtime rejects**. Fix: `fold_defined_base_init` folds a leading defined-const-base to the module's placed address. Plus a `log::warn!` on no-reloc value-address acceptance (observability, **not** a detector — undecidable). Corrects SR-48's overstated "shall HARD-ERROR" text.

**Oracles:** `pic_extended_const_353.rs::..._339` (wasmtime rejects→accepts, `get_g()==base+8`) and `value_address_warn_339.rs`. **Mythos:** NO DELTA-INTRODUCED FINDING (immutable-only + i32-only base map; value-preserving).

**#339 stays OPEN** — the bare no-reloc absolute-const global and the operand-swapped `i32.add(N, global.get $defined_base)` form are documented residuals (undecidable / unobserved from wasm-ld; the latter fails loud at instantiation), not claimed fixed.

## Falsification
- Fuse a component whose call flattens to >16 params + a multi-field result — before: all-zeros at runtime; now: correct round-trip on wasmtime.
- Fuse a PIC component with a `__memory_base + N` global initializer under `--memory shared --address-rebase` — before: wasmtime refuses to instantiate; now: instantiates and the global holds `base + N`.

## Verification
Full suite **806 passed / 45 binaries / 0 failed**; `clippy --all-targets` clean; `rivet validate` PASS. Local Mythos delta-pass on each Tier-5 change (adapter/, merger/address_strategy); the CI auto-Mythos gate re-runs on this PR.

Traceability: SR-58 + SR-59 verified, SWV-48 + SWV-49; #299 diagnostic under SR-50; SR-48 wording corrected. v0.45.0 SRs (SR-60 ordeal, SR-61/62 scry+witness gates, SR-63 embedder seam) are in rivet as `proposed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)