### PR TITLE
fix(cli): the reloc warning cried wolf, and the component count was inflated

### DIFF
--- a/meld-cli/src/main.rs
+++ b/meld-cli/src/main.rs
@@ -541,7 +541,7 @@ fn fuse_command(
     }
 
     println!();
-    println!("Fusing {} components...", fuser.component_count());
+    println!("Fusing {} components...", fuser.input_count());
 
     // Perform fusion
     let (fused_bytes, stats) = fuser.fuse_with_stats().context("Fusion failed")?;

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -519,8 +519,23 @@ impl Fuser {
     }
 
     /// Get the number of components added
+    /// How many components are in the FLATTENED set — one per component after
+    /// nested sub-components are hoisted out. This is the number the fuser
+    /// actually operates on, and `nested_component` asserts flattening through
+    /// it; for the number the caller passed, use [`Self::input_count`].
     pub fn component_count(&self) -> usize {
         self.components.len()
+    }
+
+    /// How many components the caller ADDED — the files they passed.
+    ///
+    /// Distinct from [`Self::component_count`], which counts the flattened set
+    /// and gains an entry per nested sub-component. Printing the flattened
+    /// number to a user reported two input files as "Fusing 4 components",
+    /// sending readers to look for inputs they never supplied. Anything
+    /// user-facing wants this one.
+    pub fn input_count(&self) -> usize {
+        self.original_components.len()
     }
 
     /// Inspect P3 async usage across all added components.
@@ -674,15 +689,20 @@ impl Fuser {
         // direct load/store) is already a hard error there (path-F).
         if self.config.memory_strategy == MemoryStrategy::SharedMemory
             && self.config.address_rebasing
-            && self.any_component_lacks_reloc_metadata()
         {
-            log::warn!(
-                "memory strategy: shared memory + address rebasing with at least one \
-                 input that carries NO relocation metadata. Absolute addresses in such \
-                 a module cannot be rebased, so it may silently alias another \
-                 component's memory (#326/#339). Rebuild every input with \
-                 `--emit-relocs`, or use `--memory multi`."
-            );
+            let lacking = self.components_lacking_reloc_metadata();
+            if !lacking.is_empty() {
+                log::warn!(
+                    "memory strategy: shared memory + address rebasing, but these \
+                     components carry NO relocation metadata: {}. Absolute addresses in \
+                     such a module cannot be rebased, so it may silently alias another \
+                     component's memory (#326/#339). Rebuild the corresponding input with \
+                     `--emit-relocs`, or use `--memory multi`. (Names are of FUSED \
+                     components, which include ones synthesized from an input's nested \
+                     structure — so a name you do not recognise is not one of your files.)",
+                    lacking.join(", ")
+                );
+            }
         }
         self.fuse_with_stats_resolved()
     }
