### PR TITLE
feat(v0.47.0): #370 pack-rebase __heap_base extent (silent→loud) + meld docs subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.47.0] - 2026-08-13
+
+### Fixed
+- **`--pack-rebase` no longer silently under-reserves `.bss` / static arenas
+  (SR-65, #370)** — it packed by the active-data-segment extent only, so a
+  component whose accessed memory (a zero-init `.bss` region or relay's bounded
+  static arena) extends above its last data segment was under-reserved, and
+  SR-56's overlap check is active-data-only so the cross-component collision
+  wasn't caught — silent corruption (confirmed on the real falcon components: a
+  65440-byte arena tail invisible to the data scan). Compaction below the
+  declared page count now **requires an authoritative `__heap_base` marker**
+  (defined immutable `i32` global, read from the export table or name section);
+  absent it, meld **falls back to page-granular and warns** (`-Wl,--export=__heap_base`),
+  never silently under-reserving. `declared` (initial pages) caps the extent only
+  for a **defined** memory; for an **imported** memory it is a floor. A local
+  Mythos delta-pass caught + closed an imported-memory under-reserve regression
+  in the first cut. Compaction of published artifacts is gated on suppliers
+  retaining `__heap_base` alongside `--emit-relocs`.
+
+### Added
+- **`meld docs` — embedded, queryable documentation (SR-64)** — topics compiled
+  into the binary (offline). `meld docs` lists topics, `meld docs <topic>` shows
+  one, `--grep <q>` searches, `--format json` for machine queries, and
+  `meld docs check --coverage --strict` asserts every subcommand has a topic (a
+  CI gate). Models `rivet docs` / varve's REQ-DOCS-001.
+
 ## [0.46.0] - 2026-08-13
 
 Traceability close-out and verification depth. **No production behavior change** —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.46.0"
