### PR TITLE
fix(v0.55.1): attest a count the caller can check (SR-74, #401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.55.1] - 2026-09-09
+
+### Fixed
+- **The attestation reported a count the caller could not check (SR-74, #401).**
+  `components_fused` read meld's *flattened* component list, which gains an
+  entry per nested sub-component — five input files were attested as ten
+  components. v0.55.0 corrected the console line and not this, which made it
+  worse rather than better: for one run the tool printed one number and shipped
+  another. As the reporter put it, two disagreeing numbers read as two
+  independent facts rather than one number and one bug. `modules_merged` was
+  correct throughout and continues to answer the separate question of internal
+  structure.
+
+### Documentation
+- **`--reproducible` also replaces attested input names (#401).** The help text
+  described only the attestation id and timestamp, but the flag additionally
+  substitutes a positional identifier (`component-0`, ...) for each input name,
+  because a caller-supplied path differs between checkouts and would otherwise
+  change the output hash (#341). Input content stays pinned by its recorded
+  sha256, but a provenance story that depends on the names themselves loses them
+  under this flag. The behaviour is deliberate; the documentation was not.
+
 ## [0.55.0] - 2026-09-05
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "meld-cli"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "meld-core"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.55.0"
+version = "0.55.1"
 authors = ["PulseEngine <https://github.com/pulseengine>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/meld-cli/src/main.rs
+++ b/meld-cli/src/main.rs
@@ -129,6 +129,13 @@ enum Commands {
         /// id from the output content and take the timestamp from
         /// `SOURCE_DATE_EPOCH` (default epoch 0) instead of a random UUID +
         /// wall clock, so identical input yields an identical sha256.
+        ///
+        /// Also replaces each attested input NAME with a positional identifier
+        /// (`component-0`, `component-1`, ...), because a caller-supplied path
+        /// differs between checkouts and would otherwise change the hash (#341).
+        /// Input content stays pinned by its recorded sha256, but if your
+        /// provenance story depends on the input names themselves, they are not
+        /// preserved under this flag.
         #[arg(long)]
         reproducible: bool,
 

--- a/meld-core/src/lib.rs
+++ b/meld-core/src/lib.rs
@@ -963,7 +963,17 @@ impl Fuser {
         }
 
         let mut stats = FusionStats {
-            components_fused: self.components.len(),
+            // #401: the components the CALLER fused, not the flattened list.
+            //
+            // This is the number that travels in the attestation and that an
+            // auditor reasons from, so it must be the one they can check: the
+            // files they passed. Reading `self.components` reported 10 for five
+            // inputs, because flattening adds an entry per nested sub-component
+            // — and after the console line was corrected in v0.55.0 the two
+            // disagreed for the same run, which reads as two independent facts
+            // rather than one number and one bug. `modules_merged` already
+            // carries the internal structure.
+            components_fused: self.original_components.len(),
             memory_strategy: self.memory_strategy_label().to_string(),
             ..Default::default()
         };

--- a/meld-core/tests/attestation_counts_401.rs
+++ b/meld-core/tests/attestation_counts_401.rs
@@ -1,0 +1,93 @@
+//! #401 — the attestation must report a number the caller can check.
+//!
+//! `components_fused` read the FLATTENED component list, which gains an entry
+//! per nested sub-component: five input files were attested as ten components.
+//! v0.55.0 corrected the console line (`Fusing N components...`) but not this,
+//! so for one run the tool printed one number and shipped another.
+//!
+//! As the reporter put it, the two disagreeing is worse than both being wrong:
+//! it reads as two independent facts rather than one number and one bug. The
+//! attestation is the half that travels with the artifact and that an auditor
+//! reasons from, so it is the half that had to be right.
+//!
+//! `modules_merged` already carries the internal structure and was correct
+//! throughout — the two fields answer different questions and are pinned here
+//! as distinct on purpose.
+
+use meld_core::{Fuser, FuserConfig, MemoryStrategy};
+
+fn fixture() -> Option<Vec<u8>> {
+    let path = format!(
+        "{}/../tests/wit_bindgen/fixtures/compose_record_use/composed_record_use.wasm",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    std::fs::read(path).ok()
+}
+
+/// What the attestation says must equal what the caller passed — and what the
+/// CLI printed, which reports `input_count()`.
+// rivet: verifies SR-74
+#[test]
+fn components_fused_counts_inputs_not_flattened_components() {
+    let Some(bytes) = fixture() else {
+        eprintln!("compose_record_use fixture absent — skipping");
+        return;
+    };
+    let mut fuser = Fuser::new(FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        reproducible: true,
+        ..Default::default()
+    });
+    fuser
+        .add_component_named(&bytes, Some("composed"))
+        .expect("add");
+
+    let inputs = fuser.input_count();
+    let flattened = fuser.component_count();
+    let (_out, stats) = fuser.fuse_with_stats().expect("fusion");
+
+    assert_eq!(
+        stats.components_fused, inputs,
+        "#401: the attestation must report the components the caller fused ({inputs}), \
+         not the flattened list ({flattened}) — the console reports the former, and a \
+         run that prints one number and ships another reads as two independent facts"
+    );
+
+    // The fixture nests, so this is a real distinction rather than a tautology:
+    // if flattening ever stopped adding entries, this test would still pass
+    // above while proving nothing, and this assert says so out loud.
+    assert!(
+        flattened > inputs,
+        "#401: this fixture must actually nest, or the assertion above is vacuous \
+         (inputs={inputs}, flattened={flattened})"
+    );
+}
+
+/// `modules_merged` answers a different question and must not be collapsed into
+/// the one above. It was correct throughout and stays independent.
+// rivet: verifies SR-74
+#[test]
+fn modules_merged_is_independent_of_the_input_count() {
+    let Some(bytes) = fixture() else {
+        eprintln!("compose_record_use fixture absent — skipping");
+        return;
+    };
+    let mut fuser = Fuser::new(FuserConfig {
+        memory_strategy: MemoryStrategy::MultiMemory,
+        attestation: false,
+        reproducible: true,
+        ..Default::default()
+    });
+    fuser
+        .add_component_named(&bytes, Some("composed"))
+        .expect("add");
+    let (_out, stats) = fuser.fuse_with_stats().expect("fusion");
+
+    assert!(
+        stats.modules_merged >= stats.components_fused,
+        "one input contributes at least one core module (merged={}, fused={})",
+        stats.modules_merged,
+        stats.components_fused
+    );
+}

--- a/safety/requirements/safety-requirements.yaml
+++ b/safety/requirements/safety-requirements.yaml
@@ -3269,3 +3269,46 @@ artifacts:
       references:
         - "https://github.com/pulseengine/meld/issues/390"
         - "https://github.com/pulseengine/meld/issues/391"
+
+  - id: SR-74
+    type: sw-req
+    title: The attestation reports counts the caller can check
+    description: >
+      A quantity recorded in the fusion attestation shall be one the caller can
+      independently verify, and shall not contradict what the same run reported
+      on the console. `components_fused` shall count the components the caller
+      supplied, not meld's flattened internal list, which gains an entry per
+      nested sub-component; `modules_merged` continues to answer the separate
+      question of internal structure.
+      The two fields answer different questions and shall stay distinct.
+      This corrects a state in which five input files were attested as ten
+      components. The console line was fixed first, which made the defect worse
+      rather than better: for one run the tool printed one number and shipped
+      another, and a reader has no way to tell which is the measurement and
+      which is the bug. An attested quantity that disagrees with the tool's own
+      output is not merely inaccurate — it presents as two independent facts.
+    status: verified
+    tags: [attestation, traceability, observability, correctness]
+    release: v0.55.1
+    links:
+      - type: derives-from
+        target: SYS-6
+      - type: refines
+        target: SR-69
+    cited-source:
+      - uri: "https://github.com/pulseengine/meld/issues/401"
+        kind: github
+        last-checked: 2026-09-09
+    fields:
+      implementation:
+        - meld-core/src/lib.rs
+      verification-method: test
+      verification-description: >
+        Verified by meld-core/tests/attestation_counts_401.rs (2 tests): the
+        attested count equals the caller's input count, and `modules_merged`
+        stays independent. The first test additionally asserts that the fixture
+        genuinely nests (flattened > inputs), so that if flattening ever stopped
+        adding entries the assertion would fail loudly rather than pass while
+        proving nothing.
+      references:
+        - "https://github.com/pulseengine/meld/issues/401"

--- a/safety/requirements/sw-verifications.yaml
+++ b/safety/requirements/sw-verifications.yaml
@@ -1307,3 +1307,19 @@ artifacts:
     links:
       - type: verifies
         target: SR-73
+
+  - id: SWV-86
+    type: sw-verification
+    title: "Verification of SR-74: attested counts are checkable"
+    description: >
+      Verifies SR-74 via meld-core/tests/attestation_counts_401.rs (2 tests):
+      `components_fused` equals the caller's input count rather than the
+      flattened list, and `modules_merged` remains an independent measure of
+      internal structure. The first test guards its own potency by asserting the
+      fixture actually nests, so the equality cannot pass vacuously.
+    status: implemented
+    fields:
+      method: automated-test
+    links:
+      - type: verifies
+        target: SR-74


### PR DESCRIPTION
Fixes #401, reported by jess.

## The console fix made this worse, not better

v0.55.0 corrected `Fusing N components...` but not the attestation, which still read the *flattened* component list — five input files attested as **ten components**.

Her framing is sharper than mine was:

> the two disagreeing is arguably worse than both being 10, because it looks like two independent facts

Exactly right. For one run the tool now printed one number and shipped another, and a reader has no way to tell which is the measurement and which is the bug.

**I fixed the half I could see while running the tool.** The attestation is the half that travels with the artifact and that an auditor reasons from — it was the half that had to be right.

Reproduced before / after:

```
before:  console "Fusing 2 components"   attestation components_fused=4
after:   console "Fusing 2 components"   attestation components_fused=2
         modules_merged=4 in both — correct throughout, different question
```

`components_fused` now counts what the caller supplied. `modules_merged` continues to answer internal structure; the two stay distinct on purpose.

The regression test **guards its own potency**: it asserts the fixture actually nests (`flattened > inputs`), so if flattening ever stopped adding entries the equality would fail loudly rather than pass while proving nothing.

## `--reproducible` does more than its help text says

Also hers. The flag substitutes a positional identifier (`component-0`, ...) for each attested input name. That is deliberate — #341, because a caller-supplied path differs between checkouts and would otherwise change the output hash — and input content stays pinned by its recorded sha256. But the help text described only the attestation id and timestamp.

Someone whose provenance story depends on those names would lose them by enabling a flag documented as affecting ids and timestamps. The behaviour is correct; the documentation was not. Now documented.

## Traceability

SR-74 + SWV-86, advanced by `rivet verify` with evidence.

fmt clean, clippy `-D warnings` clean, **881** (`--workspace`) / **880** (`--all-features`), both exit 0. `rivet validate` PASS, v0.55.1 cuttable.

## Not in this PR

**#400** (fused modules carry no WIT type info, so runtimes cannot lower typed args) is a capability request, not a defect, and needs a design decision between re-emitting `component-type*` sections and a signature manifest. Left for scoping rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrmMqf1iuTS1UBEes5TmdC