### PR TITLE
feat(SR-67/#382): --share-stack call-topology envelope gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.49.0] - 2026-08-14
+
+### Added
+- **`--share-stack` call-topology envelope gate (SR-67, #382)** — the shared
+  shadow-stack region (SR-66/#380) is sized `max_i(sp_i)`, sound only while at
+  most one stack is live at a time. Since `mcu_dissolve::coalesce_stack_pointers`
+  collapses every `__stack_pointer` across all components *and modules* onto one
+  survivor, the region is per-module and a call from one memory-bearing module
+  into another chains their stacks in it. meld now analyses the fused-set call
+  graph — nodes `(component, module)`, edges = every cross-module function call
+  (`adapter_sites` ∪ function-kind `module_resolutions`), weighted by `sp` — and:
+  no cross-module edges → sound, silent (the gale/F100 shape); an acyclic DAG
+  whose worst root-to-leaf `sp`-sum exceeds the region → `log::warn` naming the
+  chain and the required sum; a call **cycle** → hard-fail (unbounded live
+  stack). This is the mechanical form of the self-check the falcon supplier
+  proposed on #370 ("a seam that vanishes from the residual imports is a
+  component now calling a sibling"), done more precisely than an external
+  undefined-symbol diff. Not a blanket refuse — the orchestrator composition
+  (sound at `max_i(orchestrator + driver_i)`) is warned, only a cycle is refused.
+  A local Mythos delta-pass hardened it (per-module granularity; the pure graph
+  engine verified against missed-cycle / undercount attacks). Known narrow gap
+  (documented): a resource-destructor call routed via handle tables is not seen.
+
 ## [0.48.0] - 2026-08-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.48.0"
+version = "0.49.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/meld-core/src/merger/memory.rs
+++ b/meld-core/src/merger/memory.rs
@@ -134,7 +134,7 @@ impl Merger {
             // while at most one provider's stack is live. Check the fused-set
             // call graph and refuse a cycle (unbounded live stack); warn on a DAG
             // whose worst call chain exceeds the region.
-            self.check_share_stack_call_topology(graph, &share_entries, s_raw)?;
+            self.check_share_stack_call_topology(graph, components, &share_entries, s_raw)?;
         } else if self.address_rebasing {
             // Byte-granular running base. Under the default page-granular
             // strategy each module strides by its declared page count; under
@@ -278,73 +278,132 @@ impl Merger {
     }
 
     /// SR-67 / #382: the `--share-stack` call-topology envelope check. The shared
-    /// region is `max_i(sp_i)`, sound only while at most one provider's stack is
-    /// live — i.e. the providers are mutually-non-calling. Every fused
-    /// cross-component function call (an `AdapterSite` with
-    /// `from_component != to_component`) makes a caller live while its callee
-    /// runs, so the live requirement along a call chain is the SUM of stacks.
+    /// region is `max_i(sp_i)`, sound only while at most one stack is live at a
+    /// time. But the region is per-MODULE, not per-component:
+    /// `mcu_dissolve::coalesce_stack_pointers` collapses EVERY `__stack_pointer`
+    /// across all components AND modules onto one survivor, so every module's
+    /// stack lives in the single `[0, s_raw)` region. A call from one
+    /// memory-bearing module into another (whether cross-component or
+    /// intra-component cross-module) chains their `sp`s in that region.
     ///
-    /// - no such edges → the region is sound; nothing to do.
-    /// - an acyclic call graph (an orchestrator DAG) whose worst root-to-leaf
-    ///   `sp`-sum exceeds the region → `log::warn!` (the region may be undersized,
-    ///   but boundedly; the integrator judges it against real stack bounds). If
-    ///   the worst chain still fits the region, it is sound — say nothing.
-    /// - a call cycle → the live stack is unbounded → hard-fail (the same
-    ///   loud-refusal posture as the other `--share-stack` gates).
+    /// Nodes are therefore `(component, module)` and edges are cross-module
+    /// function calls from two sources (Mythos SR-67 delta-pass, Finding 1):
+    ///   - `graph.adapter_sites` — every internalized cross-component call, plus
+    ///     intra-component encoding-differing calls (both carry distinct
+    ///     `(from_module, to_module)`);
+    ///   - function-kind `graph.module_resolutions` — intra-component cross-module
+    ///     calls that never become adapter sites (under `SharedMemory` only an
+    ///     encoding difference makes one, so plain cross-module calls stay here).
     ///
-    /// All cross-component edges count — including resource-op and async-lift
-    /// calls, which still execute callee code and keep the (possibly suspended)
-    /// caller stack live. Over-approximating here yields a false warn/refuse at
+    /// Resource-op and async-lift calls count too (they still execute callee code
+    /// on the shared stack). Over-approximating yields a false warn/refuse at
     /// worst, never a silent under-reservation.
+    ///
+    /// Verdict (via [`analyze_call_topology`], weighting each node by its `sp`):
+    ///   - no cross-module edges → sound; proceed silently.
+    ///   - acyclic DAG, worst root-to-leaf `sp`-sum > region → `log::warn!`.
+    ///   - a call cycle → unbounded live stack → hard-fail.
+    ///
+    /// KNOWN GAP (Finding 3, unconfirmed): a standalone resource-DESTRUCTOR
+    /// invocation (drop of an owned handle → the defining component's dtor) that
+    /// is routed through handle tables rather than an adapter site would not
+    /// appear here. Narrow for the scalar MCU driver shape `--share-stack`
+    /// targets (no resources); documented rather than claimed-covered.
     fn check_share_stack_call_topology(
         &self,
         graph: &DependencyGraph,
+        components: &[ParsedComponent],
         share_entries: &[((usize, usize), u64, u64)],
         region: u64,
     ) -> Result<()> {
-        // Cross-component call edges (self-edges are intra-component promotions,
-        // not sibling calls — exclude them).
-        let edges: Vec<(usize, usize)> = graph
-            .adapter_sites
-            .iter()
-            .filter(|s| s.from_component != s.to_component)
-            .map(|s| (s.from_component, s.to_component))
-            .collect();
-
-        // Per-component stack size: the largest `sp` among a component's rebased
-        // memory modules (its shadow-stack region).
-        let mut sp_by_comp: HashMap<usize, u64> = HashMap::new();
-        for &((comp_idx, _), sp, _) in share_entries {
-            let slot = sp_by_comp.entry(comp_idx).or_insert(0);
-            *slot = (*slot).max(sp);
+        // No shared region to protect (defensive — Finding 2). Unreachable via
+        // the plan (a non-empty memory set always yields entries), but explicit.
+        if share_entries.is_empty() {
+            return Ok(());
         }
 
-        match analyze_call_topology(&edges, &sp_by_comp) {
+        // Intern `(component, module)` keys to dense ids so the pure analysis
+        // stays integer-keyed; `label` maps back for diagnostics.
+        let mut id_of: HashMap<(usize, usize), usize> = HashMap::new();
+        let mut label: Vec<(usize, usize)> = Vec::new();
+        let mut intern = |key: (usize, usize)| -> usize {
+            *id_of.entry(key).or_insert_with(|| {
+                label.push(key);
+                label.len() - 1
+            })
+        };
+
+        // Per-module stack weight.
+        let mut sp: HashMap<usize, u64> = HashMap::new();
+        for &(key, weight, _) in share_entries {
+            let id = intern(key);
+            sp.insert(id, weight);
+        }
+
+        // Cross-module call edges from both sources (exclude same-module).
+        let mut edges: Vec<(usize, usize)> = Vec::new();
+        for site in &graph.adapter_sites {
+            let from = (site.from_component, site.from_module);
+            let to = (site.to_component, site.to_module);
+            if from != to {
+                edges.push((intern(from), intern(to)));
+            }
+        }
+        for res in &graph.module_resolutions {
+            if res.from_module == res.to_module {
+                continue;
+            }
+            // FUNCTION-kind only: a memory/global/table wiring is not a call.
+            let is_call = components
+                .get(res.component_idx)
+                .and_then(|c| c.core_modules.get(res.to_module))
+                .is_some_and(|m| {
+                    m.exports
+                        .iter()
+                        .any(|e| e.name == res.export_name && matches!(e.kind, ExportKind::Function))
+                });
+            if is_call {
+                let from = (res.component_idx, res.from_module);
+                let to = (res.component_idx, res.to_module);
+                edges.push((intern(from), intern(to)));
+            }
+        }
+
+        let describe = |ids: &[usize]| -> Vec<(usize, usize)> {
+            ids.iter().map(|&id| label[id]).collect()
+        };
+
+        match analyze_call_topology(&edges, &sp) {
             CallTopology::NoEdges => Ok(()),
             CallTopology::Acyclic {
                 worst_sum,
                 worst_path,
             } => {
                 if worst_sum > region {
+                    let chain = describe(&worst_path);
                     log::warn!(
-                        "--share-stack: the fused set is not mutually-non-calling — component \
-                         call chain {worst_path:?} needs up to {worst_sum} bytes of shadow stack \
-                         (the sum along the chain), but the shared region is sized {region} bytes \
-                         (the max single provider). At most one provider's stack is assumed live \
-                         at a time; a live caller+callee needs their sum. This is sound only if \
-                         the chain's true peak fits {region} — verify against your per-stage stack \
-                         bounds (e.g. a scry static bound). If it does not, do not use \
+                        "--share-stack: the fused set is not mutually-non-calling — the \
+                         (component, module) call chain {chain:?} needs up to {worst_sum} bytes of \
+                         shadow stack (the sum along the chain), but the shared region is sized \
+                         {region} bytes (the largest single module). At most one module's stack is \
+                         assumed live at a time; a live caller+callee needs their sum. Sound only \
+                         if the chain's true peak fits {region} — verify against your per-stage \
+                         stack bounds (e.g. a scry static bound). If it does not, do not use \
                          --share-stack for this composition."
                     );
                 }
                 Ok(())
             }
-            CallTopology::Cyclic { cycle } => Err(Error::MemoryStrategyUnsupported(format!(
-                "--share-stack: the fused set contains a component call CYCLE {cycle:?} — the live \
-                 shadow-stack depth is unbounded, so a single region sized to the largest provider \
-                 cannot be sound. --share-stack requires a non-recursive, one-live-at-a-time \
-                 composition; remove the cycle or drop --share-stack."
-            ))),
+            CallTopology::Cyclic { cycle } => {
+                let chain = describe(&cycle);
+                Err(Error::MemoryStrategyUnsupported(format!(
+                    "--share-stack: the fused set contains a (component, module) call CYCLE \
+                     {chain:?} — the live shadow-stack depth is unbounded, so a single region \
+                     sized to the largest module cannot be sound. --share-stack requires a \
+                     non-recursive, one-live-at-a-time composition; remove the cycle or drop \
+                     --share-stack."
+                )))
+            }
         }
     }
 }
@@ -1065,15 +1124,18 @@ mod topology_tests {
     use crate::resolver::{AdapterRequirements, AdapterSite, DependencyGraph};
     use crate::merger::Merger;
 
-    fn site(from: usize, to: usize) -> AdapterSite {
+    /// A `((from_component, from_module), (to_component, to_module))` call edge.
+    type ModEdge = ((usize, usize), (usize, usize));
+
+    fn site_mod(fc: usize, fm: usize, tc: usize, tm: usize) -> AdapterSite {
         AdapterSite {
-            from_component: from,
-            from_module: 0,
+            from_component: fc,
+            from_module: fm,
             import_name: "f".into(),
             import_module: "m".into(),
             import_func_type_idx: None,
-            to_component: to,
-            to_module: 0,
+            to_component: tc,
+            to_module: tm,
             export_name: "f".into(),
             export_func_idx: 0,
             crosses_memory: false,
@@ -1082,12 +1144,27 @@ mod topology_tests {
         }
     }
 
+    /// Component-level edges (module 0 on both sides).
     fn graph(edges: &[(usize, usize)]) -> DependencyGraph {
+        graph_sites(edges.iter().map(|&(f, t)| site_mod(f, 0, t, 0)).collect())
+    }
+
+    /// `(component, module)` edges.
+    fn graph_mods(edges: &[ModEdge]) -> DependencyGraph {
+        graph_sites(
+            edges
+                .iter()
+                .map(|&((fc, fm), (tc, tm))| site_mod(fc, fm, tc, tm))
+                .collect(),
+        )
+    }
+
+    fn graph_sites(adapter_sites: Vec<AdapterSite>) -> DependencyGraph {
         DependencyGraph {
             instantiation_order: Vec::new(),
             resolved_imports: HashMap::new(),
             unresolved_imports: Vec::new(),
-            adapter_sites: edges.iter().map(|&(f, t)| site(f, t)).collect(),
+            adapter_sites,
             resource_graph: None,
             stream_pair_graph: None,
             module_resolutions: Vec::new(),
@@ -1112,7 +1189,7 @@ mod topology_tests {
         // gale shape: no adapter sites -> mutually-non-calling -> Ok.
         let m = share_merger();
         assert!(
-            m.check_share_stack_call_topology(&graph(&[]), &entries(), 100)
+            m.check_share_stack_call_topology(&graph(&[]), &[], &entries(), 100)
                 .is_ok()
         );
     }
@@ -1122,7 +1199,7 @@ mod topology_tests {
         // from == to is an intra-component promotion, not a sibling call.
         let m = share_merger();
         assert!(
-            m.check_share_stack_call_topology(&graph(&[(0, 0), (1, 1)]), &entries(), 100)
+            m.check_share_stack_call_topology(&graph(&[(0, 0), (1, 1)]), &[], &entries(), 100)
                 .is_ok()
         );
     }
@@ -1132,7 +1209,7 @@ mod topology_tests {
         // 0 -> 1 -> 0 : unbounded live stack -> refuse.
         let m = share_merger();
         let err = m
-            .check_share_stack_call_topology(&graph(&[(0, 1), (1, 0)]), &entries(), 100)
+            .check_share_stack_call_topology(&graph(&[(0, 1), (1, 0)]), &[], &entries(), 100)
             .expect_err("a call cycle must be refused");
         let msg = err.to_string();
         assert!(
@@ -1146,7 +1223,7 @@ mod topology_tests {
         // 0 -> 1, sum 150, region 200 -> fits -> Ok, silent.
         let m = share_merger();
         assert!(
-            m.check_share_stack_call_topology(&graph(&[(0, 1)]), &entries(), 200)
+            m.check_share_stack_call_topology(&graph(&[(0, 1)]), &[], &entries(), 200)
                 .is_ok()
         );
     }
@@ -1156,7 +1233,42 @@ mod topology_tests {
         // 0 -> 1, sum 150, region 100 -> exceeds -> warn, still Ok (bounded).
         let m = share_merger();
         assert!(
-            m.check_share_stack_call_topology(&graph(&[(0, 1)]), &entries(), 100)
+            m.check_share_stack_call_topology(&graph(&[(0, 1)]), &[], &entries(), 100)
+                .is_ok()
+        );
+    }
+
+    // share_entries for a SINGLE component with TWO memory-bearing modules.
+    fn multimodule_entries() -> Vec<((usize, usize), u64, u64)> {
+        vec![((0, 0), 100, 200), ((0, 1), 80, 160)]
+    }
+
+    #[test]
+    fn gate_catches_intra_component_cross_module_cycle() {
+        // Mythos SR-67 Finding 1: the shared stack is per-MODULE, so two modules
+        // in ONE component that call each other (comp0/mod0 <-> comp0/mod1) form
+        // a cycle in the shared region. The old per-component gate dropped these
+        // as `from == to` self-edges and passed silently; per-module nodes catch
+        // it. (A cycle asserts detection unambiguously via the Err.)
+        let m = share_merger();
+        let g = graph_mods(&[((0, 0), (0, 1)), ((0, 1), (0, 0))]);
+        let err = m
+            .check_share_stack_call_topology(&g, &[], &multimodule_entries(), 100)
+            .expect_err("an intra-component cross-module call cycle must be refused");
+        assert!(
+            err.to_string().contains("CYCLE"),
+            "error must name the cycle: {err}"
+        );
+    }
+
+    #[test]
+    fn gate_warns_on_intra_component_cross_module_dag_over_region() {
+        // comp0/mod0 -> comp0/mod1, sp 100 + 80 = 180 > region 100 -> warn, Ok.
+        // The old per-component gate saw a self-edge, dropped it, and was silent.
+        let m = share_merger();
+        let g = graph_mods(&[((0, 0), (0, 1))]);
+        assert!(
+            m.check_share_stack_call_topology(&g, &[], &multimodule_entries(), 100)
                 .is_ok()
         );
     }

--- a/meld-core/src/merger/memory.rs
+++ b/meld-core/src/merger/memory.rs
@@ -17,6 +17,7 @@ impl Merger {
     pub(crate) fn compute_shared_memory_plan(
         &self,
         components: &[ParsedComponent],
+        graph: &DependencyGraph,
     ) -> Result<Option<SharedMemoryPlan>> {
         let mut memory_types = Vec::new();
         let mut import_names: Vec<(String, String)> = Vec::new();
@@ -128,6 +129,12 @@ impl Merger {
                 combined.maximum = Some(max.max(combined.initial));
             }
             shared_stack_top = Some(s_raw);
+
+            // SR-67 / #382: the shared region is sized `max_i(sp_i)`, sound only
+            // while at most one provider's stack is live. Check the fused-set
+            // call graph and refuse a cycle (unbounded live stack); warn on a DAG
+            // whose worst call chain exceeds the region.
+            self.check_share_stack_call_topology(graph, &share_entries, s_raw)?;
         } else if self.address_rebasing {
             // Byte-granular running base. Under the default page-granular
             // strategy each module strides by its declared page count; under
@@ -268,6 +275,77 @@ impl Merger {
             }
         }
         Ok(((comp_idx, mod_idx), sp, extent))
+    }
+
+    /// SR-67 / #382: the `--share-stack` call-topology envelope check. The shared
+    /// region is `max_i(sp_i)`, sound only while at most one provider's stack is
+    /// live — i.e. the providers are mutually-non-calling. Every fused
+    /// cross-component function call (an `AdapterSite` with
+    /// `from_component != to_component`) makes a caller live while its callee
+    /// runs, so the live requirement along a call chain is the SUM of stacks.
+    ///
+    /// - no such edges → the region is sound; nothing to do.
+    /// - an acyclic call graph (an orchestrator DAG) whose worst root-to-leaf
+    ///   `sp`-sum exceeds the region → `log::warn!` (the region may be undersized,
+    ///   but boundedly; the integrator judges it against real stack bounds). If
+    ///   the worst chain still fits the region, it is sound — say nothing.
+    /// - a call cycle → the live stack is unbounded → hard-fail (the same
+    ///   loud-refusal posture as the other `--share-stack` gates).
+    ///
+    /// All cross-component edges count — including resource-op and async-lift
+    /// calls, which still execute callee code and keep the (possibly suspended)
+    /// caller stack live. Over-approximating here yields a false warn/refuse at
+    /// worst, never a silent under-reservation.
+    fn check_share_stack_call_topology(
+        &self,
+        graph: &DependencyGraph,
+        share_entries: &[((usize, usize), u64, u64)],
+        region: u64,
+    ) -> Result<()> {
+        // Cross-component call edges (self-edges are intra-component promotions,
+        // not sibling calls — exclude them).
+        let edges: Vec<(usize, usize)> = graph
+            .adapter_sites
+            .iter()
+            .filter(|s| s.from_component != s.to_component)
+            .map(|s| (s.from_component, s.to_component))
+            .collect();
+
+        // Per-component stack size: the largest `sp` among a component's rebased
+        // memory modules (its shadow-stack region).
+        let mut sp_by_comp: HashMap<usize, u64> = HashMap::new();
+        for &((comp_idx, _), sp, _) in share_entries {
+            let slot = sp_by_comp.entry(comp_idx).or_insert(0);
+            *slot = (*slot).max(sp);
+        }
+
+        match analyze_call_topology(&edges, &sp_by_comp) {
+            CallTopology::NoEdges => Ok(()),
+            CallTopology::Acyclic {
+                worst_sum,
+                worst_path,
+            } => {
+                if worst_sum > region {
+                    log::warn!(
+                        "--share-stack: the fused set is not mutually-non-calling — component \
+                         call chain {worst_path:?} needs up to {worst_sum} bytes of shadow stack \
+                         (the sum along the chain), but the shared region is sized {region} bytes \
+                         (the max single provider). At most one provider's stack is assumed live \
+                         at a time; a live caller+callee needs their sum. This is sound only if \
+                         the chain's true peak fits {region} — verify against your per-stage stack \
+                         bounds (e.g. a scry static bound). If it does not, do not use \
+                         --share-stack for this composition."
+                    );
+                }
+                Ok(())
+            }
+            CallTopology::Cyclic { cycle } => Err(Error::MemoryStrategyUnsupported(format!(
+                "--share-stack: the fused set contains a component call CYCLE {cycle:?} — the live \
+                 shadow-stack depth is unbounded, so a single region sized to the largest provider \
+                 cannot be sound. --share-stack requires a non-recursive, one-live-at-a-time \
+                 composition; remove the cycle or drop --share-stack."
+            ))),
+        }
     }
 }
 
@@ -749,4 +827,337 @@ fn is_direct_memory_access(op: &wasmparser::Operator<'_>) -> bool {
             | I64Store16 { .. }
             | I64Store32 { .. }
     )
+}
+
+/// SR-67 / #382: verdict of the fused-set call-topology analysis for
+/// `--share-stack`. The shared shadow-stack region is sized `max_i(sp_i)`, which
+/// is sound only when at most one provider's stack is live at a time. A
+/// cross-component call makes a caller live while its callee runs, so the live
+/// requirement becomes the sum of stacks along the call chain.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CallTopology {
+    /// No cross-component call edges — mutually-non-calling; `max_i(sp_i)` is
+    /// sound. The current gale (F100) shape. Pass silently.
+    NoEdges,
+    /// Acyclic call graph (an orchestrator DAG). `worst_sum` is the maximum
+    /// root-to-leaf sum of `sp` along any path and `worst_path` the component
+    /// indices on it. The caller warns only when `worst_sum` exceeds the region
+    /// (the region may be undersized, but boundedly so).
+    Acyclic { worst_sum: u64, worst_path: Vec<usize> },
+    /// A call cycle (A→…→A, or recursion through a sibling) — the live stack is
+    /// unbounded. The caller hard-fails.
+    Cyclic { cycle: Vec<usize> },
+}
+
+/// Analyse the fused-set cross-component call graph for the `--share-stack`
+/// envelope (SR-67 / #382). Nodes are component indices; `edges` are
+/// `(from_component, to_component)` function-call edges (self-edges excluded by
+/// the caller). `sp` maps a component to its shadow-stack size (node weight).
+///
+/// Pure and deterministic (sorted iteration) so the graph logic — cycle
+/// detection and longest weighted path — is unit-testable and Mythos-checkable
+/// independently of the fusion pipeline.
+pub(crate) fn analyze_call_topology(
+    edges: &[(usize, usize)],
+    sp: &HashMap<usize, u64>,
+) -> CallTopology {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    if edges.is_empty() {
+        return CallTopology::NoEdges;
+    }
+
+    // Deterministic adjacency (sorted, deduped successors) + node set.
+    let mut adj: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    let mut nodes: BTreeSet<usize> = BTreeSet::new();
+    for &(f, t) in edges {
+        nodes.insert(f);
+        nodes.insert(t);
+        adj.entry(f).or_default().push(t);
+    }
+    for succ in adj.values_mut() {
+        succ.sort_unstable();
+        succ.dedup();
+    }
+
+    // Iterative DFS with colours (0 = white, 1 = gray/on-path, 2 = black/done).
+    // A back edge to a gray node is a cycle; capture it from `path`. Finish
+    // order accumulates into `topo` (= reverse topological order).
+    let mut colour: BTreeMap<usize, u8> = nodes.iter().map(|&n| (n, 0u8)).collect();
+    let mut topo: Vec<usize> = Vec::new();
+    for &start in &nodes {
+        if colour[&start] != 0 {
+            continue;
+        }
+        *colour.get_mut(&start).unwrap() = 1;
+        let mut stack: Vec<(usize, usize)> = vec![(start, 0)];
+        let mut path: Vec<usize> = vec![start];
+        while let Some(&(node, idx)) = stack.last() {
+            let next = adj.get(&node).and_then(|s| s.get(idx).copied());
+            match next {
+                Some(n) => {
+                    stack.last_mut().unwrap().1 += 1;
+                    match colour[&n] {
+                        0 => {
+                            *colour.get_mut(&n).unwrap() = 1;
+                            stack.push((n, 0));
+                            path.push(n);
+                        }
+                        1 => {
+                            let pos = path.iter().position(|&x| x == n).unwrap();
+                            return CallTopology::Cyclic {
+                                cycle: path[pos..].to_vec(),
+                            };
+                        }
+                        _ => {}
+                    }
+                }
+                None => {
+                    *colour.get_mut(&node).unwrap() = 2;
+                    topo.push(node);
+                    path.pop();
+                    stack.pop();
+                }
+            }
+        }
+    }
+
+    // Longest weighted path over the DAG. `topo` is in finish order, so every
+    // node's successors (which finish earlier) are already resolved when we
+    // reach it. `best[n]` = heaviest sp-sum of a path starting at `n`.
+    let mut best: BTreeMap<usize, u64> = BTreeMap::new();
+    let mut nexthop: BTreeMap<usize, Option<usize>> = BTreeMap::new();
+    for &node in &topo {
+        let w = *sp.get(&node).unwrap_or(&0);
+        let mut bsum = w;
+        let mut bnext = None;
+        if let Some(succs) = adj.get(&node) {
+            for &s in succs {
+                let cand = w.saturating_add(best[&s]);
+                if cand > bsum {
+                    bsum = cand;
+                    bnext = Some(s);
+                }
+            }
+        }
+        best.insert(node, bsum);
+        nexthop.insert(node, bnext);
+    }
+
+    // Worst path = argmax over nodes of `best`; reconstruct via `nexthop`.
+    // Ties break to the lowest index (BTreeMap order) for determinism.
+    let start = best
+        .iter()
+        .max_by(|a, b| a.1.cmp(b.1).then(b.0.cmp(a.0)))
+        .map(|(&n, _)| n)
+        .unwrap();
+    let mut worst_path = vec![start];
+    let mut cur = start;
+    while let Some(&Some(n)) = nexthop.get(&cur) {
+        worst_path.push(n);
+        cur = n;
+    }
+    CallTopology::Acyclic {
+        worst_sum: best[&start],
+        worst_path,
+    }
+}
+
+#[cfg(test)]
+mod topology_tests {
+    use super::{CallTopology, analyze_call_topology};
+    use std::collections::HashMap;
+
+    fn sp(pairs: &[(usize, u64)]) -> HashMap<usize, u64> {
+        pairs.iter().copied().collect()
+    }
+
+    #[test]
+    fn no_edges_is_mutually_non_calling() {
+        assert_eq!(
+            analyze_call_topology(&[], &sp(&[(0, 100), (1, 200)])),
+            CallTopology::NoEdges
+        );
+    }
+
+    #[test]
+    fn chain_sums_along_the_path() {
+        // 0 -> 1 -> 2, sp 10/20/30 => worst path 0,1,2 sum 60.
+        let v = analyze_call_topology(&[(0, 1), (1, 2)], &sp(&[(0, 10), (1, 20), (2, 30)]));
+        assert_eq!(
+            v,
+            CallTopology::Acyclic {
+                worst_sum: 60,
+                worst_path: vec![0, 1, 2]
+            }
+        );
+    }
+
+    #[test]
+    fn fanout_takes_the_heavier_branch() {
+        // 0 -> 1, 0 -> 2, sp 10/5/40 => 0,2 = 50 (heavier than 0,1 = 15).
+        let v = analyze_call_topology(&[(0, 1), (0, 2)], &sp(&[(0, 10), (1, 5), (2, 40)]));
+        assert_eq!(
+            v,
+            CallTopology::Acyclic {
+                worst_sum: 50,
+                worst_path: vec![0, 2]
+            }
+        );
+    }
+
+    #[test]
+    fn diamond_takes_the_longest_route() {
+        // 0->1, 0->2, 1->3, 2->3, sp 1/10/2/100 => 0,1,3 = 111 vs 0,2,3 = 103.
+        let v = analyze_call_topology(
+            &[(0, 1), (0, 2), (1, 3), (2, 3)],
+            &sp(&[(0, 1), (1, 10), (2, 2), (3, 100)]),
+        );
+        assert_eq!(
+            v,
+            CallTopology::Acyclic {
+                worst_sum: 111,
+                worst_path: vec![0, 1, 3]
+            }
+        );
+    }
+
+    #[test]
+    fn two_cycle_is_cyclic() {
+        match analyze_call_topology(&[(0, 1), (1, 0)], &sp(&[(0, 10), (1, 20)])) {
+            CallTopology::Cyclic { cycle } => {
+                assert!(cycle.contains(&0) && cycle.contains(&1), "cycle: {cycle:?}");
+            }
+            other => panic!("expected Cyclic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cycle_beats_dag_when_both_present() {
+        // 0->1->2->1 : the 1<->2 back edge is a cycle even though 0->1 is a DAG edge.
+        match analyze_call_topology(&[(0, 1), (1, 2), (2, 1)], &sp(&[(0, 1), (1, 1), (2, 1)])) {
+            CallTopology::Cyclic { cycle } => {
+                assert!(cycle.contains(&1) && cycle.contains(&2), "cycle: {cycle:?}");
+            }
+            other => panic!("expected Cyclic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn self_referential_weight_of_isolated_max_still_bounds() {
+        // Edges only among small nodes; the single heavy node is isolated, so
+        // the worst path (2->3 = 6) is far below it — the caller compares to the
+        // region and would NOT warn. Confirms worst_sum reflects paths, not the
+        // global max node.
+        let v = analyze_call_topology(&[(2, 3)], &sp(&[(2, 2), (3, 4)]));
+        assert_eq!(
+            v,
+            CallTopology::Acyclic {
+                worst_sum: 6,
+                worst_path: vec![2, 3]
+            }
+        );
+    }
+
+    // --- method-level: graph.adapter_sites -> verdict -> action (SR-67 gate) ---
+
+    use crate::MemoryStrategy;
+    use crate::resolver::{AdapterRequirements, AdapterSite, DependencyGraph};
+    use crate::merger::Merger;
+
+    fn site(from: usize, to: usize) -> AdapterSite {
+        AdapterSite {
+            from_component: from,
+            from_module: 0,
+            import_name: "f".into(),
+            import_module: "m".into(),
+            import_func_type_idx: None,
+            to_component: to,
+            to_module: 0,
+            export_name: "f".into(),
+            export_func_idx: 0,
+            crosses_memory: false,
+            is_async_lift: false,
+            requirements: AdapterRequirements::default(),
+        }
+    }
+
+    fn graph(edges: &[(usize, usize)]) -> DependencyGraph {
+        DependencyGraph {
+            instantiation_order: Vec::new(),
+            resolved_imports: HashMap::new(),
+            unresolved_imports: Vec::new(),
+            adapter_sites: edges.iter().map(|&(f, t)| site(f, t)).collect(),
+            resource_graph: None,
+            stream_pair_graph: None,
+            module_resolutions: Vec::new(),
+            reexporter_components: Vec::new(),
+            reexporter_resources: Vec::new(),
+        }
+    }
+
+    fn share_merger() -> Merger {
+        Merger::new(MemoryStrategy::SharedMemory, true)
+            .with_pack_rebase(true)
+            .with_share_stack(true)
+    }
+
+    // share_entries: two providers, comp 0 sp=100, comp 1 sp=50.
+    fn entries() -> Vec<((usize, usize), u64, u64)> {
+        vec![((0, 0), 100, 200), ((1, 0), 50, 100)]
+    }
+
+    #[test]
+    fn gate_passes_with_no_cross_component_calls() {
+        // gale shape: no adapter sites -> mutually-non-calling -> Ok.
+        let m = share_merger();
+        assert!(
+            m.check_share_stack_call_topology(&graph(&[]), &entries(), 100)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn gate_ignores_intra_component_self_edges() {
+        // from == to is an intra-component promotion, not a sibling call.
+        let m = share_merger();
+        assert!(
+            m.check_share_stack_call_topology(&graph(&[(0, 0), (1, 1)]), &entries(), 100)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn gate_hard_fails_on_a_call_cycle() {
+        // 0 -> 1 -> 0 : unbounded live stack -> refuse.
+        let m = share_merger();
+        let err = m
+            .check_share_stack_call_topology(&graph(&[(0, 1), (1, 0)]), &entries(), 100)
+            .expect_err("a call cycle must be refused");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cycle") || msg.contains("CYCLE"),
+            "error must name the cycle: {msg}"
+        );
+    }
+
+    #[test]
+    fn gate_allows_a_dag_that_fits_the_region() {
+        // 0 -> 1, sum 150, region 200 -> fits -> Ok, silent.
+        let m = share_merger();
+        assert!(
+            m.check_share_stack_call_topology(&graph(&[(0, 1)]), &entries(), 200)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn gate_warns_but_allows_a_dag_that_exceeds_the_region() {
+        // 0 -> 1, sum 150, region 100 -> exceeds -> warn, still Ok (bounded).
+        let m = share_merger();
+        assert!(
+            m.check_share_stack_call_topology(&graph(&[(0, 1)]), &entries(), 100)
+                .is_ok()
+        );
+    }
 }

--- a/meld-core/src/merger/memory.rs
+++ b/meld-core/src/merger/memory.rs
@@ -358,9 +358,9 @@ impl Merger {
                 .get(res.component_idx)
                 .and_then(|c| c.core_modules.get(res.to_module))
                 .is_some_and(|m| {
-                    m.exports
-                        .iter()
-                        .any(|e| e.name == res.export_name && matches!(e.kind, ExportKind::Function))
+                    m.exports.iter().any(|e| {
+                        e.name == res.export_name && matches!(e.kind, ExportKind::Function)
+                    })
                 });
             if is_call {
                 let from = (res.component_idx, res.from_module);
@@ -369,9 +369,8 @@ impl Merger {
             }
         }
 
-        let describe = |ids: &[usize]| -> Vec<(usize, usize)> {
-            ids.iter().map(|&id| label[id]).collect()
-        };
+        let describe =
+            |ids: &[usize]| -> Vec<(usize, usize)> { ids.iter().map(|&id| label[id]).collect() };
 
         match analyze_call_topology(&edges, &sp) {
             CallTopology::NoEdges => Ok(()),
@@ -902,7 +901,10 @@ pub(crate) enum CallTopology {
     /// root-to-leaf sum of `sp` along any path and `worst_path` the component
     /// indices on it. The caller warns only when `worst_sum` exceeds the region
     /// (the region may be undersized, but boundedly so).
-    Acyclic { worst_sum: u64, worst_path: Vec<usize> },
+    Acyclic {
+        worst_sum: u64,
+        worst_path: Vec<usize>,
+    },
     /// A call cycle (A→…→A, or recursion through a sibling) — the live stack is
     /// unbounded. The caller hard-fails.
     Cyclic { cycle: Vec<usize> },
@@ -1121,8 +1123,8 @@ mod topology_tests {
     // --- method-level: graph.adapter_sites -> verdict -> action (SR-67 gate) ---
 
     use crate::MemoryStrategy;
-    use crate::resolver::{AdapterRequirements, AdapterSite, DependencyGraph};
     use crate::merger::Merger;
+    use crate::resolver::{AdapterRequirements, AdapterSite, DependencyGraph};
 
     /// A `((from_component, from_module), (to_component, to_module))` call edge.
     type ModEdge = ((usize, usize), (usize, usize));

--- a/meld-core/src/merger/mod.rs
+++ b/meld-core/src/merger/mod.rs
@@ -458,7 +458,7 @@ impl Merger {
         Self::check_no_duplicate_instantiations(components)?;
 
         let shared_memory_plan = if self.memory_strategy == MemoryStrategy::SharedMemory {
-            self.compute_shared_memory_plan(components)?
+            self.compute_shared_memory_plan(components, graph)?
         } else {
             None
         };

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2790,16 +2790,21 @@ artifacts:
     title: Shared-stack call-topology envelope gate (--share-stack, SR-67)
     description: >
       Under `--share-stack` (SR-66) the shared shadow-stack region is sized
-      `max_i(sp_i)`, which is sound only while at most one provider's stack is
-      live — i.e. the fused providers are mutually-non-calling. A fused
-      cross-component function call makes a caller live while its callee runs, so
-      the live requirement along a call chain is the SUM of the participants'
-      stacks, not the max. meld shall analyse the fused-set call graph (nodes =
-      components, edges = `AdapterSite`s with `from_component != to_component` —
-      every internalized cross-component function call, including resource-op and
-      async-lift calls, which still execute callee code and keep the caller stack
-      live) and, weighting each node by its `sp_i`:
-        (a) NO cross-component edges → the region is sound; proceed silently
+      `max_i(sp_i)`, which is sound only while at most one stack is live at a
+      time. The region is per-MODULE, not per-component:
+      `mcu_dissolve::coalesce_stack_pointers` collapses EVERY `__stack_pointer`
+      across all components AND modules onto one survivor, so every module's stack
+      lives in the single region. A call from one memory-bearing module into
+      another — cross-component OR intra-component cross-module — makes the caller
+      live while the callee runs, so the live requirement along a call chain is
+      the SUM of the participants' stacks, not the max. meld shall analyse the
+      fused-set call graph with nodes = `(component, module)` and edges = every
+      cross-module function call: `AdapterSite`s (cross-component + intra-component
+      encoding-differing calls) UNION function-kind `module_resolutions`
+      (intra-component cross-module calls that never become adapter sites).
+      Resource-op and async-lift calls count too (they still execute callee code
+      on the shared stack). Weighting each node by its module `sp`:
+        (a) NO cross-module edges → the region is sound; proceed silently
             (the current gale/F100 shape).
         (b) an ACYCLIC call graph (an orchestrator DAG) whose worst root-to-leaf
             `sp`-sum EXCEEDS the region → `log::warn!`, naming the chain, the
@@ -2837,22 +2842,33 @@ artifacts:
         - meld-core/src/merger/memory.rs
       verification-method: test
       verification-description: >
-        Verified by meld-core/src/merger/memory.rs::topology_tests (12 tests).
+        Verified by meld-core/src/merger/memory.rs::topology_tests (14 tests).
         The pure graph analysis analyze_call_topology is covered by 7 unit tests:
         no-edges → NoEdges; chain/fanout/diamond → the correct worst weighted
         (sp-sum) path; a 2-cycle and a cycle-with-a-DAG-prefix → Cyclic. The gate
-        method check_share_stack_call_topology is covered by 5 method-level tests
+        method check_share_stack_call_topology is covered by 7 method-level tests
         on a constructed DependencyGraph: no cross-component sites → Ok; intra-
-        component self-edges (from == to) ignored → Ok; a call cycle → Err naming
+        component SAME-module self-edges ignored → Ok; a call cycle → Err naming
         the cycle; a DAG that fits the region → Ok (silent); a DAG that exceeds it
-        → Ok (warn). The end-to-end adapter-site construction is exercised by the
-        existing cross-component adapter tests; the share_stack_380 oracle (its
-        providers are mutually-non-calling) confirms the gate is a no-op on the
-        current shape. NOTE: a single fixture combining a real cross-component
-        call WITH the --share-stack markers is not built (it needs component-model
-        composition machinery); the adapter-site → gate wiring is covered by the
-        method-level tests plus the existing adapter-site tests rather than one
-        end-to-end fixture.
+        → Ok (warn); AND (Mythos SR-67 Finding 1 regressions) an intra-component
+        CROSS-module cycle → Err and an intra-component cross-module DAG over the
+        region → warn — the per-module granularity the old per-component gate
+        missed. A local Mythos delta-pass confirmed the pure graph engine sound
+        against missed-cycle / undercounted-path attacks, and found the
+        per-component granularity gap (the shared stack is per-module: two modules
+        in one component that call each other share the region); fixed by keying
+        nodes on (component, module) and adding function-kind module_resolutions
+        edges. The share_stack_380 oracle (mutually-non-calling providers) confirms
+        the gate is a no-op on the current shape.
+        NOTE (coverage): a single fixture combining a real cross-component call
+        WITH the --share-stack markers is not built (needs component-model
+        composition machinery); the adapter-site/module_resolutions → gate wiring
+        is covered by the method-level tests plus the existing adapter-site tests
+        rather than one end-to-end fixture.
+        KNOWN GAP (Mythos Finding 3, unconfirmed): a standalone resource-DESTRUCTOR
+        call routed via handle tables rather than an adapter site would not appear
+        as an edge; narrow for the scalar MCU driver shape (no resources),
+        documented rather than claimed-covered.
       references:
         - "https://github.com/pulseengine/meld/issues/382"
         - "meld-core/src/merger/memory.rs"

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2784,3 +2784,75 @@ artifacts:
       references:
         - "https://github.com/pulseengine/meld/issues/380"
         - "meld-core/tests/share_stack_380.rs"
+
+  - id: SR-67
+    type: sw-req
+    title: Shared-stack call-topology envelope gate (--share-stack, SR-67)
+    description: >
+      Under `--share-stack` (SR-66) the shared shadow-stack region is sized
+      `max_i(sp_i)`, which is sound only while at most one provider's stack is
+      live — i.e. the fused providers are mutually-non-calling. A fused
+      cross-component function call makes a caller live while its callee runs, so
+      the live requirement along a call chain is the SUM of the participants'
+      stacks, not the max. meld shall analyse the fused-set call graph (nodes =
+      components, edges = `AdapterSite`s with `from_component != to_component` —
+      every internalized cross-component function call, including resource-op and
+      async-lift calls, which still execute callee code and keep the caller stack
+      live) and, weighting each node by its `sp_i`:
+        (a) NO cross-component edges → the region is sound; proceed silently
+            (the current gale/F100 shape).
+        (b) an ACYCLIC call graph (an orchestrator DAG) whose worst root-to-leaf
+            `sp`-sum EXCEEDS the region → `log::warn!`, naming the chain, the
+            required sum, and the region (the region may be undersized but
+            boundedly; the integrator judges it against real per-stage stack
+            bounds). If the worst chain still fits the region, proceed silently
+            (max-sizing already covers it).
+        (c) a call CYCLE (A→…→A, or recursion through a sibling) → the live
+            depth is unbounded → HARD-FAIL (the same loud-refusal posture as
+            SR-66's other gates), naming the cycle.
+      This is the mechanical form of the self-check the falcon supplier (fathom)
+      proposed on #370 ("a seam that vanishes from the residual imports is a
+      component now calling a sibling"): meld sees the internalized call directly
+      (the merger resolves each cross-component import to its export target),
+      more precisely than an external undefined-symbol diff. A blanket refuse on
+      ANY edge was rejected — it would break the natural orchestrator
+      composition, which is sound at `max_i(orchestrator + driver_i)`; the
+      three-way disposition distinguishes it from unbounded recursion.
+    status: implemented
+    tags: [merger, memory, shared, mcu, share-stack, shadow-stack, call-graph]
+    release: v0.49.0
+    links:
+      - type: derives-from
+        target: SYS-6
+      - type: mitigates
+        target: LS-M-12
+      - type: refines
+        target: SR-66
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/382"
+        kind: github
+        last-checked: 2026-08-14
+    fields:
+      implementation:
+        - meld-core/src/merger/memory.rs
+      verification-method: test
+      verification-description: >
+        Verified by meld-core/src/merger/memory.rs::topology_tests (12 tests).
+        The pure graph analysis analyze_call_topology is covered by 7 unit tests:
+        no-edges → NoEdges; chain/fanout/diamond → the correct worst weighted
+        (sp-sum) path; a 2-cycle and a cycle-with-a-DAG-prefix → Cyclic. The gate
+        method check_share_stack_call_topology is covered by 5 method-level tests
+        on a constructed DependencyGraph: no cross-component sites → Ok; intra-
+        component self-edges (from == to) ignored → Ok; a call cycle → Err naming
+        the cycle; a DAG that fits the region → Ok (silent); a DAG that exceeds it
+        → Ok (warn). The end-to-end adapter-site construction is exercised by the
+        existing cross-component adapter tests; the share_stack_380 oracle (its
+        providers are mutually-non-calling) confirms the gate is a no-op on the
+        current shape. NOTE: a single fixture combining a real cross-component
+        call WITH the --share-stack markers is not built (it needs component-model
+        composition machinery); the adapter-site → gate wiring is covered by the
+        method-level tests plus the existing adapter-site tests rather than one
+        end-to-end fixture.
+      references:
+        - "https://github.com/pulseengine/meld/issues/382"
+        - "meld-core/src/merger/memory.rs"

--- a/safety/requirements/sw-verifications.yaml
+++ b/safety/requirements/sw-verifications.yaml
@@ -1162,18 +1162,21 @@ artifacts:
     type: sw-verification
     title: "Verification of SR-67: --share-stack call-topology envelope gate"
     description: >
-      Verifies SR-67 via meld-core/src/merger/memory.rs::topology_tests (12
+      Verifies SR-67 via meld-core/src/merger/memory.rs::topology_tests (14
       tests). Pure analysis analyze_call_topology (7): no-edges → NoEdges;
       chain/fanout/diamond → correct worst weighted (sp-sum) path; 2-cycle and
       cycle-after-a-DAG-prefix → Cyclic. Gate method
-      check_share_stack_call_topology (5, on a constructed DependencyGraph): no
-      cross-component sites → Ok; intra-component self-edges (from == to) ignored
-      → Ok; call cycle → Err naming the cycle; DAG that fits the region → Ok
-      (silent); DAG that exceeds it → Ok (warn). The share_stack_380 oracle
-      (mutually-non-calling providers) confirms the gate is a no-op on the current
-      gale shape. Mechanical form of fathom's #370 residual-import self-check;
-      three-way (pass / warn-DAG / fail-cycle) rather than a blanket refuse so the
-      orchestrator composition is not broken.
+      check_share_stack_call_topology (7, on a constructed DependencyGraph): no
+      cross-component sites → Ok; intra-component SAME-module self-edges ignored
+      → Ok; call cycle → Err; DAG that fits the region → Ok (silent); DAG that
+      exceeds it → Ok (warn); plus the Mythos Finding-1 regressions — an intra-
+      component CROSS-module cycle → Err and cross-module DAG over region → warn
+      (per-(component,module) nodes + function-kind module_resolutions edges, the
+      granularity the old per-component gate missed). Local Mythos confirmed the
+      pure engine sound vs missed-cycle/undercount and found the granularity gap.
+      share_stack_380 oracle (mutually-non-calling) confirms the gate is a no-op
+      on the gale shape. Three-way (pass / warn-DAG / fail-cycle), not a blanket
+      refuse, so the orchestrator composition is not broken.
     status: implemented
     fields:
       method: automated-test

--- a/safety/requirements/sw-verifications.yaml
+++ b/safety/requirements/sw-verifications.yaml
@@ -1157,3 +1157,26 @@ artifacts:
     links:
       - type: verifies
         target: SR-66
+
+  - id: SWV-79
+    type: sw-verification
+    title: "Verification of SR-67: --share-stack call-topology envelope gate"
+    description: >
+      Verifies SR-67 via meld-core/src/merger/memory.rs::topology_tests (12
+      tests). Pure analysis analyze_call_topology (7): no-edges → NoEdges;
+      chain/fanout/diamond → correct worst weighted (sp-sum) path; 2-cycle and
+      cycle-after-a-DAG-prefix → Cyclic. Gate method
+      check_share_stack_call_topology (5, on a constructed DependencyGraph): no
+      cross-component sites → Ok; intra-component self-edges (from == to) ignored
+      → Ok; call cycle → Err naming the cycle; DAG that fits the region → Ok
+      (silent); DAG that exceeds it → Ok (warn). The share_stack_380 oracle
+      (mutually-non-calling providers) confirms the gate is a no-op on the current
+      gale shape. Mechanical form of fathom's #370 residual-import self-check;
+      three-way (pass / warn-DAG / fail-cycle) rather than a blanket refuse so the
+      orchestrator composition is not broken.
+    status: implemented
+    fields:
+      method: automated-test
+    links:
+      - type: verifies
+        target: SR-67


### PR DESCRIPTION
## What

Adds SR-67: the `--share-stack` call-topology envelope gate (#382). Follow-up to
#380/SR-66, implementing the self-check fathom (gale) proposed on #370.

`--share-stack` sizes the shared shadow-stack region as `max_i(sp_i)` — sound
only while at most one provider's stack is live, i.e. the providers are
**mutually-non-calling**. A fused cross-component call makes a caller live while
its callee runs, so a call chain needs the **sum** of stacks, not the max. This
gate detects that.

## The three-way disposition (not a blanket refuse)

Building the fused-set call graph (nodes = components, edges = `AdapterSite`s
with `from_component != to_component`, weight = `sp_i`):

- **no edges** → mutually-non-calling; region is sound → proceed silently (the
  current gale/F100 shape)
- **acyclic DAG**, worst root-to-leaf `sp`-sum **≤ region** → max-sizing already
  covers the deepest chain → silent
- **acyclic DAG**, worst sum **> region** → `log::warn` naming the chain, the
  required sum, and the region (bounded undersize — the integrator judges it
  against real stack bounds)
- **a call cycle** → unbounded live stack → **hard-fail**

A blanket "any edge → refuse" was rejected (see the #382 thread): it would break
the natural orchestrator composition, which is sound at
`max_i(orchestrator + driver_i)`. Only a cycle is genuinely unbounded.

## Why meld can do this better than the external heuristic

fathom's check was "a seam that vanishes from the residual imports is a component
now calling a sibling." meld sees the internalized call **directly** — the merger
resolves each cross-component import to its export target (`AdapterSite`) — so it
doesn't need to diff undefined-symbol sets. All cross-component edges count,
including resource-op and async-lift calls (they still execute callee code and
keep the caller's suspended stack live).

## Verification

`analyze_call_topology` is a **pure, deterministic** function (iterative-DFS
cycle detection + longest weighted path). 12 tests in `topology_tests`:
- 7 pure: no-edges, chain, fanout, diamond (longest route), 2-cycle,
  cycle-after-a-DAG-prefix, isolated-max-node
- 5 method-level on a constructed `DependencyGraph`: no-calls → Ok, self-edges
  ignored → Ok, cycle → Err, DAG-fits → Ok, DAG-exceeds → Ok (warn)

`share_stack_380` oracle unregressed (its providers are mutually-non-calling → the
gate is a no-op). Full suite **848/0**, clippy `--all-targets -D warnings` clean,
rivet SR-67/SWV-79.

**Honest coverage note:** a single fixture combining a real cross-component call
*with* the `--share-stack` markers is not built (it needs component-model
composition machinery); the adapter-site → gate wiring is covered by the
method-level tests plus the existing adapter-site construction tests, not one
end-to-end fixture.

Tier-5 → local Mythos delta-pass (focused on false-pass: missed cycle /
undercounted path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
