### PR TITLE
feat(SR-70): attest per-module memory placement (ADR-7 P1 increment 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-08-19
+
+### Added
+- **Per-module memory placement is attested and observable (SR-70, ADR-7)** —
+  meld now records, for each module it places into a fused address space, where
+  it landed (`base`), how much was reserved for it (`reserved`), and **by which
+  rule**: `packed` (SR-57 used-extent compaction), `shared-stack` (SR-66) or
+  `page-granular`. The records are carried in the fusion attestation and printed
+  by `meld fuse --explain`. Together with the per-boundary call records added in
+  v0.51.0, this completes ADR-7's requirement that each fused strategy be
+  declared, attested and observable — on both the call and the memory axis.
+
+  **The rule reported is the one that actually applied, not the one requested.**
+  This matters for a case that was previously invisible: a module fused under
+  `--pack-rebase` that cannot be compacted — because it publishes no
+  authoritative `__heap_base` marker, or holds a passive/no-data region whose
+  used extent cannot be measured (SR-65) — falls back to a page-granular stride.
+  That fallback is sound, but until now a caller could request a compact
+  single-address-space layout, receive full 64 KiB pages per module, and have no
+  way to observe it from the artifact. This is not hypothetical: the marker was
+  verified absent on published falcon 1.133.0 artifacts, so a supplier rebuild
+  that drops it silently costs the compaction an MCU image depends on. Now both
+  `--explain` and the attestation say `page-granular`, per module.
+
+  Under `--memory multi` no placement records are produced: each module keeps its
+  own memory, so there is no placement decision to record, and the attested
+  `memory_strategy` already states which isolation model is in force.
+
+Fusion behaviour is unchanged — the records are observation only, and like the
+rest of the attestation they sit outside the bytes covered by the artifact hash.
+
 ## [0.51.0] - 2026-08-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.51.0"
+version = "0.52.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/meld-cli/src/main.rs
+++ b/meld-cli/src/main.rs
@@ -677,6 +677,36 @@ fn print_boundaries(stats: &FusionStats) {
         asynch,
         inlined
     );
+
+    print_placements(stats);
+}
+
+/// SR-70: the memory-axis half of `--explain` — where each module landed in the
+/// fused address space and by which rule.
+fn print_placements(stats: &FusionStats) {
+    if stats.placements.is_empty() {
+        // Not an omission: under `--memory multi` each module keeps its own
+        // memory, so there is no placement decision to report.
+        return;
+    }
+    println!();
+    println!("Memory placement");
+    println!("{}", "=".repeat(50));
+    println!();
+    let mut total = 0u64;
+    for p in &stats.placements {
+        println!(
+            "  c{}m{}  base {:>10}  reserved {:>10} B  ({})",
+            p.component, p.module, p.base, p.reserved, p.strategy
+        );
+        total += p.reserved;
+    }
+    println!();
+    println!(
+        "  {} modules placed, {} B reserved in total",
+        stats.placements.len(),
+        total
+    );
 }
 
 fn print_stats(stats: &FusionStats, total_input_size: usize, elapsed: std::time::Duration) {

--- a/meld-core/src/adapter/fact.rs
+++ b/meld-core/src/adapter/fact.rs
@@ -13083,6 +13083,7 @@ mod tests {
             async_result_globals: std::collections::HashMap::new(),
             segment_bases: std::collections::HashMap::new(),
             shared_stack_top: None,
+            placements: Vec::new(),
         }
     }
 

--- a/meld-core/src/attestation.rs
+++ b/meld-core/src/attestation.rs
@@ -180,6 +180,14 @@ pub struct FusionMetadata {
     /// deserialize.
     #[serde(default)]
     pub boundaries: Vec<crate::BoundaryRecord>,
+
+    /// SR-70: per-module memory placement — where each module landed in the
+    /// fused address space and by which rule (`page-granular` / `packed` /
+    /// `shared-stack`). The memory-axis twin of `boundaries`. Empty under
+    /// `--memory multi`, where each module keeps its own memory and there is no
+    /// placement decision to record.
+    #[serde(default)]
+    pub placements: Vec<crate::PlacementRecord>,
 }
 
 /// Builder for creating fusion attestations