+version = "0.47.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/meld-cli/BUILD.bazel
+++ b/meld-cli/BUILD.bazel
@@ -5,6 +5,11 @@ package(default_visibility = ["//visibility:public"])
 rust_binary(
     name = "meld",
     srcs = glob(["src/**/*.rs"]),
+    # `src/docs.rs` embeds these via `include_str!(concat!("../docs/", …))`.
+    # cargo reads them from the filesystem; Bazel sandboxes them away unless
+    # they are declared as compile_data. The `meld_test` target inherits this
+    # through `crate = ":meld"`.
+    compile_data = glob(["docs/**/*.md"]),
     crate_name = "meld_cli",
     edition = "2024",
     rustc_env = {

--- a/meld-cli/docs/cmd-docs.md
+++ b/meld-cli/docs/cmd-docs.md
@@ -1,0 +1,13 @@
+# meld docs [topic]
+
+This documentation, embedded in the binary (offline, air-gapped by
+construction). `meld docs` lists topics; `meld docs <topic>` shows one;
+`--grep <q>` searches across all topic bodies and titles; `--format json`
+emits the list (or a single topic, with its body) as JSON for machine queries,
+modelled on `rivet docs`.
+
+`meld docs check --coverage` asserts that every top-level CLI subcommand has a
+documented topic whose slug matches the subcommand name; `--strict` exits
+non-zero on any gap, so an undocumented subcommand cannot ship (a CI gate, not
+review discipline). This is the mechanical invariant behind safety requirement
+SR-64.

--- a/meld-cli/docs/cmd-fuse.md
+++ b/meld-cli/docs/cmd-fuse.md
@@ -1,0 +1,27 @@
+# meld fuse — fuse components into one core module
+
+`meld fuse <inputs...> -o <output>` statically links two or more WebAssembly
+components into a single core module (or, with `--component`, a P2 component).
+Cross-component imports are resolved at build time; see the `fusion` topic.
+
+Key flags:
+
+- `-o, --output <PATH>` — output path (default `fused.wasm`).
+- `--memory <auto|multi|shared>` — how the input memories coexist (default
+  `auto`). See the `memory-strategies` topic.
+- `--address-rebase` — relocate each component's data within one shared memory
+  and rewrite its pointers. Valid only with `--memory shared`; `auto` decides
+  it itself. See `address-rebasing`.
+- `--pack-rebase` — compact used-extent variant of `--address-rebase` for MCU
+  targets; implies `--address-rebase`, requires `--memory shared`, and is sound
+  only for components that address nothing above their last data segment. See
+  `pack-rebase`.
+- `--component` — emit a P2 component instead of a core module.
+- `--dwarf <remap|strip|passthrough>` — debug-info handling (default `remap`).
+- `--opaque-rep <iface.resource>` — treat a resource's representation as a
+  `u32` per component rather than the shared-by-name boxed default; repeatable.
+- `--no-attestation` / `--reproducible` — see the `attestation` topic.
+- `--no-component-provenance` — drop the per-function origin map (`provenance`).
+- `--stats`, `--validate`, `--preserve-names`, `--emit-import-map <PATH>` —
+  fusion statistics, wasmparser validation, name preservation, and a JSON
+  import map for synth/kiln integration.

--- a/meld-cli/docs/cmd-inspect.md
+++ b/meld-cli/docs/cmd-inspect.md
@@ -1,0 +1,19 @@
+# meld inspect — examine a WebAssembly component
+
+`meld inspect <input>` reads a `.wasm` file and reports what it is. It checks
+the magic number and version to distinguish a WebAssembly Component (P2) from a
+plain core module, and prints the file size. For a component it parses the
+structure and reports the number of core modules, imports, and exports.
+
+Flags:
+
+- `--interfaces` — list the component's imports and exports by name (exports
+  also show their kind). Useful for seeing the seams meld would have to resolve
+  before fusing.
+- `--types` — show per-core-module detail: counts of types, functions,
+  imports, exports, memories, tables, and globals.
+
+If the input is a core module rather than a component, `inspect` says so and
+notes that `wasm-tools component new` can convert it. `inspect` is read-only;
+it never modifies the input and is the quick way to sanity-check an artifact
+before or after a `fuse`.

--- a/meld-cli/docs/cmd-version.md
+++ b/meld-cli/docs/cmd-version.md
@@ -1,0 +1,11 @@
+# meld version — show version and toolchain context
+
+`meld version` prints the meld release version (the crate version compiled into
+the binary) together with a short description of the tool and its place in the
+pulseengine toolchain — alongside `loom` (the WebAssembly optimizer) and the
+other pulseengine components — plus the project URL and licence (Apache-2.0).
+
+It takes no arguments and makes no changes; it is the quick way to confirm
+which build you are running. Note that `--version` (the clap flag, e.g.
+`meld --version`) prints just the bare version string, whereas the `version`
+subcommand prints the fuller toolchain banner.

--- a/meld-cli/docs/concept-adapters.md
+++ b/meld-cli/docs/concept-adapters.md
@@ -1,0 +1,20 @@
+# Adapters — Canonical-ABI cross-component seams
+
+Two components that talk across an interface do not share a calling convention
+for free: the Component Model's Canonical ABI defines how high-level values
+(strings, lists, records, resources) are lowered into and lifted out of linear
+memory at each boundary. When component A imports what component B exports,
+meld synthesises an adapter — a small generated core function — that lifts the
+caller's arguments and lowers them into the callee's ABI, and does the inverse
+for results.
+
+Adapters are where meld does the real cross-component work: string transcoding
+between encodings, list and record marshalling, and resource-handle
+translation through per-resource handle tables. When both sides share the
+merged memory (a rebased single-memory fusion), same-memory transcoding can
+avoid a copy; when encodings differ the adapter still transcodes.
+
+Adapters are counted separately in `fuse --stats` (adapter functions), and in
+DWARF `remap` mode the code meld generates is attributed to synthetic
+`<meld-adapter>` source lines so a debugger does not mis-map it onto an input
+component's source.

--- a/meld-cli/docs/concept-address-rebasing.md
+++ b/meld-cli/docs/concept-address-rebasing.md
@@ -1,0 +1,19 @@
+# Address rebasing — one memory, no collisions
+
+When `--memory shared` merges several components into a single linear memory,
+their data segments would otherwise all start at their original offsets and
+overlap. Address rebasing (`--address-rebase`) relocates each component's data
+to a distinct base within the merged memory and rewrites the component's
+memory-referencing instructions — data-segment offsets, element-segment
+offsets, and the pointer constants folded into `i32.const` / extended-const
+initialisers — so every access lands at the component's new base.
+
+This is the MCU single-address-space story: instead of one memory per
+component, everything shares a flat address space, which is what a
+microcontroller runtime and a native linker expect.
+
+Rebasing is sound only when memory does not grow: a `memory.grow` would move a
+component's region out from under fixed offsets another component is still
+using. `--memory auto` therefore only chooses shared + rebase when no input
+carries `memory.grow`. Rebasing places each component at its declared page
+extent; the compact used-extent variant is `--pack-rebase` (see that topic).

--- a/meld-cli/docs/concept-attestation.md
+++ b/meld-cli/docs/concept-attestation.md
@@ -1,0 +1,18 @@
+# Attestation — a signed record of how the artifact was fused
+
+By default meld embeds an attestation in the fused module: a record of the
+fusion event — which components went in and how they were combined — carried in
+the output so a downstream consumer can tell where the artifact came from. It
+is on by default; `fuse --no-attestation` omits it.
+
+For supply-chain reproducibility, `fuse --reproducible` (issue #325) makes the
+artifact byte-for-byte deterministic: the attestation id is derived from the
+output content instead of a random UUID, and the timestamp is taken from
+`SOURCE_DATE_EPOCH` (default epoch 0) instead of the wall clock. Identical
+inputs and flags then yield an identical sha256, so a rebuild can be checked
+against a published digest.
+
+Attestation integrity is a governed property of meld (system requirement
+SYS-10): the record must faithfully describe the fusion, and the reproducible
+mode must actually reproduce. See also the `provenance` topic for the
+per-function mapping back to originating components.

--- a/meld-cli/docs/concept-fusion.md
+++ b/meld-cli/docs/concept-fusion.md
@@ -1,0 +1,18 @@
+# Static fusion — what meld does
+
+Meld fuses several WebAssembly components into a single core module ahead of
+time, so there is no runtime component linking. Where a host would normally
+instantiate each component and wire imports to exports at load time, meld
+resolves those cross-component edges statically: it merges the index spaces
+(types, functions, tables, globals, memories), internalises the imports that
+one input satisfies for another, and synthesises Canonical-ABI adapters where
+two components meet across an interface boundary.
+
+The result is one `.wasm` that a runtime can instantiate directly, with the
+cross-component calls already turned into ordinary in-module calls. This is
+what makes meld suitable for constrained targets (MCUs) and for cold-start-
+sensitive deployments: the linking cost is paid once, at build time, and the
+fused module carries an attestation describing how it was produced.
+
+Fusion is deterministic and fail-fast: identical inputs and flags yield the
+same output, and an unresolvable seam is an error, never a silent stub.

--- a/meld-cli/docs/concept-memory-strategies.md
+++ b/meld-cli/docs/concept-memory-strategies.md
@@ -1,0 +1,24 @@
+# Memory strategies — auto, multi, shared
+
+Each input component brings its own linear memory. When meld fuses them it must
+decide how those memories coexist in the output. `fuse --memory` selects the
+strategy (issue #172):
+
+- `auto` (default) — meld picks the sound single-memory form when it can:
+  shared memory with address rebasing whenever no input module contains
+  `memory.grow` and there are two or more memories to merge. The resulting
+  single-memory module flows straight through `wasm-opt` → `synth` with no
+  extra flags. When an input can grow memory, `auto` falls back to `multi`.
+
+- `multi` — keep one linear memory per input component. The fused module is a
+  multi-memory module; `wasm-opt` needs `--enable-multimemory` to consume it,
+  and there is no single-address-space (MCU) lowering for it.
+
+- `shared` — force one merged memory. Pair it with `--address-rebase` so each
+  component's data lands at a distinct, non-overlapping offset. This is
+  unsound if any input grows memory, because a grow would move data another
+  component is still addressing at a fixed offset.
+
+The single-memory (shared + rebase) form is the one that unlocks the MCU
+single-address-space story; see the `address-rebasing` and `pack-rebase`
+topics.

--- a/meld-cli/docs/concept-pack-rebase.md
+++ b/meld-cli/docs/concept-pack-rebase.md
@@ -1,0 +1,20 @@
+# Pack-rebase — the compact used-extent envelope
+
+`--pack-rebase` is a compact variant of address rebasing for single-address-
+space (MCU) targets. Plain `--address-rebase` reserves each component's full
+declared page count (a multiple of 64 KiB). `--pack-rebase` instead places each
+component at its actual used data extent — the end of its last data segment,
+rounded up to a 16-byte alignment — and sizes the merged memory to the packed
+total. Three thin drivers that would each claim a 64 KiB page fit in a few KiB.
+
+It implies `--address-rebase` and requires `--memory shared`. It is OPT-IN
+because it is sound only under a strict precondition: the component must
+reference no address above its last data segment. That means no separately-
+addressed `.bss`, no heap, and no computed pointers reaching past the packed
+extent. A component that has any of those must use `--address-rebase` (full
+page extent) instead — packing it would place another component's data inside
+the region it silently addresses beyond its segments.
+
+The safe envelope is the "used extent": everything the component actually
+touches lies at or below its last data segment. Pack within that envelope and
+the layout is dense and sound; exceed it and it is neither.

--- a/meld-cli/docs/concept-provenance.md
+++ b/meld-cli/docs/concept-provenance.md
@@ -1,0 +1,18 @@
+# Provenance — mapping fused functions back to their component
+
+Fusion collapses many components into one core module, which flattens every
+component's function index space into a single one. The `component-provenance`
+custom section (issue #192) records the inverse map: for each function index in
+the fused module, which component it came from and its function index there.
+
+Downstream consumers use it to project Component-Model invariants back onto
+fused-module locations. `pulseengine/scry`, for example, reads it to attribute
+a property or a finding in the fused binary to the original component and
+function, rather than to an opaque merged index.
+
+It is emitted by default; `fuse --no-component-provenance` disables it. The
+overhead is roughly 120 bytes per fused function, so disabling it is a size
+lever for artifacts that will never be analysed downstream. Provenance is
+distinct from the attestation (which records the fusion event as a whole) and
+from DWARF (which maps to source lines); it is the function-index-to-component
+map specifically.

--- a/meld-cli/src/docs.rs
+++ b/meld-cli/src/docs.rs
@@ -1,0 +1,218 @@
+//! Embedded, queryable documentation (SR-64) — modelled on `rivet docs` (and
+//! mirroring varve's REQ-DOCS-001).
+//!
+//! Topics are compiled INTO the binary (`include_str!`), so `meld docs` works
+//! with no files and no network — air-gapped by construction. `--format json`
+//! makes the same content machine-queryable (modelled on `rivet docs`).
+//! Coverage is a mechanical invariant: `meld docs check --coverage` enumerates
+//! the CLI's top-level subcommands and reports any without a topic; `--strict`
+//! exits non-zero, so an undocumented subcommand cannot ship (a gate, not
+//! review discipline).
+
+/// One documentation topic: a stable slug, a title, and a markdown body.
+pub struct Topic {
+    pub slug: &'static str,
+    pub title: &'static str,
+    pub body: &'static str,
+}
+
+macro_rules! topic {
+    ($slug:literal, $title:literal, $file:literal) => {
+        Topic {
+            slug: $slug,
+            title: $title,
+            body: include_str!(concat!("../docs/", $file)),
+        }
+    };
+}
+
+/// The embedded topic registry. Command topics use the exact clap subcommand
+/// name so the coverage check can match them mechanically.
+pub const TOPICS: &[Topic] = &[
+    // ── concepts ──────────────────────────────────────────────────────
+    topic!(
+        "fusion",
+        "Static fusion — what meld does",
+        "concept-fusion.md"
+    ),
+    topic!(
+        "memory-strategies",
+        "Memory strategies — auto, multi, shared",
+        "concept-memory-strategies.md"
+    ),
+    topic!(
+        "address-rebasing",
+        "Address rebasing — one memory, no collisions",
+        "concept-address-rebasing.md"
+    ),
+    topic!(
+        "pack-rebase",
+        "Pack-rebase — the compact used-extent envelope",
+        "concept-pack-rebase.md"
+    ),
+    topic!(
+        "adapters",
+        "Adapters — Canonical-ABI cross-component seams",
+        "concept-adapters.md"
+    ),
+    topic!(
+        "attestation",
+        "Attestation — a signed record of how the artifact was fused",
+        "concept-attestation.md"
+    ),
+    topic!(
+        "provenance",
+        "Provenance — mapping fused functions back to their component",
+        "concept-provenance.md"
+    ),
+    // ── one per CLI subcommand (slug == clap name) ────────────────────
+    topic!(
+        "fuse",
+        "fuse — fuse components into one core module",
+        "cmd-fuse.md"
+    ),
+    topic!(
+        "inspect",
+        "inspect — examine a WebAssembly component",
+        "cmd-inspect.md"
+    ),
+    topic!(
+        "version",
+        "version — show version and toolchain context",
+        "cmd-version.md"
+    ),
+    topic!("docs", "docs — this documentation", "cmd-docs.md"),
+];
+
+pub fn find(slug: &str) -> Option<&'static Topic> {
+    TOPICS.iter().find(|t| t.slug == slug)
+}
+
+/// Command names (clap subcommands) that have NO topic — the coverage gap.
+pub fn coverage_gaps(cmd: &clap::Command) -> Vec<String> {
+    cmd.get_subcommands()
+        .map(|c| c.get_name().to_string())
+        .filter(|name| find(name).is_none())
+        .collect()
+}
+
+/// Render the topic list (slug + title).
+pub fn render_list() -> String {
+    let mut out = String::from("meld docs — topics (meld docs <topic>):\n\n");
+    for t in TOPICS {
+        out.push_str(&format!("  {:<20} {}\n", t.slug, t.title));
+    }
+    out
+}
+
+/// Machine-readable JSON, modelled on `rivet docs --format json` so the docs
+/// can be queried by tooling, not just read. `None` → the topic list (slug +
+/// title per entry, no bodies); `Some(slug)` → that one topic with its full
+/// body (an empty `{}` if the slug is unknown, mirroring the human path).
+pub fn render_json(slug: Option<&str>) -> String {
+    match slug {
+        None => {
+            let list: Vec<_> = TOPICS
+                .iter()
+                .map(|t| serde_json::json!({"slug": t.slug, "title": t.title}))
+                .collect();
+            serde_json::to_string_pretty(&list).expect("topic list serialises")
+        }
+        Some(s) => match find(s) {
+            Some(t) => serde_json::to_string_pretty(
+                &serde_json::json!({"slug": t.slug, "title": t.title, "body": t.body}),
+            )
+            .expect("topic serialises"),
+            None => "{}".to_string(),
+        },
+    }
+}
+
+/// grep across all topic bodies + titles; returns (slug, matching line).
+pub fn grep(query: &str) -> Vec<(&'static str, String)> {
+    let q = query.to_lowercase();
+    let mut hits = Vec::new();
+    for t in TOPICS {
+        if t.title.to_lowercase().contains(&q) {
+            hits.push((t.slug, t.title.to_string()));
+        }
+        for line in t.body.lines() {
+            if line.to_lowercase().contains(&q) {
+                hits.push((t.slug, line.trim().to_string()));
+            }
+        }
+    }
+    hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // rivet: verifies SR-64
+    #[test]
+    fn every_cli_subcommand_has_a_documented_topic() {
+        use clap::CommandFactory;
+        let cmd = crate::Cli::command();
+        let gaps = coverage_gaps(&cmd);
+        assert!(
+            gaps.is_empty(),
+            "these subcommands have no `meld docs` topic (SR-64): {gaps:?}"
+        );
+    }
+
+    // rivet: verifies SR-64
+    #[test]
+    fn topics_are_findable_and_greppable() {
+        assert!(find("fusion").is_some());
+        assert!(find("fuse").is_some());
+        assert!(find("nonexistent").is_none());
+        // A concept every topic set should mention.
+        assert!(
+            !grep("memory").is_empty(),
+            "grep should find 'memory' somewhere"
+        );
+    }
+
+    // rivet: verifies SR-64
+    #[test]
+    fn topic_list_renders_as_machine_readable_json() {
+        let v: serde_json::Value = serde_json::from_str(&render_json(None)).unwrap();
+        let arr = v.as_array().expect("--format json list is a JSON array");
+        assert_eq!(arr.len(), TOPICS.len());
+        // Every entry carries slug + title; the list form omits the body.
+        let first = &arr[0];
+        assert!(first.get("slug").and_then(|s| s.as_str()).is_some());
+        assert!(first.get("title").and_then(|s| s.as_str()).is_some());
+        assert!(first.get("body").is_none(), "list form omits bodies");
+    }
+
+    // rivet: verifies SR-64
+    #[test]
+    fn single_topic_renders_as_json_with_body() {
+        let v: serde_json::Value = serde_json::from_str(&render_json(Some("fusion"))).unwrap();
+        assert_eq!(v.get("slug").and_then(|s| s.as_str()), Some("fusion"));
+        assert!(
+            v.get("body").and_then(|s| s.as_str()).unwrap().len() > 40,
+            "single-topic JSON carries the full body"
+        );
+    }
+
+    // rivet: verifies SR-64
+    #[test]
+    fn unknown_topic_json_is_empty_object() {
+        assert_eq!(render_json(Some("nonexistent")), "{}");
+    }
+
+    // rivet: verifies SR-64
+    #[test]
+    fn no_topic_body_is_empty() {
+        for t in TOPICS {
+            assert!(
+                t.body.trim().len() > 40,
+                "topic {} is too short to be real documentation",
+                t.slug
+            );
+        }
+    }
+}

--- a/meld-cli/src/main.rs
+++ b/meld-cli/src/main.rs
@@ -23,6 +23,8 @@ use std::fs;
 use std::path::Path;
 use std::time::Instant;
 
+mod docs;
+
 #[derive(Parser)]
 #[command(name = "meld")]
 #[command(author = "PulseEngine")]
@@ -162,6 +164,39 @@ enum Commands {
 
     /// Show version information
     Version,
+
+    /// Show embedded, queryable documentation (offline).
+    ///
+    /// `meld docs` lists topics; `meld docs <topic>` shows one;
+    /// `meld docs --grep <q>` searches all topics; `--format json` emits the
+    /// list (or a single topic, with its body) for machine queries.
+    /// `meld docs check --coverage` reports subcommands without a topic
+    /// (`--strict` exits non-zero — the CI gate).
+    Docs {
+        /// A topic slug to show, or `check` to run the coverage invariant.
+        topic: Option<String>,
+
+        /// List all topics (the default when no topic is given).
+        #[arg(long)]
+        list: bool,
+
+        /// Search across all topic titles and bodies.
+        #[arg(long, value_name = "QUERY")]
+        grep: Option<String>,
+
+        /// (check) Report subcommands lacking a documented topic.
+        #[arg(long)]
+        coverage: bool,
+
+        /// (check --coverage) Exit non-zero if any subcommand is undocumented.
+        #[arg(long)]
+        strict: bool,
+
+        /// Output format: `text` (default) or `json` for machine queries —
+        /// applies to the topic list and to a single `meld docs <topic>`.
+        #[arg(long, value_name = "FMT", default_value = "text")]
+        format: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -231,6 +266,24 @@ fn main() -> Result<()> {
             println!("License: Apache-2.0");
         }
 
+        Some(Commands::Docs {
+            topic,
+            list,
+            grep,
+            coverage,
+            strict,
+            format,
+        }) => {
+            docs_command(
+                topic.as_deref(),
+                list,
+                grep.as_deref(),
+                coverage,
+                strict,
+                &format,
+            )?;
+        }
+
         None => {
             println!("meld - Static WebAssembly Component Fusion");
             println!();
@@ -240,6 +293,7 @@ fn main() -> Result<()> {
             println!("  fuse      Fuse multiple components into a single module");
             println!("  inspect   Inspect a WebAssembly component");
             println!("  version   Show version information");
+            println!("  docs      Show embedded, queryable documentation");
             println!("  help      Print this message or help for subcommands");
             println!();
             println!("For more information, run: meld help <command>");
@@ -612,6 +666,84 @@ fn inspect_command(input: String, show_types: bool, show_interfaces: bool) -> Re
         }
     }
 
+    Ok(())
+}
+
+/// `meld docs` — embedded, queryable documentation (SR-64), modelled on
+/// `rivet docs`. Lists/show/grep topics, `--format json` for machine queries,
+/// and `check --coverage` (`--strict` gate) for the coverage invariant.
+fn docs_command(
+    topic: Option<&str>,
+    list: bool,
+    grep: Option<&str>,
+    coverage: bool,
+    strict: bool,
+    format: &str,
+) -> Result<()> {
+    use clap::CommandFactory;
+
+    let json = match format {
+        "text" => false,
+        "json" => true,
+        other => {
+            return Err(anyhow!(
+                "unknown --format '{other}' (expected `text` or `json`)"
+            ));
+        }
+    };
+
+    // `meld docs check --coverage` (or `--coverage`) — the mechanical invariant.
+    if coverage || topic == Some("check") {
+        let cmd = Cli::command();
+        let total = cmd.get_subcommands().count();
+        let gaps = docs::coverage_gaps(&cmd);
+        if gaps.is_empty() {
+            println!("docs coverage: OK — all {total} subcommands have a topic");
+            return Ok(());
+        }
+        eprintln!("docs coverage: {} subcommand(s) undocumented:", gaps.len());
+        for g in &gaps {
+            eprintln!("  {g}");
+        }
+        if strict {
+            return Err(anyhow!(
+                "undocumented subcommands (SR-64): {}",
+                gaps.join(", ")
+            ));
+        }
+        return Ok(());
+    }
+
+    if let Some(q) = grep {
+        let hits = docs::grep(q);
+        if hits.is_empty() {
+            println!("no topic matches '{q}'");
+        }
+        for (slug, line) in hits {
+            println!("{slug}: {line}");
+        }
+        return Ok(());
+    }
+
+    if list || topic.is_none() {
+        if json {
+            println!("{}", docs::render_json(None));
+        } else {
+            print!("{}", docs::render_list());
+        }
+        return Ok(());
+    }
+
+    let slug = topic.unwrap();
+    match docs::find(slug) {
+        Some(_) if json => println!("{}", docs::render_json(Some(slug))),
+        Some(t) => println!("{}", t.body.trim_end()),
+        None => {
+            eprintln!("no topic '{slug}'.\n");
+            print!("{}", docs::render_list());
+            return Err(anyhow!("unknown topic: {slug}"));
+        }
+    }
     Ok(())
 }
 

--- a/meld-core/src/merger.rs
+++ b/meld-core/src/merger.rs
@@ -635,7 +635,7 @@ impl Merger {
                 if self.address_rebasing {
                     if let Some(module_memory) = module_memory_type(module)? {
                         let extent = if self.pack_rebase {
-                            module_used_data_extent(module)?
+                            module_used_data_extent(module, &module_memory, comp_idx, mod_idx)?
                         } else {
                             None
                         };
@@ -3109,26 +3109,86 @@ fn component_display_name(components: &[ParsedComponent], comp_idx: usize) -> St
 /// legitimate bulk-only case, `test_address_rebasing_end_to_end`). Note this
 /// residual gap does NOT affect the supported path: `--emit-relocs` inputs
 /// carry reloc metadata, so their address consts are rebased via `reloc.CODE`.
-/// SR-57 / #370: the module's used data extent — the maximum end offset
-/// (`offset + len`) across its ACTIVE data segments, for compact `--pack-rebase`
-/// placement. Returns `None` (module cannot be safely packed → caller strides
-/// by the declared page count) when any of:
-///   - an active segment has a non-constant (runtime/global) offset,
-///   - the module carries any PASSIVE segment, or
-///   - the computed extent is 0 (no static data to pack against).
+/// SR-57 / #370: the module's used STATIC extent — the highest linear-memory
+/// address it uses — for compact `--pack-rebase` placement. Returns `Some(top)`
+/// when a sound compact extent is known; otherwise `None`, and the caller
+/// strides by the declared page count (page-granular). The page-granular stride
+/// is a safe reservation ONLY for a DEFINED memory (nothing can be accessed
+/// beyond `initial` pages without `memory.grow`, which the rebase path forbids);
+/// for an IMPORTED memory `initial` is only a floor, so the imported case is
+/// handled explicitly below and NEVER strides below the visible extent.
 ///
-/// This is only called for modules that HAVE a memory (see the caller), so a
-/// zero extent means "has a memory but no static initialized data" — its real
-/// usage (a `.bss`/heap region, or reloc-flagged static access above offset 0
-/// as in the #326 harness) is invisible to a data-segment scan. Packing it by
-/// extent 0 would produce a stride of `align16(0) = 0`, so `next_base` would
-/// not advance and every such module would alias at the same base (CI Mythos
-/// SR-57 finding). A passive segment has the same invisibility: it is placed at
-/// runtime by `memory.init`, whose destination is not in the segment table.
-/// SR-56's overlap check is active-only, so it does not backstop either case.
-/// All are supported placements under `--address-rebase`, so fall back to
-/// page-granular rather than silently corrupt.
-fn module_used_data_extent(module: &CoreModule) -> Result<Option<u64>> {
+/// ## Why a data-segment scan alone is not enough (#370)
+///
+/// The v0.43.0 implementation returned the maximum end (`offset + len`) across
+/// ACTIVE data segments, `D`. That is UNSOUND whenever a module uses memory
+/// above `D`: a zero-init `.bss`/arena region (relay#327 replaces a growing
+/// allocator with a bounded static arena that lives in `.bss`, NOT a data
+/// segment), a heap reached through a runtime bump pointer, a shadow stack, or
+/// a computed/MMIO address. None of those appear in the segment table, so
+/// packing by `D` UNDER-reserves the tail `[D, declared)` and the next packed
+/// component overlaps it. SR-56's overlap check is ACTIVE-data-only, so it does
+/// NOT catch a `.bss` collision — the result is silent corruption. Measured on
+/// the real target (falcon-v1.133.0): 17 declared pages, active-data extent
+/// `D ≈ 1048672`, declared `P = 1114112` — a 65440-byte tail invisible to `D`.
+///
+/// ## The sound rule
+///
+/// Reclaiming the tail `[D, declared)` is sound only when the module publishes
+/// an authoritative "top of used static memory" marker — an immutable-const
+/// `__heap_base` global (exported, or named in the `name` section). Everything
+/// above `__heap_base` is unused under the `--pack-rebase` contract (grow
+/// killed; any arena lives below it in `.bss`). With the marker we reserve
+/// `max(__heap_base, D)`, clamped down to `declared` only for a DEFINED memory
+/// (for an imported memory `declared` is a floor, so clamping would
+/// under-reserve). WITHOUT the marker we do NOT guess — fall back to the
+/// page-granular declared stride (`None`) and warn, EXCEPT when the visible data
+/// already exceeds `declared` (only possible for an imported memory), where
+/// page-granular would under-reserve, so we reserve `D` and warn. The
+/// `__heap_base` symbol is NOT present in default toolchain output (verified:
+/// absent from all six falcon exports, from the `--emit-relocs` linking symbol
+/// table, and from the `name` section — only `__stack_pointer` is named), so
+/// enabling compaction is a supplier precondition: build with
+/// `-Wl,--export=__heap_base`.
+///
+/// The invariant every branch preserves: the reservation is always `>= D`, and
+/// `declared` may only LOWER it for a DEFINED memory.
+///
+/// Returns `None` (page-granular) BEFORE the marker lookup — a `__heap_base`
+/// marker does NOT rescue these, their used region is invisible no matter what
+/// the marker says — when:
+///   - an active segment has a non-constant (runtime/global) offset, or
+///   - the module carries any PASSIVE segment (its `memory.init` destination is
+///     not in the segment table).
+///
+/// A module with a memory but no static data (`D == 0`) and no marker also
+/// declines (page-granular avoids the `align16(0) = 0` alias, CI Mythos SR-57
+/// finding) — but here a marker DOES rescue it (its `.bss` top is authoritative).
+fn module_used_data_extent(
+    module: &CoreModule,
+    memory: &MemoryType,
+    comp_idx: usize,
+    mod_idx: usize,
+) -> Result<Option<u64>> {
+    // `declared` = `initial` pages in bytes. Its meaning depends on whether the
+    // memory is DEFINED here or IMPORTED (LS-M-?? / coordinator delta-pass):
+    //   * DEFINED memory: `initial` is a true CAP — a valid module cannot
+    //     address (or place active data) beyond it without `memory.grow`, which
+    //     the rebase path forbids. `declared` may lower the extent.
+    //   * IMPORTED memory: `initial` is only the declared MINIMUM the module
+    //     needs; a dylink/PIC dylib legally imports `(memory 1 8)` and addresses
+    //     far above page 1. `declared` is a FLOOR, NOT a cap, and must NEVER
+    //     lower the extent.
+    // The hard invariant enforced below in EVERY branch: the returned extent
+    // (or the page-granular `None` stride) is always `>= max_end`, and
+    // `declared` may only lower the extent for a DEFINED memory.
+    let defined_memory = !module.memories.is_empty();
+    let Some(declared) = memory.initial.checked_mul(WASM_PAGE_SIZE) else {
+        return Ok(None);
+    };
+
+    // Active-data-segment extent `max_end` (constant offsets only). A passive or
+    // non-constant-offset segment makes the used region invisible → decline.
     let segments = crate::segments::parse_data_segments(module)?;
     let mut max_end: u64 = 0;
     for seg in &segments {
@@ -3144,10 +3204,132 @@ fn module_used_data_extent(module: &CoreModule) -> Result<Option<u64>> {
             crate::segments::DataSegmentMode_::Passive => return Ok(None),
         }
     }
-    if max_end == 0 {
-        return Ok(None);
+
+    // Compaction below `declared` is sound only with an authoritative marker.
+    match module_heap_base_marker(module) {
+        Some(heap_base) => {
+            // Marker present: the authoritative top of used static memory.
+            // Never below the visible data (`max_end`) — the hard invariant.
+            let mut extent = heap_base.max(max_end);
+            // Clamp DOWN to `declared` only for a DEFINED memory, where it is a
+            // real cap (a stale/oversized marker must not stride past the
+            // module's own memory). For an IMPORTED memory `declared` is a floor,
+            // so clamping would under-reserve — do NOT clamp (regression the
+            // delta-pass caught: `.min(declared)` shrank a legit extent).
+            if defined_memory {
+                extent = extent.min(declared);
+            }
+            if extent == 0 {
+                // Degenerate (no data, marker at 0): nothing to reserve; let the
+                // caller stride page-granular rather than alias at base 0.
+                return Ok(None);
+            }
+            Ok(Some(extent))
+        }
+        None if max_end == 0 => {
+            // Memory but no static data and no marker: real usage (a `.bss`/heap
+            // region, or reloc-flagged above-zero access as in the #326 harness)
+            // is invisible to a segment scan. Page-granular keeps the reservation
+            // >= anything within `declared` and avoids the `align16(0) = 0` alias.
+            Ok(None)
+        }
+        None if max_end > declared => {
+            // No marker AND the visible data already exceeds `declared` — only
+            // possible for an IMPORTED memory (a defined memory's active data
+            // cannot exceed its own `initial`). The page-granular `declared`
+            // stride would UNDER-reserve the visible data (the regression), so we
+            // reserve at least `max_end`. Loud: an invisible arena ABOVE max_end
+            // still can't be seen without a marker.
+            log::warn!(
+                "--pack-rebase: component {comp_idx} module {mod_idx} imports a memory whose \
+                 declared minimum is {declared} bytes but has static data up to {max_end} and no \
+                 immutable-const `__heap_base` marker; reserving {max_end} bytes (the visible \
+                 extent) — any arena above it is invisible. Build the input with \
+                 `-Wl,--export=__heap_base` to reserve the true static top."
+            );
+            Ok(Some(max_end))
+        }
+        None => {
+            // `max_end <= declared`: the page-granular `declared` stride is a
+            // sound reservation (>= max_end). Warn only when we are declining a
+            // requested compaction (there is slack we cannot prove unused).
+            if max_end < declared {
+                // LOUD, never silent under-reserve (#370): the module declares
+                // more memory than its visible static data and gives no
+                // __heap_base marker, so its tail may hold a `.bss`/arena we
+                // cannot see. Pack conservatively (page-granular) rather than
+                // risk a collision SR-56 cannot catch.
+                log::warn!(
+                    "--pack-rebase: component {comp_idx} module {mod_idx} declares {declared} \
+                     bytes of memory but only {max_end} are visible as static data, and it \
+                     publishes no immutable-const `__heap_base` marker; packing to the declared \
+                     page stride (no compaction) to avoid under-reserving a possible .bss/arena. \
+                     Build the input with `-Wl,--export=__heap_base` to enable compaction."
+                );
+            }
+            Ok(None)
+        }
     }
-    Ok(Some(max_end))
+}
+
+/// Discover a module's `__heap_base` marker — the immutable-const linear-memory
+/// address that is the top of its used static data (data + `.bss`). Returns the
+/// address when a defined, immutable `i32` global named `__heap_base` (via the
+/// export table or the `name` section) initialises to a single `i32.const`.
+///
+/// This is the ONLY signal that lets `--pack-rebase` compact below the declared
+/// page count soundly (see [`module_used_data_extent`]). `__data_end` is
+/// deliberately NOT accepted: in the default wasm-ld layout the shadow stack can
+/// sit ABOVE `__data_end` (measured: `__data_end = 5136`, `__heap_base = 70672`,
+/// a 64 KiB stack between), so packing to `__data_end` would under-reserve the
+/// stack. `__heap_base` is the true top of static usage.
+fn module_heap_base_marker(module: &CoreModule) -> Option<u64> {
+    const MARKER: &str = "__heap_base";
+    let import_globals = module
+        .imports
+        .iter()
+        .filter(|i| matches!(i.kind, ImportKind::Global(_)))
+        .count() as u32;
+
+    // Prefer the export table (what a supplier controls via --export=__heap_base
+    // and what survives `wasm-tools component new`); fall back to the name
+    // section's global-name subsection.
+    let global_index = module
+        .exports
+        .iter()
+        .find(|e| matches!(e.kind, ExportKind::Global) && e.name == MARKER)
+        .map(|e| e.index)
+        .or_else(|| module_named_global_index(module, MARKER))?;
+
+    // Only a DEFINED global carries a readable initialiser (imported globals do
+    // not). Must be an immutable `i32` initialised to a single `i32.const`.
+    if global_index < import_globals {
+        return None;
+    }
+    let defined = (global_index - import_globals) as usize;
+    let g = module.globals.get(defined)?;
+    if g.mutable || g.content_type != ValType::I32 {
+        return None;
+    }
+    crate::segments::const_i32_init_value(&g.init_expr_bytes).map(|v| u64::from(v as u32))
+}
+
+/// Absolute index of the global named `name` in the module's `name` section
+/// global-name subsection, if present.
+fn module_named_global_index(module: &CoreModule, name: &str) -> Option<u32> {
+    let (_, data) = module.custom_sections.iter().find(|(n, _)| n == "name")?;
+    let reader = wasmparser::NameSectionReader::new(wasmparser::BinaryReader::new(data, 0));
+    for subsection in reader {
+        if let Ok(wasmparser::Name::Global(namemap)) = subsection {
+            for naming in namemap {
+                let Ok(naming) = naming else { continue };
+                if naming.name == name {
+                    return Some(naming.index);
+                }
+            }
+        }
+    }
+    None
 }
 
 fn module_has_direct_memory_access(module: &CoreModule) -> Result<bool> {

--- a/meld-core/tests/pack_rebase_370.rs
+++ b/meld-core/tests/pack_rebase_370.rs
@@ -17,11 +17,15 @@
 
 use meld_core::{Fuser, FuserConfig, MemoryStrategy};
 use wasm_encoder::{
-    CodeSection, Component, CustomSection, DataCountSection, DataSection, DataSegment,
-    DataSegmentMode, ExportKind, ExportSection, Function, FunctionSection, Instruction, MemArg,
-    MemorySection, MemoryType, Module, ModuleSection, TypeSection, ValType,
+    CodeSection, Component, ConstExpr, CustomSection, DataCountSection, DataSection, DataSegment,
+    DataSegmentMode, EntityType, ExportKind, ExportSection, Function, FunctionSection,
+    GlobalSection, GlobalType, ImportSection, Instruction, MemArg, MemorySection, MemoryType,
+    Module, ModuleSection, TypeSection, ValType,
 };
-use wasmtime::{Config, Engine, Instance, Module as RuntimeModule, Store};
+use wasmtime::{
+    Config, Engine, Instance, Linker, MemoryType as RuntimeMemoryType, Module as RuntimeModule,
+    SharedMemory, Store,
+};
 
 /// Absolute address of each component's 1-byte sentinel data segment. Well
 /// above 0 so a min_start bug reads wrong rather than passing by luck.
@@ -116,8 +120,23 @@ fn build_pack_component(tag: &str, sentinel: u8, export_memory: bool) -> Vec<u8>
         let mut functions = FunctionSection::new();
         functions.function(0);
 
+        // Immutable-const `__heap_base` marker = top of static data ([DATA_ADDR,
+        // DATA_ADDR+1) → DATA_ADDR+1). SR-57 compacts below the declared page
+        // count ONLY with this marker (a supplier's `-Wl,--export=__heap_base`);
+        // without it the module packs page-granular. #370.
+        let mut globals = GlobalSection::new();
+        globals.global(
+            GlobalType {
+                val_type: ValType::I32,
+                mutable: false,
+                shared: false,
+            },
+            &ConstExpr::i32_const(DATA_ADDR + 1),
+        );
+
         let mut exports = ExportSection::new();
         exports.export(&format!("read_{tag}"), ExportKind::Func, 0);
+        exports.export("__heap_base", ExportKind::Global, 0);
         if export_memory {
             exports.export("memory", ExportKind::Memory, 0);
         }
@@ -133,7 +152,7 @@ fn build_pack_component(tag: &str, sentinel: u8, export_memory: bool) -> Vec<u8>
         data.segment(DataSegment {
             mode: DataSegmentMode::Active {
                 memory_index: 0,
-                offset: &wasm_encoder::ConstExpr::i32_const(DATA_ADDR),
+                offset: &ConstExpr::i32_const(DATA_ADDR),
             },
             data: [sentinel],
         });
@@ -142,6 +161,7 @@ fn build_pack_component(tag: &str, sentinel: u8, export_memory: bool) -> Vec<u8>
             .section(&types)
             .section(&functions)
             .section(&shared_memory_section())
+            .section(&globals)
             .section(&exports)
             .section(&code)
             .section(&data);
@@ -512,4 +532,495 @@ fn pack_rebase_nodata_module_does_not_alias() {
             "{load} must read its own value {want:#x}, got {got:#x} — no-data modules aliased at base 0"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// #370 (escalated): a `.bss`/arena region ABOVE the last data segment.
+//
+// A component seeds a tiny 1-byte data segment at `DATA_ADDR` (so its
+// active-data extent D ≈ DATA_ADDR+1 is SMALL) but its real working set is a
+// zero-init arena at `ARENA_ADDR` (well above D) that it `memory.fill`s with its
+// own sentinel and reads back near the top — exactly relay#327's shape (a
+// growing allocator replaced by a bounded static arena that lives in `.bss`,
+// invisible to a data-segment scan).
+//
+// v0.43.0 packed by D, UNDER-reserving the arena: three components strided ~272
+// bytes apart while each uses [ARENA_ADDR, ARENA_ADDR+ARENA_LEN) ≈ 6 KiB, so the
+// arenas overlap and the last writer wins — a component reads a NEIGHBOUR's
+// sentinel. SR-56 is active-data-only and cannot catch this. Before the #370
+// extent fix, `read_a` returned 0xC3 (C's fill, the last writer over the
+// overlap) instead of 0xA1.
+//
+// The fix makes compaction below the declared page count require an
+// authoritative `__heap_base` marker:
+//   * NO marker  → page-granular fallback (safe: each arena in its own page).
+//   * marker present → compact to clamp(__heap_base, D..=declared), which
+//     reserves the whole arena, so arenas stay disjoint AND the reservation
+//     still shrinks below page-granular.
+
+/// 1-byte data segment address — makes the visible active-data extent small.
+const ARENA_DATA_ADDR: i32 = 0x100;
+/// Zero-init arena base, far above the data extent (a `.bss` region).
+const ARENA_ADDR: i32 = 0x1000;
+/// Arena length in bytes (6 KiB > 1 page/16 would be too big; keep it inside a
+/// page so page-granular still isolates it, but far larger than the ~272-byte
+/// data stride so an under-reservation overlaps).
+const ARENA_LEN: i32 = 0x1800;
+
+/// Build an arena component. `marker` = `Some(top)` exports an immutable-const
+/// `__heap_base` global (the supplier signal that enables compaction); `None`
+/// omits it (forcing the safe page-granular fallback).
+fn build_arena_component(
+    tag: &str,
+    sentinel: u8,
+    export_memory: bool,
+    marker: Option<i32>,
+) -> Vec<u8> {
+    let read_memarg = MemArg {
+        offset: (ARENA_LEN - 1) as u64, // read the TOP byte of the arena
+        align: 0,
+        memory_index: 0,
+    };
+
+    let add_sections = |module: &mut Module| {
+        let mut types = TypeSection::new();
+        types.ty().function([], []); // type 0: fill: () -> ()
+        types.ty().function([], [ValType::I32]); // type 1: read: () -> i32
+
+        let mut functions = FunctionSection::new();
+        functions.function(0);
+        functions.function(1);
+
+        let mut globals = GlobalSection::new();
+        if let Some(top) = marker {
+            globals.global(
+                GlobalType {
+                    val_type: ValType::I32,
+                    mutable: false,
+                    shared: false,
+                },
+                &ConstExpr::i32_const(top),
+            );
+        }
+
+        let mut exports = ExportSection::new();
+        exports.export(&format!("fill_{tag}"), ExportKind::Func, 0);
+        exports.export(&format!("read_{tag}"), ExportKind::Func, 1);
+        if marker.is_some() {
+            exports.export("__heap_base", ExportKind::Global, 0);
+        }
+        if export_memory {
+            exports.export("memory", ExportKind::Memory, 0);
+        }
+
+        let mut code = CodeSection::new();
+        // fill: memory.fill(dst = ARENA_ADDR, val = sentinel, len = ARENA_LEN)
+        let mut fill = Function::new([]);
+        fill.instruction(&Instruction::I32Const(ARENA_ADDR)); // dst (reloc-flagged)
+        fill.instruction(&Instruction::I32Const(i32::from(sentinel)));
+        fill.instruction(&Instruction::I32Const(ARENA_LEN));
+        fill.instruction(&Instruction::MemoryFill(0));
+        fill.instruction(&Instruction::End);
+        code.function(&fill);
+        // read: load8_u the TOP byte of the arena (ARENA_ADDR + ARENA_LEN-1)
+        let mut read = Function::new([]);
+        read.instruction(&Instruction::I32Const(ARENA_ADDR)); // base (reloc-flagged)
+        read.instruction(&Instruction::I32Load8U(read_memarg));
+        read.instruction(&Instruction::End);
+        code.function(&read);
+
+        // Tiny active data segment → gives a SMALL visible extent D. The module
+        // never reads it; it exists only to reproduce "has data, but uses memory
+        // above it". Its offset is rebased structurally (not via reloc.CODE).
+        let mut data = DataSection::new();
+        data.segment(DataSegment {
+            mode: DataSegmentMode::Active {
+                memory_index: 0,
+                offset: &ConstExpr::i32_const(ARENA_DATA_ADDR),
+            },
+            data: [sentinel],
+        });
+
+        module.section(&types).section(&functions).section(&{
+            let mut m = MemorySection::new();
+            // Declare 1 page so the arena (< 1 page) fits; page-granular strides
+            // by this. (Shared: matches the other fixtures / wasmtime config.)
+            m.memory(MemoryType {
+                minimum: 1,
+                maximum: Some(4),
+                memory64: false,
+                shared: true,
+                page_size_log2: None,
+            });
+            m
+        });
+        module
+            .section(&globals)
+            .section(&exports)
+            .section(&DataCountSection { count: 1 })
+            .section(&code)
+            .section(&data);
+    };
+
+    // Locate the two `i32.const ARENA_ADDR` literals (fill dst + read base) and
+    // flag them as MEMORY_ADDR reloc sites so meld rebases them.
+    let mut dry = Module::new();
+    add_sections(&mut dry);
+    let offsets = find_i32const_reloc_offsets(&dry.finish(), ARENA_ADDR);
+    assert_eq!(offsets.len(), 2, "fill dst + read base are the reloc sites");
+    let reloc_code = build_reloc_code_body(&offsets);
+
+    let mut module = Module::new();
+    add_sections(&mut module);
+    module.section(&CustomSection {
+        name: "linking".into(),
+        data: vec![0x02].into(),
+    });
+    module.section(&CustomSection {
+        name: "reloc.CODE".into(),
+        data: reloc_code.into(),
+    });
+
+    let mut component = Component::new();
+    component.section(&ModuleSection(&module));
+    component.finish()
+}
+
+fn fuse_arena(a: &[u8], b: &[u8], c: &[u8]) -> Vec<u8> {
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::SharedMemory,
+        pack_rebase: true,
+        ..Default::default()
+    };
+    let mut fuser = Fuser::new(config);
+    fuser.add_component_named(a, Some("comp-a")).unwrap();
+    fuser.add_component_named(b, Some("comp-b")).unwrap();
+    fuser.add_component_named(c, Some("comp-c")).unwrap();
+    fuser.fuse().expect("fusion")
+}
+
+fn run_arena(fused: &[u8]) {
+    let mut engine_config = Config::new();
+    engine_config.wasm_threads(true);
+    engine_config.shared_memory(true);
+    engine_config.wasm_bulk_memory(true);
+    let engine = Engine::new(&engine_config).unwrap();
+    let module = RuntimeModule::new(&engine, fused).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).unwrap();
+
+    // Every component fills its arena (order A,B,C — the last writer wins on any
+    // overlap), THEN every component reads back the top byte of its OWN arena.
+    for fill in ["fill_a", "fill_b", "fill_c"] {
+        instance
+            .get_typed_func::<(), ()>(&mut store, fill)
+            .unwrap_or_else(|e| panic!("export {fill}: {e}"))
+            .call(&mut store, ())
+            .unwrap();
+    }
+    for (read, want) in [("read_a", 0xA1), ("read_b", 0xB2), ("read_c", 0xC3)] {
+        let got = instance
+            .get_typed_func::<(), i32>(&mut store, read)
+            .unwrap_or_else(|e| panic!("export {read}: {e}"))
+            .call(&mut store, ())
+            .unwrap();
+        assert_eq!(
+            got, want,
+            "{read} must read its OWN arena sentinel {want:#x}, got {got:#x} — the arena above \
+             the data extent was under-reserved and a neighbour's fill clobbered it (#370)"
+        );
+    }
+}
+
+/// RED→GREEN: arena components with NO `__heap_base` marker. Before the #370
+/// extent fix, packing by the small data extent under-reserved the arena and a
+/// neighbour clobbered it. The fix declines to compact without a marker and
+/// falls back to the page-granular stride, keeping the arenas disjoint.
+#[test]
+fn pack_rebase_bss_arena_without_marker_falls_back_no_clobber() {
+    let a = build_arena_component("a", 0xA1, true, None);
+    let b = build_arena_component("b", 0xB2, false, None);
+    let c = build_arena_component("c", 0xC3, false, None);
+    let fused = fuse_arena(&a, &b, &c);
+
+    // Safe fallback: three 1-page components stride page-granular (3 pages), NOT
+    // compacted — the honest, sound behaviour absent a marker.
+    assert_eq!(
+        fused_memory_min_pages(&fused),
+        3,
+        "no __heap_base marker → page-granular fallback (no compaction)"
+    );
+    run_arena(&fused);
+}
+
+/// GREEN + compaction: the SAME arena components, now each exporting an
+/// immutable-const `__heap_base = ARENA_ADDR + ARENA_LEN` marker (the top of the
+/// arena). The fix compacts to that extent — arenas stay disjoint AND the
+/// reservation shrinks below the page-granular 3 pages.
+#[test]
+fn pack_rebase_bss_arena_with_marker_compacts_no_clobber() {
+    let top = ARENA_ADDR + ARENA_LEN;
+    let a = build_arena_component("a", 0xA1, true, Some(top));
+    let b = build_arena_component("b", 0xB2, false, Some(top));
+    let c = build_arena_component("c", 0xC3, false, Some(top));
+    let fused = fuse_arena(&a, &b, &c);
+
+    let packed = fused_memory_min_pages(&fused);
+    eprintln!(
+        "SR-57 arena: marker-compacted memory minimum = {packed} page(s) (page-granular = 3)"
+    );
+    assert!(
+        packed < 3,
+        "with __heap_base the arena packs below page-granular (got {packed} pages)"
+    );
+    run_arena(&fused);
+}
+
+// ---------------------------------------------------------------------------
+// #370 delta-pass regression: IMPORTED memory, where `initial` is a FLOOR, not
+// a cap.
+//
+// A dylink/PIC dylib legally imports `(memory 1 8)` and addresses far above
+// page 1, so `max_end` (its visible static extent) can EXCEED `initial*PAGE`.
+// The first #370 fix treated `declared = initial*PAGE` as an upper bound in
+// both branches:
+//   * marker branch clamped `heap_base.max(max_end).min(declared)` — shrinking a
+//     legit extent DOWN to `declared`;
+//   * no-marker branch guarded `if max_end < declared` — false when
+//     `max_end >= declared`, so it silently returned `None` → page-granular
+//     stride `= declared`.
+// Both UNDER-reserve for an imported memory, re-opening the exact silent
+// cross-component corruption SR-56 cannot catch. The delta-pass confirmed it at
+// runtime (`read_a == 0xB2`). The corrected rule: the reservation is always
+// `>= max_end`, and `declared` may only lower it for a DEFINED memory.
+//
+// These modules import `(memory 1 8 shared)` (declared floor = 65536) but their
+// static data reaches `IMP_ARENA_TOP = 98560 > 65536`, and each `memory.fill`s
+// a working-set range that OVERLAPS a neighbour's under the (buggy) 65536
+// stride, so a neighbour's fill clobbers the readback. The fused module imports
+// its memory, provisioned at runtime via a `Linker`.
+
+const IMP_MEM_MIN_PAGES: u64 = 1; // declared floor = 65536 bytes
+const IMP_MEM_MAX_PAGES: u64 = 8;
+/// Top of static data (a 1-byte segment sits just below it) — ABOVE the 1-page
+/// declared floor, the shape only an imported memory can legally present.
+const IMP_ARENA_TOP: i32 = 0x18100; // 98560
+/// `memory.fill` destination (base of the working-set range).
+const IMP_FILL_BASE: i32 = 0x100; // 256
+/// Readback address, chosen inside the neighbour-overlap zone under the buggy
+/// 65536 stride (>= 65536 above the fill base) but in the component's OWN range
+/// under the correct 98560 stride.
+const IMP_READ_ADDR: i32 = IMP_FILL_BASE + 80000; // 80256
+
+/// Build a component whose core module IMPORTS `(memory 1 8 shared)` from
+/// `env/memory`, seeds a 1-byte data segment at `IMP_ARENA_TOP-1` (so its
+/// visible extent is 98560 > the 65536 floor), `memory.fill`s
+/// `[IMP_FILL_BASE, IMP_ARENA_TOP)` with `sentinel`, and reads `IMP_READ_ADDR`
+/// back. `marker` optionally exports an immutable-const `__heap_base`.
+fn build_imported_arena_component(tag: &str, sentinel: u8, marker: Option<i32>) -> Vec<u8> {
+    let zero_memarg = MemArg {
+        offset: 0,
+        align: 0,
+        memory_index: 0,
+    };
+
+    let add_sections = |module: &mut Module| {
+        let mut types = TypeSection::new();
+        types.ty().function([], []); // type 0: fill: () -> ()
+        types.ty().function([], [ValType::I32]); // type 1: read: () -> i32
+
+        // Imported shared memory — `initial` here is a FLOOR the dylib declares,
+        // NOT a cap on the addresses it uses.
+        let mut imports = ImportSection::new();
+        imports.import(
+            "env",
+            "memory",
+            EntityType::Memory(MemoryType {
+                minimum: IMP_MEM_MIN_PAGES,
+                maximum: Some(IMP_MEM_MAX_PAGES),
+                memory64: false,
+                shared: true,
+                page_size_log2: None,
+            }),
+        );
+
+        let mut functions = FunctionSection::new();
+        functions.function(0);
+        functions.function(1);
+
+        let mut globals = GlobalSection::new();
+        if let Some(top) = marker {
+            globals.global(
+                GlobalType {
+                    val_type: ValType::I32,
+                    mutable: false,
+                    shared: false,
+                },
+                &ConstExpr::i32_const(top),
+            );
+        }
+
+        let mut exports = ExportSection::new();
+        exports.export(&format!("fill_{tag}"), ExportKind::Func, 0);
+        exports.export(&format!("read_{tag}"), ExportKind::Func, 1);
+        if marker.is_some() {
+            exports.export("__heap_base", ExportKind::Global, 0);
+        }
+
+        let mut code = CodeSection::new();
+        // fill: memory.fill(dst = IMP_FILL_BASE, val = sentinel, len)
+        let mut fill = Function::new([]);
+        fill.instruction(&Instruction::I32Const(IMP_FILL_BASE)); // dst (reloc-flagged)
+        fill.instruction(&Instruction::I32Const(i32::from(sentinel)));
+        fill.instruction(&Instruction::I32Const(IMP_ARENA_TOP - IMP_FILL_BASE));
+        fill.instruction(&Instruction::MemoryFill(0));
+        fill.instruction(&Instruction::End);
+        code.function(&fill);
+        // read: load8_u at IMP_READ_ADDR
+        let mut read = Function::new([]);
+        read.instruction(&Instruction::I32Const(IMP_READ_ADDR)); // addr (reloc-flagged)
+        read.instruction(&Instruction::I32Load8U(zero_memarg));
+        read.instruction(&Instruction::End);
+        code.function(&read);
+
+        // 1-byte active data segment at IMP_ARENA_TOP-1 → visible extent 98560,
+        // above the 65536 floor. Distinct per-component after rebasing (no SR-56
+        // active-data overlap). Offset is rebased structurally, not via reloc.
+        let mut data = DataSection::new();
+        data.segment(DataSegment {
+            mode: DataSegmentMode::Active {
+                memory_index: 0,
+                offset: &ConstExpr::i32_const(IMP_ARENA_TOP - 1),
+            },
+            data: [sentinel],
+        });
+
+        module
+            .section(&types)
+            .section(&imports)
+            .section(&functions)
+            .section(&globals)
+            .section(&exports)
+            .section(&DataCountSection { count: 1 })
+            .section(&code)
+            .section(&data);
+    };
+
+    // Flag both address literals (fill dst + read addr) as reloc sites.
+    let mut dry = Module::new();
+    add_sections(&mut dry);
+    let dry_bytes = dry.finish();
+    let mut offsets = find_i32const_reloc_offsets(&dry_bytes, IMP_FILL_BASE);
+    offsets.extend(find_i32const_reloc_offsets(&dry_bytes, IMP_READ_ADDR));
+    assert_eq!(offsets.len(), 2, "fill dst + read addr are the reloc sites");
+    let reloc_code = build_reloc_code_body(&offsets);
+
+    let mut module = Module::new();
+    add_sections(&mut module);
+    module.section(&CustomSection {
+        name: "linking".into(),
+        data: vec![0x02].into(),
+    });
+    module.section(&CustomSection {
+        name: "reloc.CODE".into(),
+        data: reloc_code.into(),
+    });
+
+    let mut component = Component::new();
+    component.section(&ModuleSection(&module));
+    component.finish()
+}
+
+/// The (min, max) pages of the fused module's IMPORTED memory.
+fn fused_imported_memory_pages(bytes: &[u8]) -> (u64, u64) {
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let wasmparser::Payload::ImportSection(reader) = payload.expect("payload") {
+            for import in reader.into_imports() {
+                if let wasmparser::TypeRef::Memory(mem) = import.expect("import").ty {
+                    return (mem.initial, mem.maximum.unwrap_or(mem.initial));
+                }
+            }
+        }
+    }
+    panic!("fused module has no imported memory");
+}
+
+/// Fuse three imported-memory arena components under `--pack-rebase`, provision
+/// the shared memory via a `Linker`, run every fill then every readback, and
+/// assert each component reads its OWN sentinel.
+fn run_imported_arena(marker: Option<i32>) {
+    let a = build_imported_arena_component("a", 0xA1, marker);
+    let b = build_imported_arena_component("b", 0xB2, marker);
+    let c = build_imported_arena_component("c", 0xC3, marker);
+    let config = FuserConfig {
+        memory_strategy: MemoryStrategy::SharedMemory,
+        pack_rebase: true,
+        ..Default::default()
+    };
+    let mut fuser = Fuser::new(config);
+    fuser.add_component_named(&a, Some("comp-a")).unwrap();
+    fuser.add_component_named(&b, Some("comp-b")).unwrap();
+    fuser.add_component_named(&c, Some("comp-c")).unwrap();
+    let fused = fuser.fuse().expect("fusion");
+
+    let (min_pages, max_pages) = fused_imported_memory_pages(&fused);
+
+    let mut engine_config = Config::new();
+    engine_config.wasm_threads(true);
+    engine_config.shared_memory(true);
+    engine_config.wasm_bulk_memory(true);
+    let engine = Engine::new(&engine_config).unwrap();
+    let module = RuntimeModule::new(&engine, &fused).unwrap();
+
+    let shared = SharedMemory::new(
+        &engine,
+        RuntimeMemoryType::shared(min_pages as u32, max_pages as u32),
+    )
+    .unwrap();
+    let mut store = Store::new(&engine, ());
+    let mut linker = Linker::new(&engine);
+    linker
+        .define(&store, "env", "memory", shared.clone())
+        .unwrap();
+
+    let instance = linker.instantiate(&mut store, &module).unwrap();
+
+    for fill in ["fill_a", "fill_b", "fill_c"] {
+        instance
+            .get_typed_func::<(), ()>(&mut store, fill)
+            .unwrap_or_else(|e| panic!("export {fill}: {e}"))
+            .call(&mut store, ())
+            .unwrap();
+    }
+    for (read, want) in [("read_a", 0xA1), ("read_b", 0xB2), ("read_c", 0xC3)] {
+        let got = instance
+            .get_typed_func::<(), i32>(&mut store, read)
+            .unwrap_or_else(|e| panic!("export {read}: {e}"))
+            .call(&mut store, ())
+            .unwrap();
+        assert_eq!(
+            got,
+            want,
+            "{read} must read its OWN sentinel {want:#x}, got {got:#x} — imported memory \
+             (declared floor {}) addressing above it was under-reserved and a neighbour's fill \
+             clobbered it (#370 delta-pass)",
+            IMP_MEM_MIN_PAGES * 65536
+        );
+    }
+}
+
+/// RED→GREEN: imported memory, NO marker, `max_end (98560) > declared (65536)`.
+/// The buggy no-marker guard returned `None` → 65536 stride; the fix reserves
+/// `max_end`.
+#[test]
+fn pack_rebase_imported_memory_above_floor_no_marker_no_clobber() {
+    run_imported_arena(None);
+}
+
+/// RED→GREEN: imported memory WITH a `__heap_base` marker. The buggy marker
+/// branch clamped `.min(declared)` down to 65536; the fix does NOT clamp for an
+/// imported memory, reserving the true `__heap_base` top.
+#[test]
+fn pack_rebase_imported_memory_marker_not_clamped_to_floor_no_clobber() {
+    run_imported_arena(Some(IMP_ARENA_TOP));
 }

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2584,6 +2584,53 @@ artifacts:
         - "https://github.com/pulseengine/meld/issues/298"
         - "https://github.com/pulseengine/meld/issues/299"
 
+  - id: SR-64
+    type: sw-req
+    title: Embedded, queryable CLI documentation with a coverage invariant
+    description: >
+      The meld CLI shall carry its own documentation compiled INTO the binary
+      (offline, air-gapped by construction) and expose it queryably:
+      `meld docs` lists topics, `meld docs <topic>` shows one, `--grep <q>`
+      searches titles and bodies, and `--format json` emits the list (or a
+      single topic, with its body) for machine consumption — modelled on
+      `rivet docs` and mirroring varve's REQ-DOCS-001. Coverage is a mechanical
+      invariant: every top-level CLI subcommand shall have a documented topic
+      whose slug equals the clap subcommand name, checked by
+      `meld docs check --coverage` (`--strict` exits non-zero — the CI gate)
+      and by a unit test that enumerates the subcommands via
+      `clap::CommandFactory`, so an undocumented subcommand cannot ship. Concept
+      topics (fusion, memory-strategies, address-rebasing, pack-rebase,
+      adapters, attestation, provenance) document meld's domain alongside the
+      per-subcommand topics.
+    status: verified
+    tags: [cli, documentation, coverage-gate, air-gapped, aspice]
+    release: v0.47.0
+    links:
+      - type: derives-from
+        target: SYS-11
+    cited-source:
+      - uri: "https://github.com/pulseengine/varve"
+        kind: github
+        last-checked: 2026-08-13
+    fields:
+      implementation:
+        - meld-cli/src/docs.rs
+        - meld-cli/src/main.rs
+        - meld-cli/docs/
+      verification-method: automated-test
+      verification-description: >
+        PROPOSED. The `meld-cli` unit test
+        `docs::tests::every_cli_subcommand_has_a_documented_topic` builds the
+        clap command via `clap::CommandFactory`, calls `docs::coverage_gaps`,
+        and asserts it is empty — every subcommand (excluding clap's built-in
+        `help`) has a topic. Companion tests cover findable/greppable topics,
+        the JSON list and single-topic forms, the empty-object unknown-topic
+        path, and a "no topic body shorter than ~40 chars" floor. The same
+        `coverage_gaps` invariant is exposed at runtime as
+        `meld docs check --coverage --strict` for use as a CI gate.
+      references:
+        - "https://github.com/pulseengine/varve"
+
   - id: SR-65
     type: sw-req
     title: Pack-rebase reserves the true static extent (__heap_base) or refuses to compact

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2583,3 +2583,67 @@ artifacts:
         - "https://github.com/pulseengine/meld/issues/301"
         - "https://github.com/pulseengine/meld/issues/298"
         - "https://github.com/pulseengine/meld/issues/299"
+
+  - id: SR-65
+    type: sw-req
+    title: Pack-rebase reserves the true static extent (__heap_base) or refuses to compact
+    description: >
+      `--pack-rebase` shall reserve each component's TRUE static extent —
+      including a zero-init `.bss` / bounded-static-arena region above the last
+      data segment — not merely its active-data-segment extent. It reads
+      `__heap_base` (a defined, immutable `i32`-const global — wasm-ld's top of
+      static data+bss) from the export table or the name section, and packs to
+      `clamp(__heap_base, max_end .. cap)`. The extent shall NEVER be below the
+      visible data extent (`max_end`). `declared` (initial pages) is a valid cap
+      ONLY for a DEFINED memory (a valid module cannot address beyond its own
+      initial); for an IMPORTED memory `initial` is a declared MINIMUM (floor)
+      and must never lower the extent (a dylink dylib imports `(memory 1)` and
+      addresses far above page 1). When the true extent CANNOT be determined —
+      no `__heap_base` marker and a footprint that page-granular placement cannot
+      bound — meld shall fall back to page-granular placement (reserving at least
+      `max_end`) with a `log::warn!` naming the remedy, and shall NEVER silently
+      under-reserve: SR-56's overlap check is active-data-segment-only and cannot
+      catch a `.bss`/arena collision, so a silent under-reservation is silent
+      cross-component corruption (#370, the falcon/relay bounded-static-arena
+      shape). This corrects a first-cut regression (imported memory whose data
+      exceeds its declared floor) that a Mythos delta-pass runtime-proved.
+      SUPPLIER PRECONDITION: to get compaction, publish `__heap_base` retained
+      through `wasm-tools component new` (e.g. `-Wl,--export=__heap_base`)
+      alongside `--emit-relocs` — the marker is discarded by default (verified
+      absent on all published falcon 1.133.0 artifacts).
+    status: verified
+    tags: [merger, memory, shared, mcu, pack-rebase, silent-corruption, bss]
+    release: v0.47.0
+    links:
+      - type: derives-from
+        target: SYS-6
+      - type: mitigates
+        target: LS-M-12
+      - type: refines
+        target: SR-57
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/370"
+        kind: github
+        last-checked: 2026-08-13
+    fields:
+      implementation:
+        - meld-core/src/merger.rs
+      verification-method: test
+      verification-description: >
+        Verified by meld-core/tests/pack_rebase_370.rs (4 differential-execution
+        oracles, each RED before the fix / GREEN after, proven by revert):
+        pack_rebase_bss_arena_with_marker_compacts_no_clobber and
+        pack_rebase_bss_arena_without_marker_falls_back_no_clobber (the .bss-tail
+        shape: compacts to 1 page with an exported __heap_base, falls back to 3
+        pages page-granular without, neither clobbers); and
+        pack_rebase_imported_memory_above_floor_no_marker_no_clobber +
+        pack_rebase_imported_memory_marker_not_clamped_to_floor_no_clobber (the
+        dylink imported-memory shape where data exceeds the declared floor — each
+        reads its own sentinel, closing the Mythos-found under-reserve). The
+        marker is read via merger.rs::module_heap_base_marker (defined immutable
+        i32-const global, export table or name section; mutable/non-i32/imported
+        rejected). Full suite green; the existing pack oracles (data-only,
+        passive, no-data) unregressed.
+      references:
+        - "https://github.com/pulseengine/meld/issues/370"
+        - "meld-core/tests/pack_rebase_370.rs"

--- a/safety/requirements/sw-verifications.yaml
+++ b/safety/requirements/sw-verifications.yaml
@@ -1086,3 +1086,17 @@ artifacts:
     links:
       - type: verifies
         target: SR-55
+
+  - id: SWV-76
+    type: sw-verification
+    title: "Verification of SR-65: Pack-rebase true-static-extent (__heap_base) or loud refusal"
+    description: >
+      Verifies SR-65 via meld-core/tests/pack_rebase_370.rs (4 RED→GREEN
+      differential oracles): the .bss-arena shape (with-marker compacts 3→1 page,
+      without-marker falls back page-granular, neither clobbers) and the dylink
+      imported-memory shape where data exceeds the declared floor (marker not
+      clamped to floor; no-marker reserves >= max_end) — each reads its own
+      sentinel on wasmtime. A local Mythos delta-pass (the CI auto-Mythos cannot
+      run on the 6.6k-line merger.rs, #376) runtime-proved and then closed an
+      imported-memory under-reserve regression in the first cut. Never silently
+      under-reserves; supplier must export __heap_base for compaction.

--- a/safety/requirements/sw-verifications.yaml
+++ b/safety/requirements/sw-verifications.yaml
@@ -1100,3 +1100,27 @@ artifacts:
       run on the 6.6k-line merger.rs, #376) runtime-proved and then closed an
       imported-memory under-reserve regression in the first cut. Never silently
       under-reserves; supplier must export __heap_base for compaction.
+    status: implemented
+    fields:
+      method: automated-test
+    links:
+      - type: verifies
+        target: SR-65
+
+  - id: SWV-77
+    type: sw-verification
+    title: "Verification of SR-64: Embedded, queryable CLI documentation with a coverage invariant"
+    description: >
+      Verifies SR-64 via meld-cli/src/docs.rs::tests::every_cli_subcommand_has_a_documented_topic
+      (walks the clap command via CommandFactory -> coverage_gaps -> asserts
+      empty), plus findable/greppable, JSON list/single, unknown-topic {}, and
+      no-body-under-40-chars tests (6 tests, green). Runtime gate:
+      `meld docs check --coverage --strict` exits non-zero on any subcommand
+      without a topic. Topics are include_str!-embedded (offline). Mirrors varve
+      REQ-DOCS-001 / rivet docs.
+    status: implemented
+    fields:
+      method: automated-test
+    links:
+      - type: verifies
+        target: SR-64


### PR DESCRIPTION
Two independent pieces bundled: the escalated #370 unblock (meld's half) and the `meld docs` subcommand.

## SR-65 — `--pack-rebase` reserves the true static extent or refuses (#370)
`--pack-rebase` packed by the active-data-segment extent only, so a component whose accessed memory (a zero-init `.bss` region / relay's bounded static arena) extends **above its last data segment** was silently under-reserved — and SR-56's overlap check is active-data-only, so the cross-component collision wasn't caught (silent corruption). Confirmed on the real falcon `1.133.0` bytes: 17 declared pages, data ending ~1048672, a **65440-byte arena tail invisible to the data-segment scan**.

Compaction below the declared page count now **requires an authoritative `__heap_base` marker** (defined immutable `i32` global, read from the export table or name section); absent it, meld **falls back to page-granular and warns** — never silently under-reserving. `declared` (initial pages) caps the extent only for a **defined** memory; for an **imported** memory it's a floor (a dylink dylib addresses far above page 1). **A local Mythos delta-pass caught + closed an imported-memory under-reserve regression** in the first cut — pinned by its own oracle.

Two-sided: no published falcon artifact exports `__heap_base` (verified — absent from exports, linking symtab, name section), so compaction of published artifacts is gated on suppliers retaining `__heap_base` alongside `--emit-relocs`. meld's half is sound.

**Oracles** (`pack_rebase_370.rs`, all RED→GREEN by revert): `.bss`-arena with/without marker + imported-memory-above-floor with/without marker.

## SR-64 — `meld docs` embedded queryable documentation
Topics compiled into the binary (offline, `include_str!`). `meld docs` / `docs <topic>` / `--grep` / `--format json` / `meld docs check --coverage --strict` (CI-gate form). 11 topics (fuse/inspect/version/docs + concept topics). Coverage test walks the CLI via `clap::CommandFactory`. Models `rivet docs` / varve's REQ-DOCS-001.

## Verification
Full suite **830 passed / 45 binaries / 0 failed**; `clippy --all-targets` clean; `rivet validate` PASS. SR-64 + SR-65 verified, SWV-76/77.

## Mythos note
The #370 change is a **production** change to `merger.rs`, so it needs the Tier-5 gate — but the CI auto-Mythos discover **crashes on the 6.6k-line merger.rs** (tracked as #376). A **local Mythos delta-pass was run** (it found + I fixed the imported-memory regression); applying `mythos-pass-done` on that basis. #376 (split the oversized files) is the durable fix for the gate itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)