@@ -722,12 +742,36 @@ impl Fuser {
     /// (`reloc::has_reloc_metadata`) that `resolve_address_plan` gates on, so
     /// the warning cannot disagree with the strategy that follows it.
     fn any_component_lacks_reloc_metadata(&self) -> bool {
-        self.components.iter().any(|component| {
-            component
-                .core_modules
-                .iter()
-                .any(|module| !reloc::has_reloc_metadata(&module.custom_sections))
-        })
+        !self.components_lacking_reloc_metadata().is_empty()
+    }
+
+    /// Which components carry no relocation metadata, by name.
+    ///
+    /// Reported by name because the bare "at least one input" phrasing was a
+    /// false alarm in practice: this walks the FLATTENED component list, which
+    /// includes components synthesized from an input's nested structure — not
+    /// the files the caller passed. A caller whose every input was built with
+    /// `--emit-relocs` could still be told an input lacked them, and go looking
+    /// for a defect in their own artifacts that was never there. Keep the
+    /// flattened scope, since a nested module without relocs is a real hazard,
+    /// but say WHICH one so the reader can tell it apart from their inputs.
+    fn components_lacking_reloc_metadata(&self) -> Vec<String> {
+        self.components
+            .iter()
+            .enumerate()
+            .filter(|(_, component)| {
+                component
+                    .core_modules
+                    .iter()
+                    .any(|module| !reloc::has_reloc_metadata(&module.custom_sections))
+            })
+            .map(|(idx, component)| {
+                component
+                    .name
+                    .clone()
+                    .unwrap_or_else(|| format!("<unnamed component {idx}>"))
+            })
+            .collect()
     }
 
     /// Resolve `MemoryStrategy::Auto` against the added components.

--- a/meld-core/tests/shared_rebase_warning_386.rs
+++ b/meld-core/tests/shared_rebase_warning_386.rs
@@ -24,10 +24,27 @@ use wasm_encoder::{
 };
 
 /// The substring unique to the #386 warning (distinct from the per-module
-/// `address_strategy` warning, which names a component/module instead).
-const WARN_MARKER: &str = "at least one input";
+/// `address_strategy` warning, which reports a placement failure instead).
+///
+/// The phrase this used to key on — "at least one input" — was removed: it was
+/// inaccurate. The check walks the FLATTENED component list, which includes
+/// components synthesized from an input's nested structure, so a caller whose
+/// every input carried relocs could still be told an *input* lacked them. The
+/// warning now names the offenders; see `the_warning_names_which_components`.
+const WARN_MARKER: &str = "carry NO relocation metadata";
 
 static CAPTURED: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+/// Serializes the tests that CAPTURE warnings.
+///
+/// `CAPTURED` is process-global and `drain()` empties it, so two such tests
+/// running concurrently steal each other's records. That is not hypothetical:
+/// adding a second capturing test made this file pass under `--workspace` and
+/// fail under `--all-features`, purely on scheduling order — a flaky test, which
+/// is worse than a missing one because it teaches people to re-run.
+///
+/// Tests that do not capture warnings need not take this.
+static CAPTURE_LOCK: Mutex<()> = Mutex::new(());
 static LOGGER: CaptureLogger = CaptureLogger;
 
 struct CaptureLogger;
@@ -208,7 +225,8 @@ fn drain() -> Vec<String> {
 /// raced by parallel test threads.
 #[test]
 fn shared_rebase_warns_only_when_an_input_lacks_relocs() {
-    log::set_logger(&LOGGER).expect("install capture logger");
+    let _guard = CAPTURE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = log::set_logger(&LOGGER);
     log::set_max_level(log::LevelFilter::Warn);
 
     // Phase 1 — every input is reloc-covered: meld can rebase every address at
@@ -243,5 +261,77 @@ fn shared_rebase_warns_only_when_an_input_lacks_relocs() {
     assert!(
         warnings.iter().any(|w| w.contains(WARN_MARKER)),
         "an input without reloc metadata must draw the warning, got: {warnings:?}"
+    );
+}
+
+/// The warning must NAME the components it is complaining about.
+///
+/// Reported by a downstream consumer: every one of their inputs was built with
+/// `--emit-relocs`, and meld still said "at least one input ... carries NO
+/// relocation metadata". The offender was a component synthesized from an
+/// input's nested structure, not a file they had passed — so the message sent
+/// them auditing artifacts that were fine. A safety tool's false alarm costs
+/// exactly the trust its true alarms depend on.
+// rivet: verifies SR-68
+#[test]
+fn the_warning_names_which_components() {
+    let _guard = CAPTURE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(log::LevelFilter::Warn);
+    let _ = drain();
+
+    // `b` has no relocs, so the warning must fire — and say so by name.
+    let a = build_component("aa", 0x11, true, true);
+    let b = build_component("bb", 0x22, false, false);
+    let _ = fuse_shared_rebase(a, b);
+
+    let warnings = drain();
+    let warning = warnings
+        .iter()
+        .find(|w| w.contains(WARN_MARKER))
+        .unwrap_or_else(|| panic!("expected the #386 warning; got {warnings:?}"));
+
+    assert!(
+        warning.contains("component"),
+        "the warning must identify what is missing relocs, not just that something is: {warning}"
+    );
+    // The old phrasing asserted something the check cannot know.
+    assert!(
+        !warning.contains("at least one input"),
+        "the warning must not claim an INPUT lacks relocs — it walks the flattened \
+         component list, which includes components the caller never passed: {warning}"
+    );
+}
+
+/// `input_count()` reports what the caller ADDED, not the flattened total.
+///
+/// Two input files were reported as "Fusing 4 components", which sends a reader
+/// looking for inputs they never passed — the same false-trail problem as the
+/// warning above, in the line printed directly before it.
+// rivet: verifies SR-68
+#[test]
+fn input_count_reports_inputs_not_flattened_components() {
+    let a = build_component("aa", 0x11, true, true);
+    let b = build_component("bb", 0x22, false, true);
+
+    let mut fuser = Fuser::new(FuserConfig {
+        memory_strategy: MemoryStrategy::SharedMemory,
+        address_rebasing: true,
+        attestation: false,
+        ..Default::default()
+    });
+    fuser.add_component_named(&a, Some("a")).expect("add a");
+    assert_eq!(fuser.input_count(), 1, "one component added");
+    fuser.add_component_named(&b, Some("b")).expect("add b");
+    assert_eq!(
+        fuser.input_count(),
+        2,
+        "two components added — not the flattened count"
+    );
+    // `component_count` keeps its existing meaning: nested_component asserts
+    // flattening through it, so this is an addition, not a redefinition.
+    assert!(
+        fuser.component_count() >= fuser.input_count(),
+        "the flattened count is never smaller than the number of inputs"
     );
 }

--- a/meld-core/tests/value_address_warn_339.rs
+++ b/meld-core/tests/value_address_warn_339.rs
@@ -143,10 +143,20 @@ fn value_address_no_reloc_accept_warns_and_validates_339() {
     );
 
     // The acceptance warning must fire, naming the module and the remedy.
+    //
+    // Selected on BOTH the module name and "UN-REBASED": the #386 shared+rebase
+    // warning also names the components it complains about, so matching on the
+    // module name alone can pick up the wrong warning. Both properties are still
+    // asserted on one warning — this disambiguates which, it does not relax what.
     let warnings = CAPTURED.lock().unwrap().clone();
-    let hit = warnings.iter().find(|w| w.contains("value-addr-mod"));
+    let hit = warnings
+        .iter()
+        .find(|w| w.contains("value-addr-mod") && w.contains("UN-REBASED"));
     let hit = hit.unwrap_or_else(|| {
-        panic!("expected an acceptance warning naming the module; captured: {warnings:?}")
+        panic!(
+            "expected the per-module acceptance warning naming the module and the \
+             un-rebased risk; captured: {warnings:?}"
+        )
     });
     assert!(
         hit.contains("UN-REBASED") && hit.contains("--emit-relocs"),


### PR DESCRIPTION
Reported by jess on #390 — in a comment I did not read before shipping v0.53.0. Two cosmetic-looking defects that cost her real time auditing artifacts that were fine.

## What she saw

Every one of her four inputs was built with `--emit-relocs` — verified individually with `wasm-tools objdump` — and meld still said:

> shared memory + address rebasing with **at least one input** that carries NO relocation metadata

and, for **two** input files:

> Fusing **3** components...

In her words: *"Harmless here, but it sent me checking my own artifacts for a problem that wasn't there."*

## Why

Both read `self.components` — the **flattened** list. `add_component` hoists nested sub-components out of each input, so the list gains entries the caller never passed and cannot rebuild with `--emit-relocs`. `self.original_components` is what they actually supplied.

Reproduced locally: two input files print `Fusing 4 components...`.

## Fix

- **The warning names its offenders**, and says outright that an unrecognised name is not one of your files. The flattened scope is kept — a nested module without relocs is a genuine hazard — but a warning that cannot be tied to anything actionable is how a safety tool spends the trust its true warnings depend on.
- **`input_count()`** reports what the caller added; the CLI uses it. **`component_count()` keeps its existing meaning** — `nested_component` asserts flattening through it, and that test caught me redefining a public method's semantics instead of adding a second one.

Before / after on two inputs:

```
- Fusing 4 components...
- ... at least one input that carries NO relocation metadata ...
+ Fusing 2 components...
+ ... these components carry NO relocation metadata: <name>, <name> ...
+     (Names are of FUSED components ... a name you do not recognise is not one of your files.)
```

## Two test problems this surfaced, both mine

- **`value_address_warn_339` selected its warning by module name alone.** Now that the #386 warning also names components, that selector could match the wrong one — and did. It now requires the module name **and** `UN-REBASED`: the same two properties asserted, just disambiguated. Not a relaxation.
- **Adding a second warning-capturing test made this file pass under `--workspace` and fail under `--all-features`**, purely on scheduling — `CAPTURED` is process-global and `drain()` empties it. Serialized behind a lock, then run three times to confirm. A flaky test is worse than a missing one; it teaches people to re-run.

## Gate

fmt clean, clippy `-D warnings` clean, **877** (`--workspace`) / **876** (`--all-features`), both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrmMqf1iuTS1UBEes5TmdC