@@ -339,6 +347,7 @@ impl FusionAttestationBuilder {
                 size_reduction_percent: size_reduction,
                 parameters: self.parameters,
                 boundaries: stats.boundaries.clone(),
+                placements: stats.placements.clone(),
             },
         }
     }

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -378,6 +378,30 @@ pub struct BoundaryRecord {
     pub crosses_memory: bool,
 }
 
+/// Where ONE module's memory landed in the fused address space, and by which
+/// rule (ADR-7 / SR-70). The memory-axis twin of [`BoundaryRecord`]: together
+/// they make "strategy declared, attested, observable" concrete for both the
+/// call axis and the memory axis.
+///
+/// Only produced on the rebasing (`--memory shared`) path, where a placement
+/// decision actually exists. Under `--memory multi` each module keeps its own
+/// memory and nothing is placed — the attested `memory_strategy` says so.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PlacementRecord {
+    pub component: usize,
+    pub module: usize,
+    /// `page-granular`, `packed` (SR-57 used-extent compaction) or
+    /// `shared-stack` (SR-66). A `--pack-rebase` module that DECLINED to pack —
+    /// no `__heap_base` marker, or a passive/no-data region — is honestly
+    /// reported as `page-granular`, which is what actually happened and exactly
+    /// what an auditor needs to see.
+    pub strategy: String,
+    /// Byte offset this module's addresses were shifted by.
+    pub base: u64,
+    /// Bytes reserved for this module (its stride in the fused memory).
+    pub reserved: u64,
+}
+
 /// Statistics about the fusion process
 #[derive(Debug, Clone, Default)]
 pub struct FusionStats {
@@ -424,6 +448,11 @@ pub struct FusionStats {
     /// it does not perturb the artifact hash) and printed by `meld fuse
     /// --explain`.
     pub boundaries: Vec<BoundaryRecord>,
+
+    /// ADR-7 / SR-70: per-module memory placement, on the rebasing path. Empty
+    /// under `--memory multi`, where each module keeps its own memory and there
+    /// is no placement decision to record.
+    pub placements: Vec<PlacementRecord>,
 }
 
 /// Main fuser interface for static component fusion
@@ -966,6 +995,8 @@ impl Fuser {
                 .retain(|e| !memory_probe::is_vestigial_realloc_export_name(&e.name));
         }
         stats.total_functions = merged.functions.len();
+        // SR-70: carry the per-module placement decisions out for attestation.
+        stats.placements = merged.placements.clone();
         stats.total_exports = merged.exports.len();
 
         // Step 2.4: Lower P3 async canonical built-ins to `pulseengine:async`
@@ -2417,6 +2448,10 @@ impl Fuser {
         metadata.insert(
             "boundaries".to_string(),
             serde_json::json!(stats.boundaries),
+        );
+        metadata.insert(
+            "placements".to_string(),
+            serde_json::json!(stats.placements),
         );
         let size_reduction = if stats.input_size > 0 {
             ((stats.input_size as f64 - stats.output_size as f64) / stats.input_size as f64) * 100.0

--- a/meld-core/src/merger/memory.rs
+++ b/meld-core/src/merger/memory.rs
@@ -3,6 +3,22 @@
 
 use super::*;
 
+/// SR-70 / ADR-7: where one module's memory was placed in the fused address
+/// space, and by which rule. The memory-axis twin of `BoundaryRecord` (which
+/// covers the call axis) — together they make ADR-7's "strategy declared,
+/// attested, observable" concrete for both.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlacementEntry {
+    pub(crate) component: usize,
+    pub(crate) module: usize,
+    /// `page-granular`, `packed` (SR-57 used-extent) or `shared-stack` (SR-66).
+    pub(crate) strategy: &'static str,
+    /// Byte offset this module's addresses were shifted by.
+    pub(crate) base: u64,
+    /// Bytes reserved for it (its stride).
+    pub(crate) reserved: u64,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct SharedMemoryPlan {
     pub(crate) memory: EncoderMemoryType,
@@ -11,6 +27,9 @@ pub(crate) struct SharedMemoryPlan {
     /// SR-66 / #380: top of the single shared shadow-stack region under
     /// `--share-stack` (`max_i(sp_i)`). `None` when `--share-stack` is off.
     pub(crate) shared_stack_top: Option<u64>,
+    /// SR-70: per-module placement, in assignment order (deterministic — the
+    /// modules are visited in component/module index order).
+    pub(crate) placements: Vec<PlacementEntry>,
 }
 
 impl Merger {
@@ -87,6 +106,7 @@ impl Merger {
         };
 
         let mut bases = HashMap::new();
+        let mut placements: Vec<PlacementEntry> = Vec::new();
         let mut shared_stack_top: Option<u64> = None;
         // 16-byte alignment keeps `v128` accesses aligned after the uniform
         // `+base` shift (shared by the pack and share-stack strides below).
@@ -122,6 +142,13 @@ impl Merger {
                 let stride = (extent - sp)
                     .checked_next_multiple_of(PACK_ALIGN)
                     .ok_or_else(overflow)?;
+                placements.push(PlacementEntry {
+                    component: key.0,
+                    module: key.1,
+                    strategy: "shared-stack",
+                    base,
+                    reserved: stride,
+                });
                 next_base = next_base.checked_add(stride).ok_or_else(overflow)?;
             }
             combined.initial = next_base.div_ceil(WASM_PAGE_SIZE).max(1);
@@ -153,15 +180,32 @@ impl Merger {
                 // Stride: packed extent when available, else the declared page
                 // count (the fallback also covers a module whose data offsets
                 // are non-constant and therefore cannot be safely packed).
-                let stride = match (self.pack_rebase, extent) {
-                    (true, Some(bytes)) => (*bytes)
-                        .checked_next_multiple_of(PACK_ALIGN)
-                        .ok_or_else(overflow)?,
-                    _ => module_memory
-                        .initial
-                        .checked_mul(WASM_PAGE_SIZE)
-                        .ok_or_else(overflow)?,
+                let (stride, strategy) = match (self.pack_rebase, extent) {
+                    (true, Some(bytes)) => (
+                        (*bytes)
+                            .checked_next_multiple_of(PACK_ALIGN)
+                            .ok_or_else(overflow)?,
+                        "packed",
+                    ),
+                    // Also the honest label for a `--pack-rebase` module that
+                    // DECLINED to pack (no `__heap_base` marker, or a
+                    // passive/no-data region): it really is page-granular, and
+                    // that fallback is exactly what an auditor wants to see.
+                    _ => (
+                        module_memory
+                            .initial
+                            .checked_mul(WASM_PAGE_SIZE)
+                            .ok_or_else(overflow)?,
+                        "page-granular",
+                    ),
                 };
+                placements.push(PlacementEntry {
+                    component: key.0,
+                    module: key.1,
+                    strategy,
+                    base: base_bytes,
+                    reserved: stride,
+                });
                 next_base = next_base.checked_add(stride).ok_or_else(overflow)?;
             }
 
@@ -182,6 +226,7 @@ impl Merger {
             import,
             bases,
             shared_stack_top,
+            placements,
         }))
     }
 

--- a/meld-core/src/merger/mod.rs
+++ b/meld-core/src/merger/mod.rs
@@ -217,6 +217,11 @@ pub struct MergedModule {
     /// onto one survivor initialised to this value (regardless of the providers'
     /// original inits).
     pub shared_stack_top: Option<u64>,
+
+    /// SR-70: per-module memory placement chosen by the shared-memory plan
+    /// (`(component, module, strategy, base, reserved)`), carried out of the
+    /// merger so it can be attested. Empty when not rebasing.
+    pub placements: Vec<crate::PlacementRecord>,
 }
 
 /// Info about a generated task.return shim function.
@@ -504,6 +509,7 @@ impl Merger {
             async_result_globals: HashMap::new(),
             segment_bases: HashMap::new(),
             shared_stack_top: None,
+            placements: Vec::new(),
         };
 
         // Process components in topological order
@@ -775,6 +781,17 @@ impl Merger {
 
         if let Some(plan) = shared_memory_plan {
             merged.shared_stack_top = plan.shared_stack_top;
+            merged.placements = plan
+                .placements
+                .iter()
+                .map(|p| crate::PlacementRecord {
+                    component: p.component,
+                    module: p.module,
+                    strategy: p.strategy.to_string(),
+                    base: p.base,
+                    reserved: p.reserved,
+                })
+                .collect();
             if plan.import.is_none() {
                 merged.memories.clear();
                 merged.memories.push(plan.memory);

--- a/meld-core/src/merger/tests_a.rs
+++ b/meld-core/src/merger/tests_a.rs
@@ -168,6 +168,7 @@ fn test_multi_memory_index_maps() {
         async_result_globals: HashMap::new(),
         segment_bases: HashMap::new(),
         shared_stack_top: None,
+        placements: Vec::new(),
     };
 
     // Simulate multi-memory merging for module A (comp 0, mod 0)

--- a/meld-core/src/merger/tests_b.rs
+++ b/meld-core/src/merger/tests_b.rs
@@ -996,6 +996,7 @@ fn empty_merged_fixture() -> MergedModule {
         async_result_globals: std::collections::HashMap::new(),
         segment_bases: std::collections::HashMap::new(),
         shared_stack_top: None,
+        placements: Vec::new(),
     }
 }
 

--- a/meld-core/tests/mcu_dissolve.rs
+++ b/meld-core/tests/mcu_dissolve.rs
@@ -122,6 +122,7 @@ fn merged_base() -> MergedModule {
         async_result_globals: HashMap::new(),
         segment_bases: HashMap::new(),
         shared_stack_top: None,
+        placements: Vec::new(),
     }
 }
 

--- a/meld-core/tests/placement_records_p1.rs
+++ b/meld-core/tests/placement_records_p1.rs
@@ -1,0 +1,212 @@
+//! ADR-7 P1 increment 2 (SR-70) — per-module memory placement is attested and
+//! observable: where each module landed in the fused address space, and by which
+//! rule.
+//!
+//! This is the memory-axis twin of the boundary records. It matters most for the
+//! case it makes visible: under `--pack-rebase` a module that cannot be compacted
+//! (no `__heap_base` marker, or a passive/no-data region) silently falls back to
+//! a page-granular stride. That fallback is sound but invisible — a user asking
+//! for compaction could get none and never know. The placement record reports the
+//! rule that actually applied, per module.
+//!
+//! Pinned here:
+//!   1. `--pack-rebase` with markers → `packed`, with a compact reservation;
+//!   2. the same shape WITHOUT markers → `page-granular` (the honest label for
+//!      the declined-compaction fallback), reserving a full page;
+//!   3. records reach the artifact's attestation;
+//!   4. `--memory multi` records none (there is no placement decision to make).
+
+use meld_core::{Fuser, FuserConfig, MemoryStrategy};
+use wasm_encoder::{
+    CodeSection, Component, ConstExpr, DataSection, DataSegment, DataSegmentMode, ExportKind,
+    ExportSection, Function, FunctionSection, GlobalSection, GlobalType, Instruction,
+    MemorySection, MemoryType, Module, ModuleSection, TypeSection, ValType,
+};
+
+const DATA_ADDR: i32 = 0x100;
+
+fn shared_memory_section() -> MemorySection {
+    let mut memory = MemorySection::new();
+    memory.memory(MemoryType {
+        minimum: 1,
+        maximum: Some(2),
+        memory64: false,
+        shared: true,
+        page_size_log2: None,
+    });
+    memory
+}
+
+/// A thin provider. `with_marker` decides whether it publishes the
+/// `__heap_base` marker that licenses compaction (SR-65).
+fn build_provider(tag: &str, sentinel: u8, export_memory: bool, with_marker: bool) -> Vec<u8> {
+    let mut types = TypeSection::new();
+    types.ty().function([], [ValType::I32]);
+
+    let mut functions = FunctionSection::new();
+    functions.function(0);
+
+    let mut globals = GlobalSection::new();
+    if with_marker {
+        globals.global(
+            GlobalType {
+                val_type: ValType::I32,
+                mutable: false,
+                shared: false,
+            },
+            &ConstExpr::i32_const(DATA_ADDR + 1),
+        );
+    }
+
+    let mut exports = ExportSection::new();
+    exports.export(&format!("read_{tag}"), ExportKind::Func, 0);
+    if with_marker {
+        exports.export("__heap_base", ExportKind::Global, 0);
+    }
+    if export_memory {
+        exports.export("memory", ExportKind::Memory, 0);
+    }
+
+    // Deliberately NO memory access: a no-reloc module that does a direct
+    // load/store is (correctly) rejected by the path-F gate, and placement is
+    // decided from the module's memory + data segments, not from its code.
+    let mut code = CodeSection::new();
+    let mut read = Function::new([]);
+    read.instruction(&Instruction::I32Const(DATA_ADDR));
+    read.instruction(&Instruction::End);
+    code.function(&read);
+
+    let mut data = DataSection::new();
+    data.segment(DataSegment {
+        mode: DataSegmentMode::Active {
+            memory_index: 0,
+            offset: &ConstExpr::i32_const(DATA_ADDR),
+        },
+        data: [sentinel],
+    });
+
+    let mut module = Module::new();
+    module.section(&types).section(&functions);
+    module.section(&shared_memory_section());
+    module.section(&globals).section(&exports).section(&code);
+    module.section(&data);
+
+    let mut component = Component::new();
+    component.section(&ModuleSection(&module));
+    component.finish()
+}
+
+fn fuse(
+    with_marker: bool,
+    memory_strategy: MemoryStrategy,
+    pack_rebase: bool,
+) -> (Vec<u8>, meld_core::FusionStats) {
+    let config = FuserConfig {
+        memory_strategy,
+        address_rebasing: memory_strategy == MemoryStrategy::SharedMemory && !pack_rebase,
+        pack_rebase,
+        reproducible: true,
+        ..Default::default()
+    };
+    let mut fuser = Fuser::new(config);
+    fuser
+        .add_component_named(
+            &build_provider("a", 0xA1, true, with_marker),
+            Some("comp-a"),
+        )
+        .unwrap();
+    fuser
+        .add_component_named(
+            &build_provider("b", 0xB2, false, with_marker),
+            Some("comp-b"),
+        )
+        .unwrap();
+    fuser.fuse_with_stats().expect("fusion")
+}
+
+#[test]
+fn pack_rebase_with_markers_reports_packed_placement() {
+    let (_out, stats) = fuse(true, MemoryStrategy::SharedMemory, true);
+    assert_eq!(stats.placements.len(), 2, "both modules placed");
+    for p in &stats.placements {
+        assert_eq!(
+            p.strategy, "packed",
+            "a marker-carrying module under --pack-rebase must report `packed`: {p:?}"
+        );
+        assert!(
+            p.reserved < 65536,
+            "packed reservation must be compact, got {} bytes",
+            p.reserved
+        );
+    }
+    // Bases must be distinct and ascending — the placements describe a real,
+    // non-overlapping layout.
+    assert!(
+        stats.placements[0].base < stats.placements[1].base,
+        "placements must describe distinct ascending bases: {:?}",
+        stats.placements
+    );
+}
+
+#[test]
+fn pack_rebase_without_markers_reports_the_page_granular_fallback() {
+    // The case this record exists for: `--pack-rebase` was REQUESTED, but with
+    // no `__heap_base` marker meld cannot compact and silently strides
+    // page-granular (SR-65). Sound, but previously invisible — a user could ask
+    // for compaction, receive none, and have no way to see it.
+    let (_out, stats) = fuse(false, MemoryStrategy::SharedMemory, true);
+    assert_eq!(stats.placements.len(), 2, "both modules placed");
+    for p in &stats.placements {
+        assert_eq!(
+            p.strategy, "page-granular",
+            "declined compaction must be reported honestly as page-granular: {p:?}"
+        );
+        assert_eq!(
+            p.reserved, 65536,
+            "the fallback reserves a full page, got {}",
+            p.reserved
+        );
+    }
+}
+
+#[test]
+fn placement_records_reach_the_attestation() {
+    let (out, stats) = fuse(true, MemoryStrategy::SharedMemory, true);
+    assert!(!stats.placements.is_empty());
+
+    let mut attestation_json: Option<String> = None;
+    for payload in wasmparser::Parser::new(0).parse_all(&out) {
+        if let wasmparser::Payload::CustomSection(reader) = payload.expect("payload")
+            && reader.name() == "wsc.transformation.attestation"
+        {
+            attestation_json = Some(String::from_utf8_lossy(reader.data()).into_owned());
+        }
+    }
+    let json = attestation_json.expect("artifact carries an attestation");
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+    let placements = parsed
+        .get("metadata")
+        .and_then(|m| m.get("placements"))
+        .and_then(|p| p.as_array())
+        .expect("attestation records placements");
+    assert_eq!(placements.len(), stats.placements.len());
+    for key in ["component", "module", "strategy", "base", "reserved"] {
+        assert!(
+            placements[0].get(key).is_some(),
+            "attested placement must carry `{key}`: {}",
+            placements[0]
+        );
+    }
+}
+
+#[test]
+fn multi_memory_records_no_placement() {
+    // Not an omission: with one memory per component nothing is placed, and the
+    // attested `memory_strategy` already says which model is in force.
+    let (_out, stats) = fuse(true, MemoryStrategy::MultiMemory, false);
+    assert!(
+        stats.placements.is_empty(),
+        "multi-memory has no placement decision to record, got {:?}",
+        stats.placements
+    );
+}

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -3002,3 +3002,63 @@ artifacts:
       references:
         - "https://github.com/pulseengine/meld/issues/386"
         - "meld-core/tests/boundary_records_p1.rs"
+
+  - id: SR-70
+    type: sw-req
+    title: Per-module memory placement is attested and observable
+    description: >
+      Completing ADR-7's "strategy declared, attested, observable" on the MEMORY
+      axis (SR-69 covered the call axis), meld shall record, for each module it
+      places into a fused address space, WHERE it landed (`base`), how much was
+      reserved for it (`reserved`), and BY WHICH RULE: `packed` (SR-57
+      used-extent compaction), `shared-stack` (SR-66) or `page-granular`.
+      The rule label shall report what ACTUALLY applied, not what was requested.
+      In particular, a module fused under `--pack-rebase` that cannot be
+      compacted — no authoritative `__heap_base` marker, or a passive/no-data
+      region whose used extent is invisible (SR-65) — falls back to a
+      page-granular stride, and shall be reported as `page-granular`. That
+      fallback is sound but was previously INVISIBLE: a caller could request a
+      compact single-address-space layout, receive full pages, and have no way to
+      observe it from the artifact.
+      Records shall be emitted in module-visit order (component then module
+      index), which is deterministic, and carried in the fusion attestation as
+      well as printed by `meld fuse --explain`. Under `--memory multi` no
+      placement records are produced — each module keeps its own memory and there
+      is no placement decision to record; the attested `memory_strategy` already
+      states which isolation model is in force.
+    status: implemented
+    tags: [attestation, adr-7, traceability, observability, memory, placement]
+    release: v0.52.0
+    links:
+      - type: derives-from
+        target: SYS-6
+      - type: refines
+        target: SR-69
+      - type: refines
+        target: SR-57
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/386"
+        kind: github
+        last-checked: 2026-08-19
+    fields:
+      implementation:
+        - meld-core/src/merger/memory.rs
+        - meld-core/src/lib.rs
+        - meld-cli/src/main.rs
+      verification-method: test
+      verification-description: >
+        Verified by meld-core/tests/placement_records_p1.rs (4 tests):
+        pack_rebase_with_markers_reports_packed_placement (marker-carrying
+        modules report `packed` with a sub-page reservation, at distinct
+        ascending bases — i.e. the records describe a real non-overlapping
+        layout); pack_rebase_without_markers_reports_the_page_granular_fallback
+        (the same shape WITHOUT markers reports `page-granular` reserving exactly
+        65536 B — pinning that a declined compaction is reported honestly rather
+        than as the requested strategy); placement_records_reach_the_attestation
+        (records recovered from the artifact's attestation custom section with
+        every expected key); and multi_memory_records_no_placement (no records
+        where there is no placement decision). Both feature configurations green
+        (`--workspace` 862/0, `--all-features` 861/0).
+      references:
+        - "https://github.com/pulseengine/meld/issues/386"
+        - "meld-core/tests/placement_records_p1.rs"

--- a/safety/requirements/sw-verifications.yaml
+++ b/safety/requirements/sw-verifications.yaml
@@ -1221,3 +1221,21 @@ artifacts:
     links:
       - type: verifies
         target: SR-69
+
+  - id: SWV-82
+    type: sw-verification
+    title: "Verification of SR-70: per-module placement attestation"
+    description: >
+      Verifies SR-70 via meld-core/tests/placement_records_p1.rs (4 tests):
+      markers → `packed` with compact sub-page reservations at distinct ascending
+      bases; no markers under --pack-rebase → `page-granular` at exactly 65536 B
+      (the declined-compaction fallback reported honestly, which is the case this
+      record exists for); records recovered from the artifact's attestation
+      section; and no records under --memory multi, where no placement decision
+      exists. Both feature configurations green.
+    status: implemented
+    fields:
+      method: automated-test
+    links:
+      - type: verifies
+        target: SR-70


### PR DESCRIPTION
Completes ADR-7's "strategy **declared, attested, observable**" on the **memory**
axis. SR-69 (v0.51.0) covered the **call** axis.

## What it records

Per placed module: where it landed (`base`), how much was reserved (`reserved`),
and **by which rule** — `packed` (SR-57 used-extent compaction), `shared-stack`
(SR-66) or `page-granular`. In the fusion attestation and via `meld fuse --explain`:

```
Memory placement
==================================================

  c0m0  base          0  reserved      65536 B  (page-granular)
  c2m0  base      65536  reserved      65536 B  (page-granular)

  2 modules placed, 131072 B reserved in total
```

## Why it matters — the label reports what ACTUALLY applied

That output is from a **`--pack-rebase`** run. Compaction was requested and
silently didn't happen: neither module publishes a `__heap_base` marker, so SR-65's
sound fallback took over. Previously invisible — you could ask for a compact MCU
layout, receive full pages, and have no way to see it from the artifact.

A test pins **both** directions: markers → `packed` with a sub-page reservation at
distinct ascending bases (i.e. the records describe a real non-overlapping layout);
no markers → `page-granular` at exactly 65536 B.

## Implementation note

`SharedMemoryPlan.bases` was discarded when `Merger::merge` returned. The plan now
builds typed placement entries where the decision is made and carries them out via
`MergedModule` → `FusionStats` → both attestation paths (they are hand-duplicated,
so both were updated).

Under `--memory multi` no records are produced — each module keeps its own memory
and there is no placement decision; the attested `memory_strategy` already says
which isolation model is in force.

## Verification

rivet **SR-70 + SWV-82** (PASS). fmt 0, clippy `--workspace --all-targets -D
warnings` 0, tests `--workspace` **862/0** and `--all-features` **861/0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)