### PR TITLE
feat(v0.55.0): validate by default on shared memory; stop publishing empty releases

### DIFF
--- a/.github/workflows/release-assets-gate.yml
+++ b/.github/workflows/release-assets-gate.yml
@@ -1,0 +1,79 @@
+name: Release assets gate
+
+# A published release must actually carry the artifacts people came for.
+#
+# v0.53.0 was published with ONE asset — the compliance report — and a consumer
+# fetched it in that state (#395). The cause was ordering, not a build failure:
+# the documented release steps had a human run `gh release create` right after
+# the tag push, which PUBLISHES immediately. `compliance.yml` triggers on
+# `release: published`, so it fired at once and uploaded its report, while
+# `release.yml` (triggered by the tag push) was still queued behind a busy
+# runner fleet. The binaries arrived minutes later. In between, the release was
+# public and unconsumable.
+#
+# The process fix is to create the release as a DRAFT and publish only once the
+# assets are in (see AGENTS.md). This is the check that makes forgetting loud
+# rather than silent — a documented step nobody verifies is exactly the class of
+# gate this repo keeps finding at the wrong moment.
+#
+# It runs AFTER publication, so it cannot prevent a bad release; it reports one.
+# That is deliberate: GitHub gives no pre-publish hook, and a loud alarm minutes
+# after the fact still beats a consumer discovering it.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to audit (e.g. v0.55.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  assets:
+    name: Release assets gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Assert the release carries its artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REL_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-$REL_TAG}"
+          echo "Auditing $TAG"
+
+          NAMES="$(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name')"
+          echo "Assets present:"
+          printf '%s\n' "$NAMES" | sed 's/^/  /'
+
+          # `compliance.yml` also fires on publish and is additive, so it is not
+          # required here; these are the artifacts the release exists to deliver.
+          missing=0
+          require() {
+            if ! printf '%s\n' "$NAMES" | grep -qF "$1"; then
+              echo "::error::missing release asset matching '$1'"
+              missing=1
+            fi
+          }
+          for target in \
+            aarch64-apple-darwin aarch64-unknown-linux-gnu \
+            x86_64-apple-darwin x86_64-unknown-linux-gnu
+          do
+            require "$target.tar.gz"
+          done
+          require "SHA256SUMS.txt"
+          require "SHA256SUMS.txt.cosign.bundle"
+
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::$TAG is published but incomplete — consumers can fetch it in this state (#395)."
+            exit 1
+          fi
+          echo "$TAG carries its platform binaries, checksums and signature bundle."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -814,7 +814,16 @@ GitHub REST API).
    gh pr merge <PR#> --squash
    ```
 
-4. **Create release**: Only after merge and main CI passes
+4. **Create release**: Only after merge and main CI passes.
+
+   **Publish LAST, as a draft first.** `release.yml` creates the release itself
+   when it does not already exist; a manual `gh release create` right after the
+   tag push therefore publishes an EMPTY release that the pipeline fills minutes
+   later. Worse, `compliance.yml` triggers on `release: published`, so it fires
+   immediately and uploads its report — which is how v0.53.0 came to sit public
+   carrying one asset while a consumer fetched it (#395). On a busy runner fleet
+   that window is long.
+
    ```bash
    # Pull latest main
    git checkout main && git pull
@@ -822,13 +831,35 @@ GitHub REST API).
    # Verify main CI passed
    gh run list --branch main --limit 1
 
-   # Create and push tag
+   # Guardrail: the tag must match the committed workspace version
+   grep -A1 '^\[workspace.package\]' Cargo.toml | grep '^version'
+
+   # Create and push tag — this starts the build pipeline
    git tag -a vX.Y.Z -m "Release vX.Y.Z"
    git push origin vX.Y.Z
 
