### PR TITLE
ci: enforce the release-readiness query, and mechanize the tag guardrail

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,148 @@
+name: Release readiness
+
+# AGENTS.md marks the rivet release-readiness query MANDATORY before a tag:
+# a release is cuttable only when every artifact scoped to it is `verified`
+# or `accepted`. Nothing ran it. v0.51.0 and v0.52.0 were both tagged and
+# published while `rivet release status` still exited 1 for their own scope
+# (SR-69 and SR-70 were never moved off `implemented`). The work was done —
+# SWV-81 and SWV-82 exist and pass — but a MANDATORY gate that no machine
+# runs is a gate that cannot fail, and it did not.
+#
+# WHEN this fires, and why not simply "at release time":
+#
+#   * PR carrying a version bump — the PRIMARY gate. This repo lands the
+#     version bump inside the feature PR, so a PR whose workspace version
+#     differs from main's IS the release PR. That is the earliest honest
+#     "I am releasing" signal, and the last moment where a red gate costs
+#     nothing to fix.
+#   * tag push — the BACKSTOP, for two distinct holes the PR gate cannot
+#     cover: a tag pushed on a commit that never went through a bump PR,
+#     and an artifact scoped to the release that lands AFTER the bump PR
+#     merged but BEFORE the tag (the PR gate has already run by then).
+#
+# Failing at tag push costs a tag deletion, which is why it is the backstop
+# and not the primary. `compliance.yml` (release: published) would be later
+# still — by then the artifacts are signed and public.
+#
+# A PR that bumps no version SKIPS the check but still reports success, so
+# this is safe to make a required context. Do NOT add a `paths:` filter for
+# Cargo.toml: a required check that never reports on unrelated PRs blocks
+# them forever.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release to query (e.g. v0.53.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Pinned to match compliance.yml. Bump both together.
+  RIVET_VERSION: v0.22.0
+
+jobs:
+  readiness:
+    name: Release readiness
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need main to compare the workspace version against.
+          fetch-depth: 0
+
+      - name: Resolve which release (if any) this change claims
+        id: resolve
+        env:
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          version_of() {
+            # First `version = "..."` AFTER the [workspace.package] header,
+            # so [workspace.dependencies] pins cannot be picked up by mistake.
+            printf '%s' "$1" | awk '/^\[workspace\.package\]/{f=1} f && /^version[[:space:]]*=/{split($0,a,"\""); print a[2]; exit}'
+          }
+          HEAD_VER="$(version_of "$(cat Cargo.toml)")"
+          echo "workspace version at HEAD: ${HEAD_VER}"
+
+          case "$EVENT" in
+            workflow_dispatch)
+              echo "target=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+              echo "reason=manual query" >> "$GITHUB_OUTPUT"
+              ;;
+            push)
+              # Tag push. The tag and the committed version MUST agree —
+              # this mechanizes the guardrail that was previously a human
+              # remembering to eyeball Cargo.toml before `git tag`.
+              if [ "v${HEAD_VER}" != "$REF_NAME" ]; then
+                echo "::error::tag ${REF_NAME} does not match the workspace version (v${HEAD_VER}) at the tagged commit"
+                exit 1
+              fi
+              echo "target=${REF_NAME}" >> "$GITHUB_OUTPUT"
+              echo "reason=tag push (backstop)" >> "$GITHUB_OUTPUT"
+              ;;
+            pull_request)
+              BASE_VER="$(version_of "$(git show "${BASE_SHA}:Cargo.toml")")"
+              echo "workspace version at base: ${BASE_VER}"
+              if [ "$HEAD_VER" = "$BASE_VER" ]; then
+                echo "target=" >> "$GITHUB_OUTPUT"
+                echo "reason=no version bump — this PR claims no release" >> "$GITHUB_OUTPUT"
+              else
+                echo "target=v${HEAD_VER}" >> "$GITHUB_OUTPUT"
+                echo "reason=version bump ${BASE_VER} -> ${HEAD_VER}" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+          esac
+
+      - name: Install rivet
+        if: steps.resolve.outputs.target != ''
+        run: |
+          set -euo pipefail
+          mkdir -p "$HOME/.local/bin"
+          URL="https://github.com/pulseengine/rivet/releases/download/${RIVET_VERSION}/rivet-${RIVET_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -sSfL "$URL" | tar xz -C "$HOME/.local/bin/"
+          chmod +x "$HOME/.local/bin/rivet"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Query release readiness
+        if: steps.resolve.outputs.target != ''
+        env:
+          TARGET: ${{ steps.resolve.outputs.target }}
+          REASON: ${{ steps.resolve.outputs.reason }}
+        run: |
+          set -euo pipefail
+          rivet --version
+          echo "Checking ${TARGET} (${REASON})"
+          echo
+          # Exits non-zero when any artifact scoped to this release is not
+          # yet `verified`/`accepted`. That exit code IS the gate.
+          if ! rivet release status "$TARGET"; then
+            echo
+            echo "::error::${TARGET} is NOT cuttable — artifacts scoped to it are not yet verified."
+            echo "::error::Close each one's V (tests passing at the right levels), move it to \`verified\`, and re-run."
+            exit 1
+          fi
+          echo
+          echo "${TARGET} is cuttable."
+
+      - name: Report skip
+        if: steps.resolve.outputs.target == ''
+        env:
+          REASON: ${{ steps.resolve.outputs.reason }}
+        run: |
+          echo "Skipped: ${REASON}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -782,6 +782,14 @@ GitHub REST API).
    rivet release status vX.Y.Z          # human burn-down; exits non-zero when not cuttable
    rivet release status vX.Y.Z --format json   # CI-consumable: {"cuttable": bool, "not_verified": [...]}
    ```
+   **Enforced by CI** since the `Release readiness` workflow
+   (`.github/workflows/release-readiness.yml`): it runs this query on any PR
+   that bumps the workspace version — the earliest point a change claims a
+   release — and again as a backstop on tag push, where it also asserts the tag
+   matches the committed version. Before that workflow existed nothing ran the
+   query, and v0.51.0 and v0.52.0 were both tagged while it still exited 1 for
+   their own scope. Run it locally anyway; CI is the net, not the plan.
+
    The release is **cuttable** only when every scoped artifact is `verified`/`accepted` (an artifact whose V is closed — verification passing at the right levels — moves `implemented`→`verified`). The `compliance.yml` rivet pin is also v0.22.0. (Historical per-release `vX.Y` *tags* on artifacts are "shipped-in" markers and stay; the `release:` field is the single forward scope `rivet release status` queries.)
 
 #### Release Steps

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -2966,7 +2966,18 @@ artifacts:
       parameter-building function destructures `FuserConfig` exhaustively, so
       adding a field fails the build until it is recorded or explicitly
       acknowledged as not a build parameter.
-    status: implemented
+
+      STATUS CORRECTED POST HOC, 2026-09-02. This entry shipped in v0.51.0 while
+      still marked `implemented`, so `rivet release status v0.51.0` exited 1 for
+      its own scope at the moment it was tagged — the pre-release readiness
+      query AGENTS.md marks MANDATORY was not run, because at that time nothing
+      in CI ran it and no human did either. The verification itself was real and
+      passing throughout — its linked sw-verification carries the evidence — and
+      only this status field was stale. It is moved
+      to `verified` here rather than silently, so the record shows both the
+      correction and the reason it was needed. The gate that would have caught
+      it is now enforced by `.github/workflows/release-readiness.yml`.
+    status: verified
     tags: [attestation, adr-7, traceability, observability, boundary, config]
     release: v0.51.0
     links:
@@ -3026,7 +3037,18 @@ artifacts:
       placement records are produced — each module keeps its own memory and there
       is no placement decision to record; the attested `memory_strategy` already
       states which isolation model is in force.
-    status: implemented
+
+      STATUS CORRECTED POST HOC, 2026-09-02. This entry shipped in v0.52.0 while
+      still marked `implemented`, so `rivet release status v0.52.0` exited 1 for
+      its own scope at the moment it was tagged — the pre-release readiness
+      query AGENTS.md marks MANDATORY was not run, because at that time nothing
+      in CI ran it and no human did either. The verification itself was real and
+      passing throughout — its linked sw-verification carries the evidence — and
+      only this status field was stale. It is moved
+      to `verified` here rather than silently, so the record shows both the
+      correction and the reason it was needed. The gate that would have caught
+      it is now enforced by `.github/workflows/release-readiness.yml`.
+    status: verified
     tags: [attestation, adr-7, traceability, observability, memory, placement]
     release: v0.52.0
     links:


### PR DESCRIPTION
Follow-up to #392. Closes the gap that surfaced while cutting v0.53.0.

## The problem

AGENTS.md marks the rivet release-readiness query **MANDATORY** before a tag. **Nothing ran it.**

```
rivet release status v0.51.0   →  ✗ NOT cuttable   exit 1
rivet release status v0.52.0   →  ✗ NOT cuttable   exit 1
```

Both were tagged and published anyway. SR-69 and SR-70 were never moved off `implemented`, so the query still fails for their own scope today. The work behind them was genuinely done — SWV-81 and SWV-82 exist and pass — so this is a stale tracker, not broken software. But **a MANDATORY gate that no machine runs is a gate that cannot fail**, and it didn't. That's the same shape as the fuser defect in #392: a check that exists and doesn't bite.

A green release pipeline and ten signed assets say nothing about this, which is why it stayed invisible across two releases.

## When it fires

It *is* release-scoped — querying an arbitrary PR is meaningless. But "release time" has three moments, and they are not equivalent:

| moment | cost of failing there |
|---|---|
| release published (`compliance.yml`) | artifacts signed and public |
| tag push (`release.yml`) | a tag deletion — what you least want to move |
| **version bump, in the PR** | **free** |

This repo lands the version bump **inside** the feature PR — all six releases — so a PR whose workspace version differs from main's *is* the release PR. That's the earliest honest "I am releasing" signal.

**Primary gate: the version bump. Backstop: tag push.** They cover different holes, so neither alone suffices:
- The PR gate can be bypassed by tagging a commit directly.
- The PR gate cannot see an artifact scoped to the release that lands *after* the bump PR merges but *before* the tag — it has already run.

On tag push it also asserts the tag matches the committed workspace version, mechanizing a guardrail that until now was a human remembering to eyeball `Cargo.toml` before `git tag`.

## Potency

Fails on exactly the releases that slipped through; passes on the one done properly:

```
v0.51.0   NOT cuttable  → blocked
v0.52.0   NOT cuttable  → blocked
v0.53.0   cuttable      → passes
```

All four branches of the resolve step were exercised against this repo's real history — tag match, tag mismatch, PR bumping `0.52.0 → 0.53.0`, PR bumping nothing — by extracting the step's shell verbatim from the YAML and running it. Worth doing: my first version-extraction used an `awk` `gsub` backreference, which isn't portable and silently emitted a literal `\1`. Testing caught it; reading wouldn't have.

This PR itself exercises the skip path (it bumps no version).

## Two things left open on purpose

**1. Not yet a required context.** It should run green on a real PR before being added to branch protection — a required check that fails environmentally blocks every PR. But until it's required it's advisory, which is precisely the failure mode this addresses, so that follow-up is the point rather than a formality. Needs admin.

**2. SR-69 and SR-70 corrected on the record** (maintainer-approved, now included in this PR). Both are moved to `verified` with a dated note in each entry saying it was a post-hoc correction and why it was needed — a shipped release's requirement changing status should carry its reason, or the correction is indistinguishable from backfilled evidence. All three shipped releases now report cuttable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrmMqf1iuTS1UBEes5TmdC