-   # Create GitHub release
-   gh release create vX.Y.Z --generate-notes
+   # Create the release as a DRAFT so nothing is public yet
+   gh release create vX.Y.Z --draft --notes-file notes.md
+
+   # Wait for release.yml to finish and upload into the draft
+   gh run watch <release-run-id>
+
+   # Verify the artifacts before anyone can fetch them: checksums AND signature,
+   # each with a negative control (see release-execution)
+   gh release download vX.Y.Z -p 'SHA256SUMS.txt*' -p '*.tar.gz'
+   shasum -a 256 -c SHA256SUMS.txt
+   cosign verify-blob --bundle SHA256SUMS.txt.cosign.bundle \
+     --certificate-identity-regexp 'https://github.com/pulseengine/meld/.*' \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     SHA256SUMS.txt
+
+   # Only now make it public
+   gh release edit vX.Y.Z --draft=false
    ```
+
+   `release-assets-gate.yml` runs on publish and fails if the platform binaries,
+   checksums or signature bundle are absent. It reports rather than prevents —
+   GitHub has no pre-publish hook — but it makes forgetting this loud.
 
 #### What NOT to do
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.55.0] - 2026-09-05
+
+### Changed
+- **`--memory shared` now validates its own output by default (#390, #391).**
+  The single-address-space paths — `--memory shared`, and therefore
+  `--address-rebase`, `--pack-rebase` and `--share-stack` — run the fused module
+  through `wasmparser` before writing it. `--no-validate` opts out;
+  `--validate` still forces it on any path.
+
+  This is where meld rewrites most invasively: rebasing absolute addresses and
+  bridging calling conventions inside one address space. It is also where both
+  of the last two releases' defects surfaced — #390 emitted invalid wasm at exit
+  0, and #393 emitted a module that validated but returned the wrong number.
+  The consumer who reported both noted they would have caught the first months
+  earlier had this been the default. The cost is one `wasmparser` pass over an
+  artifact already in memory.
+
+  A module that fails validation is **not written**. Previously an invalid
+  artifact reached disk and only failed later, in whatever consumed it.
+
+### Fixed
+- **The shared+rebase warning named "inputs" it could not have meant (#390).**
+  A consumer whose every input carried relocation metadata was still told an
+  input lacked it, and went auditing artifacts that were fine. Both that warning
+  and the `Fusing N components...` line read the *flattened* component list,
+  which gains an entry per nested sub-component — so two input files printed
+  "Fusing 4 components". The warning now names the components it means and says
+  outright that an unrecognised name is not one of your files; `input_count()`
+  reports what the caller passed.
+
+- **Releases are no longer published before their artifacts exist (#395).**
+  `release.yml` creates the GitHub release itself, so a manual `gh release
+  create` after the tag push published an empty release that the pipeline filled
+  minutes later — and `compliance.yml`, which triggers on publish, uploaded its
+  report into that window. v0.53.0 was fetched in exactly that state. Releases
+  are now created as drafts and published only after their assets are uploaded
+  and verified, and `release-assets-gate.yml` fails loudly if a published
+  release lacks its platform binaries, checksums or signature bundle.
+
 ## [0.54.0] - 2026-09-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.54.0"
+version = "0.55.0"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/meld-cli/src/main.rs
+++ b/meld-cli/src/main.rs
@@ -595,7 +595,7 @@ fn fuse_command(
     // wasmparser pass over an artifact already in memory.
     //
     // `--validate` forces it on any path; `--no-validate` opts out.
-    let implied = matches!(memory_strategy, MemoryStrategy::SharedMemory) && !no_validate;
+    let implied = validation_is_implied(&memory_strategy, no_validate);
     if validate || implied {
         println!();
         if implied && !validate {
@@ -1163,5 +1163,65 @@ mod tests {
         assert_eq!(arr[1]["name"], "[method]output-stream.write");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+/// Does the memory strategy imply validating the output? (#390 / #391)
+///
+/// Pulled out as a total function over its two inputs so the decision can be
+/// enumerated rather than reasoned about: three strategies x two opt-out states
+/// is six cases, all covered below. meld#397 makes the case that meld's own
+/// decision seams deserve this treatment; this is a small one, so it gets it.
+fn validation_is_implied(strategy: &MemoryStrategy, no_validate: bool) -> bool {
+    if no_validate {
+        return false;
+    }
+    // Shared memory is where meld rebases absolute addresses and bridges
+    // calling conventions inside one address space — the rewriting whose
+    // failures (#390, #393) reached consumers as invalid or wrong output.
+    // `--memory multi` leaves each module's memory alone, so its output is not
+    // exposed to that class and validation stays opt-in there.
+    matches!(strategy, MemoryStrategy::SharedMemory)
+}
+
+#[cfg(test)]
+mod validate_default_tests {
+    use super::*;
+
+    /// Every combination, not a sample: the point of a total function is that
+    /// its table can be written down.
+    // rivet: verifies SR-73
+    #[test]
+    fn validation_implication_table() {
+        use MemoryStrategy::*;
+        for (strategy, no_validate, expected) in [
+            (SharedMemory, false, true),
+            (SharedMemory, true, false),
+            (MultiMemory, false, false),
+            (MultiMemory, true, false),
+            (Auto, false, false),
+            (Auto, true, false),
+        ] {
+            assert_eq!(
+                validation_is_implied(&strategy, no_validate),
+                expected,
+                "strategy={strategy:?} no_validate={no_validate}"
+            );
+        }
+    }
+
+    /// The opt-out must win regardless of strategy — otherwise `--no-validate`
+    /// silently does nothing on exactly the path where someone would reach for
+    /// it.
+    // rivet: verifies SR-73
+    #[test]
+    fn no_validate_always_wins() {
+        for strategy in [
+            MemoryStrategy::SharedMemory,
+            MemoryStrategy::MultiMemory,
+            MemoryStrategy::Auto,
+        ] {
+            assert!(!validation_is_implied(&strategy, true));
+        }
     }
 }

--- a/meld-cli/src/main.rs
+++ b/meld-cli/src/main.rs
@@ -156,9 +156,23 @@ enum Commands {
         #[arg(long)]
         preserve_names: bool,
 
-        /// Validate output with wasmparser
+        /// Validate output with wasmparser. Implied on the single-address-space
+        /// paths (`--memory shared`, and therefore `--address-rebase`,
+        /// `--pack-rebase`, `--share-stack`); pass this to force it elsewhere.
         #[arg(long)]
         validate: bool,
+
+        /// Skip the validation that `--memory shared` implies.
+        ///
+        /// Validation is on by default there because that is where meld does its
+        /// most invasive rewriting — rebasing addresses and bridging calling
+        /// conventions inside one address space — and a defect shows up as a
+        /// module that no runtime accepts. #390 and #393 both shipped as invalid
+        /// or wrong output at exit 0; the reporter noted they would have caught
+        /// the first months earlier had this been the default. The cost is one
+        /// wasmparser pass over an artifact just built.
+        #[arg(long, conflicts_with = "validate")]
+        no_validate: bool,
 
         /// Output as P2 component instead of core module
         #[arg(long)]
@@ -257,6 +271,7 @@ fn main() -> Result<()> {
             dwarf,
             preserve_names,
             validate,
+            no_validate,
             component,
             emit_import_map,
             opaque_rep,
@@ -281,6 +296,7 @@ fn main() -> Result<()> {
                 dwarf,
                 preserve_names,
                 validate,
+                no_validate,
                 component,
                 emit_import_map,
                 opaque_rep,
@@ -362,6 +378,7 @@ fn fuse_command(
     dwarf: String,
     preserve_names: bool,
     validate: bool,
+    no_validate: bool,
     component: bool,
     emit_import_map: Option<String>,
     opaque_rep: Vec<String>,
@@ -567,10 +584,27 @@ fn fuse_command(
 
     let elapsed = start.elapsed();
 
-    // Validate if requested
-    if validate {
+    // Validate the output.
+    //
+    // On by default for the single-address-space paths, because that is where
+    // meld rewrites most invasively — rebasing absolute addresses and bridging
+    // calling conventions within one memory — and where a defect surfaces as a
+    // module no runtime will accept. #390 emitted invalid wasm at exit 0 and
+    // #393 emitted a module that validated and returned the wrong number; both
+    // reached a consumer. The cost of catching the first class is one
+    // wasmparser pass over an artifact already in memory.
+    //
+    // `--validate` forces it on any path; `--no-validate` opts out.
+    let implied = matches!(memory_strategy, MemoryStrategy::SharedMemory) && !no_validate;
+    if validate || implied {
         println!();
-        println!("Validating output...");
+        if implied && !validate {
+            println!("Validating output (implied by --memory shared; --no-validate to skip)...");
+        } else {
+            println!("Validating output...");
+        }
+        // Before the write: a module that fails here must not become a file
+        // somebody can pick up.
         validate_wasm(&fused_bytes)?;
         println!("  Validation passed");
     }

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -3210,3 +3210,62 @@ artifacts:
       references:
         - "https://github.com/pulseengine/meld/issues/393"
         - "meld-core/tests/used_type_size_393.rs"
+
+  - id: SR-73
+    type: sw-req
+    title: The single-address-space paths validate their own output
+    description: >
+      meld shall validate the fused module before writing it whenever the memory
+      strategy is `shared` — and therefore under `--address-rebase`,
+      `--pack-rebase` and `--share-stack`, which require it. A module that fails
+      validation shall NOT be written: an invalid artifact on disk fails later,
+      in whatever consumes it, far from the cause.
+      This is the path on which meld rewrites most invasively, rebasing absolute
+      addresses and bridging calling conventions inside one address space, and it
+      is where the defects of the two preceding releases surfaced — SR-71 emitted
+      a module that failed validation at exit 0, and SR-72 emitted one that
+      validated and returned a wrong value. Validation catches the first class
+      outright and costs a single wasmparser pass over an artifact already in
+      memory. The consumer who reported both stated they would have caught the
+      earlier defect months sooner had this been the default.
+      An explicit opt-out (`--no-validate`) shall be honoured on every strategy,
+      and an explicit `--validate` shall force validation on strategies that do
+      not imply it. The two shall be mutually exclusive rather than silently
+      ordered, so a caller cannot express a contradiction and receive one of the
+      two readings without being told.
+      Validation is not claimed to establish correctness: SR-72's defect produced
+      a fully valid module with wrong contents. It establishes only that the
+      output is well-formed, which is a floor, not a ceiling.
+    status: verified
+    tags: [cli, validation, loud-not-silent, correctness]
+    release: v0.55.0
+    links:
+      - type: derives-from
+        target: SYS-6
+      - type: refines
+        target: SR-71
+      - type: refines
+        target: SR-72
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/390"
+        kind: github
+        last-checked: 2026-09-05
+    fields:
+      implementation:
+        - meld-cli/src/main.rs
+      verification-method: test
+      verification-description: >
+        Verified by the exhaustive implication table in meld-cli
+        (`validate_default_tests`): three strategies against both opt-out states,
+        every case enumerated rather than sampled, plus an assertion that the
+        opt-out wins on every strategy. Potency established by making it fire:
+        with SR-71's bridge dispatch AND the wiring backstop both disabled — so
+        an invalid module is actually produced and validation is the only guard
+        left — `--memory shared` reports `Validation failed: type mismatch:
+        expected f32, found i32` and writes no file. Recorded also that the FIRST
+        attempt at that control never reached validation, because the wiring
+        backstop caught the defect earlier: a control that passes for the wrong
+        reason proves nothing.
+      references:
+        - "https://github.com/pulseengine/meld/issues/390"
+        - "https://github.com/pulseengine/meld/issues/391"

--- a/safety/requirements/sw-verifications.yaml
+++ b/safety/requirements/sw-verifications.yaml
@@ -1288,3 +1288,22 @@ artifacts:
     links:
       - type: verifies
         target: SR-72
+
+  - id: SWV-85
+    type: sw-verification
+    title: "Verification of SR-73: implied output validation"
+    description: >
+      Verifies SR-73 via the `validate_default_tests` module in meld-cli: an
+      exhaustive implication table over three memory strategies and both opt-out
+      states (six cases, enumerated not sampled), and an assertion that
+      `--no-validate` wins on every strategy — otherwise the opt-out silently
+      does nothing on exactly the path someone would reach for it. Flag routing
+      was additionally exercised end to end across five invocations, including
+      that `--validate` and `--no-validate` conflict rather than resolving
+      silently.
+    status: implemented
+    fields:
+      method: automated-test
+    links:
+      - type: verifies
+        target: SR-73


### PR DESCRIPTION
Two things jess reported that I had not acted on, plus her deferred ask.

## 1. `--memory shared` validates its own output by default (#390, #391)

Her ask, deferred from #390 because it was a behaviour change rather than the defect. She declined to open it unilaterally, so it went onto #391 with her reasoning attached; this implements it.

The single-address-space paths now run the fused module through `wasmparser` **before writing it**. `--no-validate` opts out; `--validate` still forces it anywhere; the two conflict rather than resolving silently.

That is where meld rewrites most invasively, and where both recent defects surfaced — #390 emitted invalid wasm at exit 0, #393 emitted a module that validated and returned the wrong number. In her words: she would have caught the first months earlier had this been the default. Cost is one `wasmparser` pass over an artifact already in memory.

**A module that fails validation is not written.** Previously the invalid artifact reached disk and failed later, in whatever consumed it.

### Potency, established by making it fire

Routing verified across five invocations. Then the control that matters — reintroduce #390 **and** disable the v0.53.0 wiring backstop, so an invalid module is actually produced and validation is the only guard left:

```
Validating output (implied by --memory shared; --no-validate to skip)...
Error: Validation failed
Caused by: type mismatch: expected f32, found i32 (at offset 0xea)
→ no file written
```

Worth recording that the **first** attempt at that control never reached validation: the wiring backstop caught the defect earlier. Defense in depth behaving correctly — and a reminder that a control passing for the wrong reason proves nothing.

## 2. Releases are no longer published before their artifacts exist (#395)

She caught v0.53.0 public with one asset — the compliance report — and fetched it in that state.

Cause was the documented process racing its own pipeline. `release.yml` creates the release itself; AGENTS.md told a human to run `gh release create` right after the tag push, which **publishes immediately**. `compliance.yml` triggers on `release: published`, so it fired at once and uploaded its report while `release.yml` was still queued behind a busy fleet. That is precisely the state she saw.

- **Process**: create as a draft, let the pipeline upload into it, verify checksums *and* the cosign signature, then `gh release edit --draft=false`. Nothing public until complete and verified.
- **Gate**: `release-assets-gate.yml` fails on publish if the four platform tarballs, `SHA256SUMS.txt` or the cosign bundle are missing.

The gate reports rather than prevents — GitHub has no pre-publish hook — and that limit is written into the workflow rather than left to be discovered. A documented step nobody verifies is the same inert-gate class this repo has now hit three times; the process fix alone would have been a fourth.

## Traceability

SR-73 + SWV-85, advanced by `rivet verify` with evidence. The decision is extracted into a total function with its implication table enumerated — six cases, not a sample — which is the treatment meld#397 argues these seams deserve.

Note the release-readiness gate from #394 did its job: `rivet release status v0.55.0` exited 1 with "no artifacts scoped", which is what forced this requirement to exist for a change small enough to have skipped it.

## Gate

fmt clean, clippy `-D warnings` clean, **879** (`--workspace`) / **878** (`--all-features`), both exit 0. `rivet validate` PASS, v0.55.0 cuttable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrmMqf1iuTS1UBEes5TmdC